### PR TITLE
radosgw-agent: remove wip display name

### DIFF
--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -4,7 +4,7 @@
     project-type: matrix
     defaults: global
     disabled: false
-    display-name: 'radosgw-agent-wip'
+    display-name: 'radosgw-agent'
     concurrent: true
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
It doesn't make sense to name this job "wip", since we're using it to build releases.