### PR TITLE
Ceph setup unpin

### DIFF
--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -30,6 +30,11 @@ rm -rf release
 #sed -i 's/^Source0:.*/Source0:        http:\/\/ceph.com\/download\/%{name}-%{version}-rc1.tar.bz2/' ceph.spec.in
 #sed -i 's/^%setup.*/%setup -q -n %{name}-%{version}-rc1/' ceph.spec.in
 
+# because autogen+configure will check for dependencies, we are forced to install them
+# and ensure they are present in the current host
+echo "Ensuring dependencies are installed"
+./install-deps.sh
+
 # run submodule updates regardless
 echo "Running submodule update ..."
 git submodule update --init

--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -1,6 +1,8 @@
 - job:
     name: ceph-setup
     description: "This job step checks out the branch and builds the tarballs, diffs, and dsc that are passed to the ceph-build step.\r\n\r\nNotes:\r\nJob needs to run on a releatively recent debian system.  The Restrict where run feature is used to specifiy an appropriate label.\r\nThe clear workspace before checkout box for the git plugin is used."
+    # we do not need to pin this to trusty anymore for the new jenkins instance
+    # FIXME: unpin when this gets ported over
     node: trusty
     disabled: false
     display-name: 'ceph-setup'


### PR DESCRIPTION
always call `./install-deps.sh` so that deps are ensured because `configure` checks for them and comment about pinning on trusty which is no longer needed in the new environment