### PR TITLE
teuthology-pull-requests: run the teuthology bootstrap on setup

### DIFF
--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -64,6 +64,8 @@
 
     builders:
       - shell:
+          !include-raw ../../setup/setup
+      - shell:
           !include-raw ../../build/build
 
     publishers:

--- a/teuthology-pull-requests/setup/setup
+++ b/teuthology-pull-requests/setup/setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+# run the teuthology bootstrap to setup this node for
+# teuthology pull requests testing
+./bootstrap


### PR DESCRIPTION
This will setup the jenkins slaves properly to successfully run the tox
tests on pull requests.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>