### PR TITLE
ceph-setup: skip tagging each build

### DIFF
--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -26,6 +26,7 @@
           url: git://jenkins.front.sepia.ceph.com/ceph/ceph.git
           branches:
             - $BRANCH
+          skip-tag: true
 
     builders:
       - shell:


### PR DESCRIPTION
Jenkins (un)helpfully tags each build. Don't do this in the ceph-setup task.

See https://bugzilla.redhat.com/show_bug.cgi?id=1214907