### PR TITLE
rm references to "quantal"

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -16,7 +16,6 @@ get_bptag() {
     [ "$dist" = "lenny" ] && dver="~bpo50+1"
     [ "$dist" = "trusty" ] && dver="$dist"
     [ "$dist" = "saucy" ] && dver="$dist"
-    [ "$dist" = "quantal" ] && dver="$dist"
     [ "$dist" = "precise" ] && dver="$dist"
     [ "$dist" = "oneiric" ] && dver="$dist"
     [ "$dist" = "natty" ] && dver="$dist"
@@ -113,7 +112,6 @@ gen_debian_version() {
     [ "$dist" = "squeeze" ] && dver="$raw~bpo60+1"
     [ "$dist" = "lenny" ] && dver="$raw~bpo50+1"
     [ "$dist" = "precise" ] && dver="$raw$dist"
-    [ "$dist" = "quantal" ] && dver="$raw$dist"
     [ "$dist" = "saucy" ] && dver="$raw$dist"
     [ "$dist" = "trusty" ] && dver="$raw$dist"
 

--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -27,7 +27,6 @@ sudo mkdir -p "$basedir"
 
 os="debian"
 [ "$DIST" = "precise" ] && os="ubuntu"
-[ "$DIST" = "quantal" ] && os="ubuntu"
 [ "$DIST" = "saucy" ] && os="ubuntu"
 [ "$DIST" = "trusty" ] && os="ubuntu"
 

--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -115,7 +115,7 @@ then
     REPO=debian-repo
     COMPONENT=main
     KEYID=${KEYID:-03C3951A}  # default is autobuild keyid
-    DEB_DIST="sid wheezy squeeze jessie quantal precise raring trusty"
+    DEB_DIST="sid wheezy squeeze jessie precise raring trusty"
     DEB_BUILD=$(lsb_release -s -c)
     #XXX only releases until we fix this
     RELEASE=1

--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -30,10 +30,6 @@
           skip-tag: true
           timeout: 20
 
-    execution-strategy:
-      combination-filter: |
-        (Arch=="x86_64")  || (Arch=="armhf" && (Dist=="quantal"))
-
     axes:
       - axis:
           type: label-expression

--- a/deb_dists
+++ b/deb_dists
@@ -3,7 +3,6 @@ wheezy
 squeeze
 jessie
 raring
-quantal
 precise
 saucy
 trusty

--- a/gen_debian_version.sh
+++ b/gen_debian_version.sh
@@ -11,7 +11,6 @@ dist=$2
 [ "$dist" = "trusty" ] && dver="$raw$dist"
 [ "$dist" = "saucy" ] && dver="$raw$dist"
 [ "$dist" = "raring" ] && dver="$raw$dist"
-[ "$dist" = "quantal" ] && dver="$raw$dist"
 [ "$dist" = "precise" ] && dver="$raw$dist"
 [ "$dist" = "oneiric" ] && dver="$raw$dist"
 [ "$dist" = "natty" ] && dver="$raw$dist"

--- a/update_pbuilder.sh
+++ b/update_pbuilder.sh
@@ -23,7 +23,6 @@ do
     [ "$dist" = "saucy" ] && os="ubuntu"
     [ "$dist" = "trusty" ] && os="ubuntu"
     [ "$dist" = "precise" ] && os="ubuntu"
-    [ "$dist" = "quantal" ] && os="ubuntu"
     [ "$dist" = "oneiric" ] && os="ubuntu"
     [ "$dist" = "natty" ] && os="ubuntu"
     [ "$dist" = "maverick" ] && os="ubuntu"


### PR DESCRIPTION
Ubuntu 12.10 (Quantal Quetzal) reached EOL May 16 2014. Remove support from the tree.
    
https://lists.ubuntu.com/archives/ubuntu-announce/2014-April/000183.html

This also removes the execution strategy filter, since it was only for quantal/arm, similar to what was done in bd3113c09370dad9eb08d5536e19ab3e94b141b9.