### PR TITLE
ceph-deploy-pull-requests: add Travis to admins list

### DIFF
--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -31,6 +31,7 @@
           admin-list:
             - alfredodeza
             - ktdreyer
+            - trhoden
           white-list:
             - xarses
             - angdraug


### PR DESCRIPTION
@trhoden is a co-maintainer of ceph-deploy; this pull request adds him to the list of administrators for the GitHub Pull Requests plugin. With this change, Jenkins will trust any pull requests from Travis and build them automatically.

(I don't know why Jenkins wasn't already trusting Travis since he's a member of the Ceph organization, and that is supposed to be whitelisted.)
