### PR TITLE
jjb: increase precision of job searches

### DIFF
--- a/jjb/config/config
+++ b/jjb/config/config
@@ -25,7 +25,7 @@ fi
 
 # Test every definition if available in the current repository and update the jobs
 # if they do define one (they should always define their definitions)
-for dir in `ls .`; do
+for dir in `find . -maxdepth 1 -path ./.git -prune -o -type d -print`; do
     definitions_dir="$dir/config/definitions"
     if [ -d "$definitions_dir" ]; then
         echo "found definitions directory: $definitions_dir"


### PR DESCRIPTION
The `for `ls .\` ... -d subdirectory` logic was examining every entry at the top-level of the workspace, both files and directories. The files entries were useless since they would never contain subdirectories.

This pull request uses `find` instead to only locate directories at the top level.

The purpose of this change is to make the verbose output (with `set -x`) easier to read, and make it easier to spot errors in the future.
