### PR TITLE
ceph-setup: wipe workspace

### DIFF
--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -27,6 +27,7 @@
           branches:
             - $BRANCH
           skip-tag: true
+          wipe-workspace: true
 
     builders:
       - shell:


### PR DESCRIPTION
The ceph-setup task occasionally gets weird errors that can only be fixed by wiping the workspace.

The latest example:

    tardir=ceph-0.94.1.3 && ${TAR-tar} chof - "$tardir" | GZIP=--best gzip -c >ceph-0.94.1.3.tar.gz
    tar: ceph-0.94.1.3/src/gmock/gtest/xcode/Samples/FrameworkSample/WidgetFramework.xcodeproj/project.pbxproj: file name is too long (max 99); not dumped
    tar: ceph-0.94.1.3/src/test/ubuntu-12.04/debian: File removed before we read it
    tar: ceph-0.94.1.3/src/test/ubuntu-14.04/debian: File removed before we read it
    tar: ceph-0.94.1.3/src/test/debian-jessie/debian: File removed before we read it
    tar: Exiting with failure status due to previous errors

... btw, :heart: the comment in this job's description, "The clear workspace before checkout box for the git plugin is used."