### PR TITLE
ansible: rm green balls plugin

### DIFF
--- a/ansible/master/master.yml
+++ b/ansible/master/master.yml
@@ -17,7 +17,6 @@
       - 'publish-over-ssh'
       - 'nested-view'
       - 'jenkins-multijob-plugin'
-      - 'greenballs'
       - 'ghprb'
       - 'github'
       - 'github-api'


### PR DESCRIPTION
This plugin is not color-blind friendly. It is possible to turn it off on a per-user setting, but that requires logging into Jenkins. Let's just turn it off entirely so we're fully accessible for people who
aren't logged in.