### PR TITLE
build_rpms.sh: terminate on unpackaged files

### DIFF
--- a/build_rpms.sh
+++ b/build_rpms.sh
@@ -30,6 +30,6 @@ cp -a rpm/*.patch ${BUILDAREA}/SOURCES/. || true
 # Build RPMs
 BUILDAREA=`readlink -fn ${BUILDAREA}`   ### rpm wants absolute path
 cd ${BUILDAREA}/SPECS
-rpmbuild -ba --define "_topdir ${BUILDAREA}" --define "_unpackaged_files_terminate_build 0" ceph.spec
+rpmbuild -ba --define "_topdir ${BUILDAREA}" ceph.spec
 
 echo done


### PR DESCRIPTION
As Ceph changes and new files get installed by default, we need to ensure that the commits which create these files also update the packaging files lists as well.

One way to do this is to tell Gitbuilder to stop skipping unpackaged files in the RPMs. This will cause Gitbuilder builds to indicate a failure when new files get added without packaging updates.