### PR TITLE
Add rhcs-installer job

### DIFF
--- a/rhcs-installer/build/rename-rhcs-installer
+++ b/rhcs-installer/build/rename-rhcs-installer
@@ -1,0 +1,21 @@
+#!/bin/bash -ex
+
+# Rename a debian package from "mariner-installer" to "rhcs-installer".
+
+oldname='mariner-installer'
+newname='rhcs-installer'
+
+cd $WORKSPACE/$oldname/debian
+
+for file in $(find . -type f); do
+    if [ $file == './copyright' ]; then
+        # The uses of "$oldname" in the copyright file are ok to leave alone.
+        continue
+    fi
+    sed -i -e "s/$oldname/$newname/g" $file
+done
+
+for file in $(find . -type f -name "*$oldname*"); do
+    newfile=$(echo $file | sed -e "s/$oldname/$newname/")
+    mv $file $newfile
+done

--- a/rhcs-installer/config/definitions/rhcs-installer.yml
+++ b/rhcs-installer/config/definitions/rhcs-installer.yml
@@ -1,0 +1,55 @@
+- job:
+    name: rhcs-installer
+    description: Build and package mariner-installer as rhcs-installer
+    project-type: matrix
+    axes:
+    - axis:
+        name: Arch
+        type: label-expression
+        values:
+        - x86_64
+    - axis:
+        name: Dist
+        type: label-expression
+        values:
+        - trusty
+    block-downstream: false
+    block-upstream: false
+
+    properties:
+    - github:
+        url: https://github.com/ceph/mariner-installer/
+
+    scm:
+    - git:
+        skip-tag: true
+        basedir: mariner-installer
+        url: https://github.com/ceph/mariner-installer
+        branches:
+         - $BRANCH
+
+    execution-strategy:
+      run-sequentially: false
+
+    builders:
+    - shell:
+        !include-raw ../../build/rename-rhcs-installer
+    - shell:
+        !include-raw ../../../mariner-installer/build/build
+    concurrent: false
+    parameters:
+    - string:
+        default: master
+        description: 'The git branch or tag to build'
+        name: BRANCH
+
+    publishers:
+    - archive:
+        allow-empty: false
+        artifacts: $BRANCH/*
+        default-excludes: true
+        fingerprint: false
+        only-if-success: false
+    - description-setter:
+        regexp: '^BRANCH: (\S+)'
+        set-for-matrix: false


### PR DESCRIPTION
Job to build rhcs-installer package from upstream mariner-installer
source/job.

At first I didn't think this would do everything we needed, but when going through it I think it might get it all.  Only way to find out I think is to build it and see what happens.

FWIW, I think in the `debian/control` file that the `Source:` line may not need to changed.  It is possible in debian packaging to handle renaming an upstream project with a different package name, but I don't know much about it.  Let's start here. :)