### PR TITLE
remove fedora20 Jenkins slave

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -33,7 +33,6 @@
             - centos7
             - rhel6.5
             - rhel7
-            - fedora20
 
     builders:
       - shell: |

--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -50,7 +50,6 @@
             - centos6.5
             - centos7
             - rhel6.5
-            - fedora20
             - opensuse12.2
             - sles11sp2
             - rhel7

--- a/ceph-package/config/definitions/ceph-package.yml
+++ b/ceph-package/config/definitions/ceph-package.yml
@@ -36,7 +36,6 @@
             - centos7
             - rhel6.5
             - rhel7
-            - fedora20
 
     builders:
 

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -37,7 +37,6 @@ rm -rf RPMBUILD
 target=$DIST
 if [ "$target" = "centos6.5" ] ; then target=el6 ; fi
 if [ "$target" = "centos7" ] ; then target=el7 ; fi
-if [ "$target" = "fedora20" ] ; then target=fc20 ; fi
 if [ "$target" = "rhel6.5" ] ; then target=rhel6 ; fi
 if [ "$target" = "sles11sp2" ] ; then target=sles11 ; fi
 echo "Target directory is: $target"

--- a/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
+++ b/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
@@ -31,7 +31,6 @@
             - centos6.5
             - centos7
             - rhel6.5
-            - fedora20
             - sles11sp2
             - rhel7
 

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -50,7 +50,6 @@
             - centos6.5
             - centos7
             - rhel6.5
-            - fedora20
             - opensuse12.2
             - sles11sp2
             - rhel7


### PR DESCRIPTION
Remove the Fedora 20 build slave from the job configs.

We're having trouble resurrecting gitbuilder-cdep-rpm-cloud-fedora20-amd64-basic.cloud.sepia.ceph.com in DreamCompute, and Fedora 20 itself is going EOL in a month or so.

This is the only Fedora builder we have, and this VM does build packages for http://ceph.com/rpm-hammer/fc20/, so it would be nice to get fresh Fedora build slaves set up eventually. But in the meantime, since this one is giving us trouble, just remove it.