### PR TITLE
teuthology-pull-requests: pass the 'install' command to ./bootstrap

### DIFF
--- a/teuthology-pull-requests/setup/setup
+++ b/teuthology-pull-requests/setup/setup
@@ -2,6 +2,7 @@
 
 set -ex
 
-# run the teuthology bootstrap to setup this node for
-# teuthology pull requests testing
-./bootstrap
+# run the teuthology bootstrap to setup this jenkins slave for
+# teuthology pull requests testing. Passing 'install' here
+# installs any missing requirements found needed to bootstrap teuthology
+./bootstrap install


### PR DESCRIPTION
This is a flag used to tell the bootstrap script to install any missing
packages it finds needed for the bootstrap process.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>