### PR TITLE
jenkins-slave-chef-pull-requests: fix Git URL

### DIFF
--- a/jenkins-slave-chef-pull-requests/config/definitions/jenkins-slave-chef-pull-requests.yml
+++ b/jenkins-slave-chef-pull-requests/config/definitions/jenkins-slave-chef-pull-requests.yml
@@ -33,12 +33,12 @@
 
     scm:
       - git:
-          url: https://github.com/ceph/ceph-build.git
+          url: https://github.com/ceph/jenkins-slave-chef.git
           branches:
             - ${sha1}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: githubweb
-          browser-url: http://github.com/ceph/ceph-build.git
+          browser-url: https://github.com/ceph/jenkins-slave-chef/
           timeout: 20
 
     builders:


### PR DESCRIPTION
Fix a bad copy & paste for the `jenkins-slave-chef-pull-requests` job configuration.
