### PR TITLE
import "ceph-puppet-modules" job

### DIFF
--- a/ceph-puppet-modules/build/rename-ceph-puppet-modules
+++ b/ceph-puppet-modules/build/rename-ceph-puppet-modules
@@ -1,0 +1,21 @@
+#!/bin/bash -ex
+
+# Rename a debian package from "takora" to "ceph-puppet-modules".
+
+oldname='takora'
+newname='ceph-puppet-modules'
+
+cd debian
+
+for file in $(find . -type f); do
+    if [ $file == './copyright' ]; then
+        # The uses of "$oldname" in the copyright file are ok to leave alone.
+        continue
+    fi
+    sed -i -e "s/$oldname/$newname/g" $file
+done
+
+for file in $(find . -type f -name "*$oldname*"); do
+    newfile=$(echo $file | sed -e "s/$oldname/$newname/")
+    mv $file $newfile
+done

--- a/ceph-puppet-modules/config/definitions/ceph-puppet-modules.yml
+++ b/ceph-puppet-modules/config/definitions/ceph-puppet-modules.yml
@@ -1,0 +1,55 @@
+- job:
+    name: ceph-puppet-modules
+    description: Build and package takora as "ceph-puppet-modules"
+    project-type: matrix
+    axes:
+    - axis:
+        name: Arch
+        type: label-expression
+        values:
+        - x86_64
+    - axis:
+        name: Dist
+        type: label-expression
+        values:
+        - trusty
+    block-downstream: false
+    block-upstream: false
+
+    properties:
+    - github:
+        url: https://github.com/ceph/takora/
+
+    scm:
+    - git:
+        skip-tag: true
+        basedir: takora
+        url: https://github.com/ceph/takora
+        branches:
+         - $BRANCH
+
+    execution-strategy:
+      run-sequentially: false
+
+    builders:
+    - shell:
+        !include-raw ../../build/rename-ceph-puppet-modules
+    - shell:
+        !include-raw ../../../takora/build/build
+    concurrent: false
+    parameters:
+    - string:
+        default: master
+        description: 'The git branch or tag to build'
+        name: BRANCH
+
+    publishers:
+    - archive:
+        allow-empty: false
+        artifacts: $BRANCH/*
+        default-excludes: true
+        fingerprint: false
+        only-if-success: false
+    - description-setter:
+        regexp: '^BRANCH: (\S+)'
+        set-for-matrix: false


### PR DESCRIPTION
The downstream takora package in RHCS is named "ceph-puppet-modules". Define a job that creates debian packages with that name.