### PR TITLE
ceph-build: better SUSE detection

### DIFF
--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -1,16 +1,7 @@
 #!/bin/bash
 set -ex
 
-# Run only in RPM based systems
-is_suse() {
-    if hash zypper 2>/dev/null; then
-        echo 1
-    else
-        echo 0
-    fi
-}
-
-if [[ ! -f /etc/redhat-release && is_suse -eq 0 ]] ; then
+if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then
     exit 0
 fi
 


### PR DESCRIPTION
As was done in 18890d5a0351ffe4fc495e0d47e3a86e0a9cb7ad for radosgw-agent, update ceph-build's SUSE detection so we check for the "zypper" file directly on-disk.