### PR TITLE
ceph-setup: remove do_autogen.sh

### DIFF
--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -39,10 +39,24 @@ rm -rf release
 echo "Running submodule update ..."
 git submodule update --init
 
+echo "Running autogen.sh ..."
+./autogen.sh
 echo "Running configure ..."
-# because this is running in a Debian-based distro we need to pass -L
-# to disable lttng
-./do_autogen.sh -L
+./configure \
+  --disable-option-checking \
+  '--prefix=/usr' \
+  '--sbindir=/sbin' \
+  '--localstatedir=/var' \
+  '--sysconfdir=/etc' \
+  '--with-debug' \
+  '--with-nss' \
+  '--with-radosgw' \
+  '--disable-static' \
+  '--without-lttng' \
+  'CFLAGS= -Wno-unused-parameter' \
+  'CXXFLAGS=  -Wno-unused-parameter' \
+  --cache-file=/dev/null \
+  --srcdir=.
 
 if [ $? -ne 0 ] ; then
     echo "autogen failed"


### PR DESCRIPTION
Remove `do_autogen.sh` from the ceph-setup task. Run `./autogen.sh` and `./configure` instead.

I've copied this long `./configure` argument list from a prior run of `./do_autogen.sh` so that we're using the same arguments. We can adjust it as needed.

One of the reasons for making this change is that `./do_autogen.sh` takes an argument ("`-L`") depending on whether we're building a Hammer or Firefly release. The goal of this change is to use a more stable interface for doing the builds.

As background, from Sage on IRC yesterday:

```
  sage: i'm surprised jenkins is using do_autogen.sh at all actually?
  ktdreyer: what should it use?
  sage: ./autogen.sh and then pass the args explicitly to ./configure
        that it wants?
  sage: it doesn't really matter i guess, but do_autogen.sh piles a
        bunch of random stuff in there
  ktdreyer: I was just looking at autobuild-ceph.git's build-ceph.sh
  ktdreyer: it does what you're suggesting
  ktdreyer: cool
  sage: do_autogen.sh in my mind is for developers.  if it makes sense
        for relase that's ok, but that's not how i've treated it
```