### PR TITLE
remove poll scm option for pull request jobs

### DIFF
--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -25,7 +25,6 @@
           description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
-      - pollscm: "*/1 * * * *"
       - github-pull-request:
           cron: '* * * * *'
           admin-list:

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -25,7 +25,6 @@
           description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
-      - pollscm: "*/1 * * * *"
       - github-pull-request:
           cron: '* * * * *'
           admin-list:


### PR DESCRIPTION
Looks like these jobs should now not poll GH for changes. The only trigger should be the pull request