### PR TITLE
ceph-setup: use bash, not sh

### DIFF
--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 #export GNUPGHOME=/home/jenkins-build/build/gnupg.autobuild/
 export GNUPGHOME=/home/jenkins-build/build/gnupg.ceph-release/


### PR DESCRIPTION
`/bin/sh` is dash on Ubuntu/Debian. Switch to bash for uniformity with RPM systems.