### PR TITLE
jjb: accept change notifications from GitHub

### DIFF
--- a/jjb/config/definitions/jjb.yml
+++ b/jjb/config/definitions/jjb.yml
@@ -13,6 +13,7 @@
 
     triggers:
       - pollscm: "H */3 * * *"
+      - github
 
     scm:
       - git:


### PR DESCRIPTION
In commit fac5ec4127ac1178b40ce0bd8bd176af355aadce I slowed down the Git SCM polling for the JJB management job, with the reasoning that the GitHub webhook would be a more responsive and efficient method of triggering builds.

However, this was not entirely sufficient because the JJB job itself must also be explicitly configured to accept the GitHub webhook notifications.

Add "github" to the list of triggers for the JJB job. (This setting corresponds to the "Build when a change is pushed to GitHub" checkbox in Jenkins web UI.)