### PR TITLE
ceph-package: fix job name

### DIFF
--- a/ceph-package/config/definitions/ceph-package.yml
+++ b/ceph-package/config/definitions/ceph-package.yml
@@ -1,5 +1,5 @@
 - job:
-    name: ceph-build
+    name: ceph-package
     defaults: global
     disabled: false
     display-name: 'ceph-build'


### PR DESCRIPTION
When I imported the ceph-package job, I made a bad copy & paste in the name - it was erroneously named "ceph-build".

This PR updates the job's name to the correct value.