### PR TITLE
jjb: be verbose and fail early on errors

### DIFF
--- a/jjb/config/config
+++ b/jjb/config/config
@@ -6,6 +6,8 @@
 # definitions.
 #
 
+set -ex
+
 # Create the virtualenv
 virtualenv venv
 . venv/bin/activate


### PR DESCRIPTION
Prior to this commit, if the `job-builder update` command failed, Jenkins would still consider the overall job to have succeeded, because the `jjb/config/config` script was exiting with a zero exit code. (This was because the for/ls loop were the final commands to run, and they were exiting with zero.)

When I modified the Jenkins UID as a part of the overall Jenkins authentication changes yesterday, the `job-builder update` command no longer worked, because the password in `jenkins_builder.ini` was no longer valid. However, Jenkins still considered the jjb job to be passing, as explained above.

This pull request tells bash to be verbose about the commands it runs (`set -x`) and fail early if there are any problems (`set -e`).

With this change, if there is a problem with `job-builder update` or any other command in the script, the job will fail right away and Jenkins will bring it to our attention sooner.
