### PR TITLE
unquote archive settings

### DIFF
--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -66,5 +66,5 @@
     publishers:
       - archive:
           artifacts: '*-repo/**, dist/**'
-          allow-empty: 'true'
-          latest-only: 'false'
+          allow-empty: true
+          latest-only: false

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -67,5 +67,5 @@
     publishers:
       - archive:
           artifacts: '*-repo/**, dist/**'
-          allow-empty: 'true'
-          latest-only: 'false'
+          allow-empty: true
+          latest-only: false


### PR DESCRIPTION
Prior to this commit the archive settings were quoted `'false'` or `'true'` instead of simply the boolean types that YAML expects.

jenkins-jobs interpreted these strings to be "true", so we ended up with the following XML:

```
  <latestOnly>true</latestOnly>
```

This meant that Jenkins deleted all the older archived ceph-deploy packages each time a new version was built.  When 1.5.22.1 was built, the "older" 1.5.23 package was deleted.

Unquote the boolean values so JJB will properly interpret them.

Thanks @dmick for pointing me in the right direction here.