### PR TITLE
build-rpms.sh: copy "*.patch" from topdir into SOURCES

### DIFF
--- a/build_rpms.sh
+++ b/build_rpms.sh
@@ -25,6 +25,7 @@ BUILDAREA=./rpm/$dist
 mkdir -p ${BUILDAREA}/{SOURCES,SRPMS,SPECS,RPMS,BUILD}
 cp -a ceph-*.tar.bz2 ${BUILDAREA}/SOURCES/.
 cp -a ceph.spec ${BUILDAREA}/SPECS/.
+cp -a *.patch ${BUILDAREA}/SOURCES/. || true
 
 # Build RPMs
 BUILDAREA=`readlink -fn ${BUILDAREA}`   ### rpm wants absolute path


### PR DESCRIPTION
This allows patches to be applied when building the RPMs; the addition
of the ceph patch to disable /etc/init.d/ceph from autostarting Ceph
daemons leads to the desire for a .patch file, conditionally applied
by the .spec.  See the Ceph sources.

Signed-off-by: Dan Mick dan.mick@inktank.com
