### PR TITLE
jenkins-slave-chef-pull-requests: add GitHub URL

### DIFF
--- a/jenkins-slave-chef-pull-requests/config/definitions/jenkins-slave-chef-pull-requests.yml
+++ b/jenkins-slave-chef-pull-requests/config/definitions/jenkins-slave-chef-pull-requests.yml
@@ -10,6 +10,9 @@
     block-downstream: false
     block-upstream: false
     retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/jenkins-slave-chef
 
     parameters:
       - string:


### PR DESCRIPTION
Configure the GitHub plugin for the `jenkins-slave-chef-pull-requests` job.

(Ideally this will allow the job to recognize the pull request web hooks that come in from GitHub.)
