### PR TITLE
Remove 'noreplace' option on installed config file, /etc/yum.repos.d/ceph.repo...

### DIFF
--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -103,9 +103,9 @@ install -pm 644 %{SOURCE0} \
 %defattr(-,root,root,-)
 #%doc GPL
 %if 0%{defined suse_version}
-%config(noreplace) /etc/zypp/repos.d/*
+%config /etc/zypp/repos.d/*
 %else
-%config(noreplace) /etc/yum.repos.d/*
+%config /etc/yum.repos.d/*
 %endif
 #/etc/pki/rpm-gpg/*
 


### PR DESCRIPTION
...in ceph-release package so the package version can replace the user-created one.

When the 'noreplace' option is used on a %config file in rpm.spec, the system will not replace an existing config file which has been modified since the last package was laid down, or which was created by a user if no previous package was installed. Instead it lays down the new config file renamed to .rpmnew and leaves the existing file alone. I think the intent of the author was likely that the package config file replace the one created by the user, as it contains more entries that are required by ceph-deploy, and the quick start preflight guide only indicates a single repo - the ceph-noarch repo.