### PR TITLE
Create a job to build teuthology docs and deploy them

### DIFF
--- a/teuthology-docs-build/build/build
+++ b/teuthology-docs-build/build/build
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -ex
+
+# Create the virtualenv
+virtualenv venv
+. venv/bin/activate
+
+# Define and ensure the PIP cache
+PIP_SDIST_INDEX="$HOME/.cache/pip"
+mkdir -p $PIP_SDIST_INDEX
+
+# Install the package by trying with the cache first, otherwise doing a download only, and then
+# trying to install from the cache again.
+if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox; then
+    venv/bin/pip install --download-directory="$PIP_SDIST_INDEX" tox
+    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox
+fi
+
+
+# create the docs build with tox
+tox -rv -e docs
+# publish docs to ceph.com/teuthology/docs
+rsync -auv --delete -e &quot;ssh -i /home/jenkins-build/.ssh/cephdocs_id_rsa -o StrictHostKeyChecking=no&quot; .tox/docs/tmp/html/* cephdocs@ceph.newdream.net:/home/ceph_site/ceph.com/teuthology/docs/

--- a/teuthology-docs-build/config/definitions/teuthology-docs-build.yml
+++ b/teuthology-docs-build/config/definitions/teuthology-docs-build.yml
@@ -1,0 +1,36 @@
+- job:
+    name: teuthology-docs-build 
+    node: gitbuilder-cdep-deb-cloud-precise-amd64-basic
+    project-type: freestyle
+    defaults: global
+    disabled: false
+    display-name: 'Teuthology: Docs Build'
+    concurrent: false
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/teuthology
+    logrotate:
+      daysToKeep: -1 
+      numToKeep: -1 
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    triggers:
+      - pollscm: "* * * * *"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/teuthology.git
+          branches:
+            - master 
+          browser: githubweb
+          browser-url: https://github.com/ceph/teuthology.git
+          timeout: 20
+
+    builders:
+      - shell:
+          !include-raw ../../build/build


### PR DESCRIPTION
I took the xml file for the ceph-deploy-docs job and tried to use it as a reference for creating this job.  I suspect I've gotten a few things incorrect here, but it's a starting point anyway.

A couple things I worry about:
- I don't believe that the ceph.com/teuthology/docs directories exist.  Will that rsync command fail if those directories don't exist?
- The teuthology docs currently do not have an index.rst.  Will contents.rst be served out instead?
- Would it be better to build docs on every push to master?  Currently this would only build docs with manual intervention.

Thanks for taking a look.

Signed-off-by: Andrew Schoen aschoen@redhat.com
