### PR TITLE
ceph-build-pull-requests: quiet output

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # Create the virtualenv
 virtualenv venv


### PR DESCRIPTION
Running the pull requests script with `-x` is very noisy. The script already prints a lot of information with "echo", so just silence the debugging outupt.