### PR TITLE
pull requests: rm "cron" settings

### DIFF
--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -26,7 +26,6 @@
 
     triggers:
       - github-pull-request:
-          cron: '* * * * *'
           admin-list:
             - alfredodeza
             - ktdreyer

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -26,7 +26,6 @@
 
     triggers:
       - github-pull-request:
-          cron: '* * * * *'
           admin-list:
             - alfredodeza
             - ktdreyer

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -26,7 +26,6 @@
 
     triggers:
       - github-pull-request:
-          cron: '* * * * *'
           admin-list:
             - alfredodeza
             - ktdreyer

--- a/jenkins-slave-chef-pull-requests/config/definitions/jenkins-slave-chef-pull-requests.yml
+++ b/jenkins-slave-chef-pull-requests/config/definitions/jenkins-slave-chef-pull-requests.yml
@@ -21,7 +21,6 @@
 
     triggers:
       - github-pull-request:
-          cron: '* * * * *'
           admin-list:
             - alfredodeza
             - ktdreyer

--- a/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
+++ b/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
@@ -26,7 +26,6 @@
 
     triggers:
       - github-pull-request:
-          cron: '* * * * *'
           admin-list:
             - alfredodeza
             - jdurgin

--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -26,7 +26,6 @@
 
     triggers:
       - github-pull-request:
-          cron: '* * * * *'
           admin-list:
             - alfredodeza
             - ktdreyer


### PR DESCRIPTION
From the Jenkins GitHub Pull Requests plugin docs on "useGitHubHooks":

    Checking this option will disable regular polling (cron) for changes
    in GitHub and will try to create a GitHub hook. Creating a GitHub hook
    requires that the user which is specified in the GitHub Pull Request
    Builder configuration has admin rights to the specified repository.

Based on the documentation above, since our PR jobs have "`github-hooks: true`", the "`cron`" values have no effect and can be removed.