### PR TITLE
add jessie to deb_dists

### DIFF
--- a/deb_dists
+++ b/deb_dists
@@ -1,6 +1,7 @@
 sid
 wheezy
 squeeze
+jessie
 raring
 quantal
 precise


### PR DESCRIPTION
to fix the error on gitbuilder of "gitbuilder-ceph-deb-jessie-amd64-basic":

```
+ /srv/ceph-build/gen_reprepro_conf.sh ../out/output/sha1/6ffb1c4ae43bcde9f5fde40dd97959399135ed86.tmp 03C3951A
dists sid
wheezy
squeeze
raring
quantal
precise
saucy
trusty
components main
done
+ GNUPGHOME=/srv/gnupg reprepro --ask-passphrase -b ../out/output/sha1/6ffb1c4ae43bcde9f5fde40dd97959399135ed86.tmp -C main --ignore=undefinedtarget --ignore=wrongdistribution include jessie out~/ceph_0.94.2-50-g6ffb1c4-1jessie_amd64.changes
Cannot find definition of distribution 'jessie'!
There have been errors!
```

see http://gitbuilder.sepia.ceph.com/gitbuilder-ceph-deb-jessie-amd64-basic/log.cgi?log=6ffb1c4ae43bcde9f5fde40dd97959399135ed86