### PR TITLE
Jessie support

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -112,15 +112,10 @@ gen_debian_version() {
     [ "$dist" = "wheezy" ] && dver="$raw~bpo70+1"
     [ "$dist" = "squeeze" ] && dver="$raw~bpo60+1"
     [ "$dist" = "lenny" ] && dver="$raw~bpo50+1"
-    [ "$dist" = "trusty" ] && dver="$raw$dist"
-    [ "$dist" = "saucy" ] && dver="$raw$dist"
-    [ "$dist" = "quantal" ] && dver="$raw$dist"
     [ "$dist" = "precise" ] && dver="$raw$dist"
-    [ "$dist" = "oneiric" ] && dver="$raw$dist"
-    [ "$dist" = "natty" ] && dver="$raw$dist"
-    [ "$dist" = "maverick" ] && dver="$raw$dist"
-    [ "$dist" = "lucid" ] && dver="$raw$dist"
-    [ "$dist" = "karmic" ] && dver="$raw$dist"
+    [ "$dist" = "quantal" ] && dver="$raw$dist"
+    [ "$dist" = "saucy" ] && dver="$raw$dist"
+    [ "$dist" = "trusty" ] && dver="$raw$dist"
 
     echo $dver
 }

--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -26,14 +26,10 @@ sudo mkdir -p "$basedir"
 # build.
 
 os="debian"
-[ "$DIST" = "saucy" ] && os="ubuntu"
-[ "$DIST" = "trusty" ] && os="ubuntu"
 [ "$DIST" = "precise" ] && os="ubuntu"
 [ "$DIST" = "quantal" ] && os="ubuntu"
-[ "$DIST" = "oneiric" ] && os="ubuntu"
-[ "$DIST" = "natty" ] && os="ubuntu"
-[ "$DIST" = "maverick" ] && os="ubuntu"
-[ "$DIST" = "lucid" ] && os="ubuntu"
+[ "$DIST" = "saucy" ] && os="ubuntu"
+[ "$DIST" = "trusty" ] && os="ubuntu"
 
 if [ $os = "debian" ]; then
     mirror="http://apt-mirror.sepia.ceph.com/ftp.us.debian.org/debian"

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -25,6 +25,7 @@
           name: Distro
           values:
             - wheezy-pbuild
+            - jessie
             - precise-pbuild
             - trusty-pbuild
             - centos6.5

--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -28,8 +28,8 @@ echo "  BRANCH=$BRANCH"
 
 # FIXME A very naive way to just list the RPM $DIST that we currently support.
 # We should be a bit more lenient to allow any rhel/centos/sles/suse
-rpm_dists="rhel centos6.5 centos7 rhel6.5 rhel7 centos sles11sp2 opensuse12.2"
-deb_dists="precise wheezy squeeze trusty"
+rpm_dists="rhel centos6.5 centos7 rhel6.5 rhel7 centos"
+deb_dists="precise wheezy squeeze trusty jessie"
 
 # A helper to match an item in a list of items, like python's `if item in list`
 listcontains() {
@@ -115,7 +115,7 @@ then
     REPO=debian-repo
     COMPONENT=main
     KEYID=${KEYID:-03C3951A}  # default is autobuild keyid
-    DEB_DIST="sid wheezy squeeze quantal precise oneiric natty raring trusty"
+    DEB_DIST="sid wheezy squeeze jessie quantal precise raring trusty"
     DEB_BUILD=$(lsb_release -s -c)
     #XXX only releases until we fix this
     RELEASE=1
@@ -186,6 +186,6 @@ EOF
     echo "Done"
 
 else
-	echo "Can't determine build host type"
+	echo "Can't determine build host type, I suck. Sorry."
         exit 4
 fi

--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -48,6 +48,7 @@
             - wheezy
             - precise
             - trusty
+            - jessie
             - centos6.5
             - centos7
             - rhel6.5

--- a/ceph-package/config/definitions/ceph-package.yml
+++ b/ceph-package/config/definitions/ceph-package.yml
@@ -23,7 +23,6 @@
           name: Arch
           values:
             - x86_64
-            - i386
       - axis:
           type: label-expression
           name: Distro
@@ -32,6 +31,7 @@
             - wheezy-pbuild
             - precise-pbuild
             - trusty-pbuild
+            - jessie
             - centos6.5
             - centos7
             - rhel6.5

--- a/radosgw-agent/build/build
+++ b/radosgw-agent/build/build
@@ -53,9 +53,10 @@ if [[ -f /etc/redhat-release || -f /usr/bin/zypper ]] ; then
             fi
         fi
 else
+        # XXX MAGICAL, Fix this
         DEB_VERSION=$(dpkg-parsechangelog | sed -rne 's,^Version: (.*),\1, p')
         BP_VERSION=${DEB_VERSION}${BPTAG}
-        DEBEMAIL="sandon@inktank.com" dch -D $DIST --force-distribution -b -v "$BP_VERSION" "$comment"
+        DEBEMAIL="adeza@redhat.com" dch -D $DIST --force-distribution -b -v "$BP_VERSION" "$comment"
         dpkg-source -b .
         dpkg-buildpackage -k$KEYID
         RC=$?

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -47,15 +47,13 @@
             - wheezy
             - precise
             - trusty
+            - jessie
             - centos6.5
             - centos7
             - rhel6.5
-            - opensuse12.2
-            - sles11sp2
             - rhel7
 
     builders:
-      - shell: "pwd"
       - shell:
           !include-raw ../../build/build
 

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -30,10 +30,6 @@
           browser-url: http://github.com/ceph/radosgw-agent.git
           timeout: 20
 
-    execution-strategy:
-      combination-filter: |
-        (Arch=="x86_64")  || (Arch=="armhf" && (Dist=="quantal"))
-
     axes:
       - axis:
           type: label-expression


### PR DESCRIPTION
Adds Jessie support on the build scripts for Ceph, radosgw-agent, and ceph-deploy

Removes older distros that we do not build for anymore