### PR TITLE
fix/improve ceph-deploy build script

### DIFF
--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -31,8 +31,16 @@ echo "  BRANCH=$BRANCH"
 rpm_dists="rhel centos6.5 centos7 rhel6.5 rhel7 centos sles11sp2 opensuse12.2"
 deb_dists="precise wheezy squeeze trusty"
 
-case $HOST in
-gitbuilder-*-rpm*)
+# A helper to match an item in a list of items, like python's `if item in list`
+listcontains() {
+  for word in $2; do
+    [[ $word = $1 ]] && return 0
+  done
+  return 1
+}
+
+if listcontains $DIST "$rpm_dists"
+then
         rm -rf rpm-repo dist/* build/rpmbuild
 
         # Tag tree and update version number in change log and
@@ -94,8 +102,9 @@ gitbuilder-*-rpm*)
         cd $WORKSPACE
         mkdir -p dist
         exit 0
-        ;;
-gitbuilder-cdep-deb* | tala* | mira*)
+
+elif listcontains $DIST "$deb_dists"
+then
         rm -rf debian-repo
         rm -rf dist
         rm -f ../*.changes ../*.dsc ../*.gz ../*.diff
@@ -175,9 +184,8 @@ EOF
     mkdir -p dist
     mv ../*.changes ../*.dsc ../*.deb ../*.tar.gz dist/.
     echo "Done"
-        ;;
-*)
+
+else
 	echo "Can't determine build host type"
         exit 4
-        ;;
-esac
+fi

--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -26,6 +26,11 @@ echo "  WS=$WORKSPACE"
 echo "  PWD=$(pwd)"
 echo "  BRANCH=$BRANCH"
 
+# FIXME A very naive way to just list the RPM $DIST that we currently support.
+# We should be a bit more lenient to allow any rhel/centos/sles/suse
+rpm_dists="rhel centos6.5 centos7 rhel6.5 rhel7 centos sles11sp2 opensuse12.2"
+deb_dists="precise wheezy squeeze trusty"
+
 case $HOST in
 gitbuilder-*-rpm*)
         rm -rf rpm-repo dist/* build/rpmbuild

--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -124,13 +124,10 @@ gitbuilder-cdep-deb* | tala* | mira*)
     rm -rf ./debian-repo
 
     # Apply backport tag if release build
-    # I am going to jump out the window if this is not fixed and removed from the source
-    # of this package. There is absolutely **NO** reason why we need to hard code the
-    # DEBEMAIL like this.
     if [ $RELEASE -eq 1 ] ; then
         DEB_VERSION=$(dpkg-parsechangelog | sed -rne 's,^Version: (.*),\1, p')
         BP_VERSION=${DEB_VERSION}${BPTAG}
-        DEBEMAIL="alfredo.deza@inktank.com" dch -D $DIST --force-distribution -b -v "$BP_VERSION" "$comment"
+        dch -D $DIST --force-distribution -b -v "$BP_VERSION" "$comment"
         dpkg-source -b .
     fi
 

--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -151,18 +151,18 @@ gitbuilder-cdep-deb* | tala* | mira*)
 
     for DIST in  $DEB_DIST ; do
         cat <<EOF >> $REPO/conf/distributions
-    Codename: $DIST
-    Suite: stable
-    Components: $COMPONENT
-    Architectures: amd64 armhf i386 source
-    Origin: Inktank
-    Description: Ceph distributed file system
-    DebIndices: Packages Release . .gz .bz2
-    DscIndices: Sources Release .gz .bz2
-    Contents: .gz .bz2
-    SignWith: $KEYID
+Codename: $DIST
+Suite: stable
+Components: $COMPONENT
+Architectures: amd64 armhf i386 source
+Origin: Inktank
+Description: Ceph distributed file system
+DebIndices: Packages Release . .gz .bz2
+DscIndices: Sources Release .gz .bz2
+Contents: .gz .bz2
+SignWith: $KEYID
 
-    EOF
+EOF
     done
 
     echo "Adding package to repo, dist: $DEB_BUILD ($PKG)"


### PR DESCRIPTION
It will now use `$DIST` although in a not very flexible way. 

It fixes a EOF error as well and removes some hard coded variables.