### PR TITLE
ceph-deploy: build with bash, not /bin/sh

### DIFF
--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This is the script that runs inside Jenkins.
 # http://jenkins.ceph.com/job/ceph-deploy/


### PR DESCRIPTION
/bin/sh is dash on Ubuntu/Debian. Switch to bash for uniformity with RPM systems.