### PR TITLE
whitelist Ivo for teuthology PRs

### DIFF
--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -45,6 +45,7 @@
             - liewegas
             - idryomov
             - vasukulkarni
+            - ivotron
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false


### PR DESCRIPTION
Ivo Jimenez (@ivotron) is a Red Hat intern working on teuthology. Whitelist his account so we don't have to manually approve testing his PRs.

cc @andrewschoen , @zmc 