### PR TITLE
remove references/tests for bindir

### DIFF
--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -19,11 +19,6 @@ fi
 
 echo "Building version $(git describe) Branch $Branch"
 
-if [ ! -d /srv/ceph-build ] ; then
-    echo "Build tools are not installed"
-    exit 1
-fi
-bindir=/srv/ceph-build
 rm -rf dist
 rm -rf release
 


### PR DESCRIPTION
We are no longer using this method of dealing with script dependency. 