### PR TITLE
use the 'trusty' label

### DIFF
--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-build-pull-requests
-    node: gitbuilder-cdep-deb-trusty-amd64-basic
+    node: trusty
     project-type: freestyle
     defaults: global
     disabled: false

--- a/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
+++ b/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
@@ -1,6 +1,6 @@
 - job:
-    name: ceph-deploy-docs 
-    node: gitbuilder-cdep-deb-trusty-amd64-basic
+    name: ceph-deploy-docs
+    node: trusty
     project-type: freestyle
     defaults: global
     disabled: false
@@ -14,8 +14,8 @@
       - github:
           url: https://github.com/ceph/ceph-deploy
     logrotate:
-      daysToKeep: -1 
-      numToKeep: -1 
+      daysToKeep: -1
+      numToKeep: -1
       artifactDaysToKeep: -1
       artifactNumToKeep: -1
 
@@ -26,7 +26,7 @@
       - git:
           url: https://github.com/ceph/ceph-deploy.git
           branches:
-            - master 
+            - master
           browser: githubweb
           browser-url: https://github.com/ceph/ceph-deploy.git
           timeout: 20

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-deploy-pull-requests
-    node: gitbuilder-cdep-deb-trusty-amd64-basic
+    node: trusty
     project-type: freestyle
     defaults: global
     disabled: false

--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-deploy
-    node: gitbuilder-cdep-deb-trusty-amd64-basic
+    node: trusty
     project-type: matrix
     defaults: global
     disabled: false

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-qa-suite-pull-requests
-    node: gitbuilder-cdep-deb-trusty-amd64-basic
+    node: trusty
     project-type: freestyle
     defaults: global
     disabled: false

--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-setup
     description: "This job step checks out the branch and builds the tarballs, diffs, and dsc that are passed to the ceph-build step.\r\n\r\nNotes:\r\nJob needs to run on a releatively recent debian system.  The Restrict where run feature is used to specifiy an appropriate label.\r\nThe clear workspace before checkout box for the git plugin is used."
-    node: gitbuilder-cdep-deb-trusty-amd64-basic
+    node: trusty
     disabled: false
     display-name: 'ceph-setup'
     concurrent: false

--- a/jjb/config/definitions/jjb.yml
+++ b/jjb/config/definitions/jjb.yml
@@ -1,6 +1,6 @@
 - job:
     name: jenkins-job-builder
-    node: gitbuilder-cdep-deb-trusty-amd64-basic
+    node: trusty
     project-type: freestyle
     defaults: global
     disabled: false

--- a/teuthology-docs/config/definitions/teuthology-docs.yml
+++ b/teuthology-docs/config/definitions/teuthology-docs.yml
@@ -1,6 +1,6 @@
 - job:
-    name: teuthology-docs 
-    node: gitbuilder-cdep-deb-trusty-amd64-basic
+    name: teuthology-docs
+    node: trusty
     project-type: freestyle
     defaults: global
     disabled: false
@@ -14,8 +14,8 @@
       - github:
           url: https://github.com/ceph/teuthology
     logrotate:
-      daysToKeep: -1 
-      numToKeep: -1 
+      daysToKeep: -1
+      numToKeep: -1
       artifactDaysToKeep: -1
       artifactNumToKeep: -1
 
@@ -26,7 +26,7 @@
       - git:
           url: https://github.com/ceph/teuthology.git
           branches:
-            - master 
+            - master
           browser: githubweb
           browser-url: https://github.com/ceph/teuthology.git
           timeout: 20


### PR DESCRIPTION
Fixes the problem with all the other jobs that used a rather hardcoded name.

Using 'trusty' is more flexible because we can have more 'trusty' nodes around