### PR TITLE
remove i386 from ceph-build

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -12,8 +12,7 @@
           url: https://github.com/ceph/ceph
 
     execution-strategy:
-      combination-filter: |
-        (Arch=="x86_64") || (Arch=="i386" && Distro=="precise-pbuild")
+      combination-filter: Arch=="x86_64"
 
     axes:
       - axis:
@@ -21,7 +20,6 @@
           name: Arch
           values:
             - x86_64
-            - i386
       - axis:
           type: label-expression
           name: Distro


### PR DESCRIPTION
Not sure if we need a combination filter anymore :/

Signed-off-by: Alfredo Deza <adeza@redhat.com>