### PR TITLE
ceph-package: fix display name

### DIFF
--- a/ceph-package/config/definitions/ceph-package.yml
+++ b/ceph-package/config/definitions/ceph-package.yml
@@ -2,7 +2,7 @@
     name: ceph-package
     defaults: global
     disabled: false
-    display-name: 'ceph-build'
+    display-name: 'ceph-package'
     node: package
     concurrent: false
     block-downstream: false


### PR DESCRIPTION
Commit f8d03a28c00e8ad6b2c496e069de6492791496ba fixed the internal Jenkins job name, this fixes the display name as well.