### PR TITLE
ceph-deploy: Set $SUDO when not root

### DIFF
--- a/ceph-deploy/build/setup
+++ b/ceph-deploy/build/setup
@@ -13,6 +13,10 @@ set -e
 
 rpm_deps="python-devel python-virtualenv python-mock python-tox pytest"
 
+if test $(id -u) != 0 ; then
+    SUDO=sudo
+fi
+
 if test -f /etc/redhat-release ; then
     $SUDO yum install -y "$rpm_deps"
 fi


### PR DESCRIPTION
The $SUDO var was not set.  Found this from another script.

Signed-off-by: Travis Rhoden <trhoden@redhat.com>