### PR TITLE
switch "precise" jobs to build on trusty

### DIFF
--- a/jenkins-slave-chef-pull-requests/config/definitions/jenkins-slave-chef-pull-requests.yml
+++ b/jenkins-slave-chef-pull-requests/config/definitions/jenkins-slave-chef-pull-requests.yml
@@ -1,6 +1,6 @@
 - job:
     name: jenkins-slave-chef-pull-requests
-    node: gitbuilder-cdep-deb-cloud-precise-amd64-basic
+    node: trusty
     project-type: freestyle
     defaults: global
     disabled: false

--- a/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
+++ b/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
@@ -1,6 +1,6 @@
 - job:
     name: radosgw-agent-pull-requests
-    node: gitbuilder-cdep-deb-cloud-precise-amd64-basic
+    node: trusty
     project-type: freestyle
     defaults: global
     disabled: false

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -1,6 +1,6 @@
 - job:
     name: radosgw-agent
-    node: gitbuilder-cdep-deb-cloud-precise-amd64-basic
+    node: trusty
     project-type: matrix
     defaults: global
     disabled: false


### PR DESCRIPTION
The DreamCompute builders (including the Precise builder) are no longer available to us.

Switch the jobs that used the DreamCompute Precise builder to use the trusty label instead.