### PR TITLE
teuthology-pull-requests: remove empty trigger-phrase

### DIFF
--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -46,7 +46,6 @@
             - liewegas
             - idryomov
             - vasukulkarni
-          trigger-phrase: ''
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false


### PR DESCRIPTION
This should be defaulted by the plugin and is unneeded here.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>