### PR TITLE
update user whitelist for ceph-deploy PRs

### DIFF
--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -33,6 +33,9 @@
           white-list:
             - xarses
             - angdraug
+            - mbroz
+            - ddiss
+            - osynge
           org-list:
             - ceph
           trigger-phrase: ''


### PR DESCRIPTION
These users have contributed patches to ceph-deploy. Whitelist their PRs going forward so we don't have to manually approve testing each one.

Milan Broz (@mbroz)
David Disseldorp (@ddiss)
Owen Synge (@osynge)

cc'ing @trhoden & @alfredodeza 