### PR TITLE
normalizing to `DIST`

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -11,23 +11,20 @@
       - github:
           url: https://github.com/ceph/ceph
 
-    execution-strategy:
-      combination-filter: Arch=="x86_64"
-
     axes:
       - axis:
           type: label-expression
-          name: Arch
+          name: ARCH
           values:
             - x86_64
       - axis:
           type: label-expression
-          name: Distro
+          name: DIST
           values:
-            - wheezy-pbuild
+            - wheezy
             - jessie
-            - precise-pbuild
-            - trusty-pbuild
+            - precise
+            - trusty
             - centos6.5
             - centos7
             - rhel6.5

--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -33,12 +33,12 @@
     axes:
       - axis:
           type: label-expression
-          name: Arch
+          name: ARCH
           values:
             - x86_64
       - axis:
           type: label-expression
-          name: Dist
+          name: DIST
           values:
             - squeeze
             - wheezy

--- a/ceph-package/config/definitions/ceph-package.yml
+++ b/ceph-package/config/definitions/ceph-package.yml
@@ -23,7 +23,6 @@
           type: label-expression
           name: DIST
           values:
-            - squeeze
             - wheezy
             - precise
             - trusty

--- a/ceph-package/config/definitions/ceph-package.yml
+++ b/ceph-package/config/definitions/ceph-package.yml
@@ -36,7 +36,7 @@
     builders:
 
       # "Clean up any prior stuff"
-      - shell: 'rm -rf Arch=* 2>/dev/null; true'
+      - shell: 'rm -rf ARCH=* 2>/dev/null; true'
 
       - copyartifact:
           project: ceph-build

--- a/ceph-package/config/definitions/ceph-package.yml
+++ b/ceph-package/config/definitions/ceph-package.yml
@@ -16,17 +16,17 @@
     axes:
       - axis:
           type: label-expression
-          name: Arch
+          name: ARCH
           values:
             - x86_64
       - axis:
           type: label-expression
-          name: Distro
+          name: DIST
           values:
-            - squeeze-pbuild
-            - wheezy-pbuild
-            - precise-pbuild
-            - trusty-pbuild
+            - squeeze
+            - wheezy
+            - precise
+            - trusty
             - jessie
             - centos6.5
             - centos7

--- a/ceph-package/config/definitions/ceph-package.yml
+++ b/ceph-package/config/definitions/ceph-package.yml
@@ -13,10 +13,6 @@
       artifactDaysToKeep: -1
       artifactNumToKeep: -1
 
-    execution-strategy:
-      combination-filter: |
-        (Arch=="x86_64") || (Arch=="i386" && (Distro=="wheezy-pbuild" || Distro=="precise-pbuild"))
-
     axes:
       - axis:
           type: label-expression

--- a/ceph-puppet-modules/config/definitions/ceph-puppet-modules.yml
+++ b/ceph-puppet-modules/config/definitions/ceph-puppet-modules.yml
@@ -4,12 +4,12 @@
     project-type: matrix
     axes:
     - axis:
-        name: Arch
+        name: ARCH
         type: label-expression
         values:
         - x86_64
     - axis:
-        name: Dist
+        name: DIST
         type: label-expression
         values:
         - trusty

--- a/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
+++ b/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
@@ -8,9 +8,6 @@
     block-downstream: false
     block-upstream: false
 
-    execution-strategy:
-      combination-filter: Arch=="x86_64"
-
     parameters:
       - string:
           name: RELEASE
@@ -19,19 +16,17 @@
     axes:
       - axis:
           type: label-expression
-          name: Arch
+          name: ARCH
           values:
             - x86_64
-            - i386
-            - arm7l
+
       - axis:
           type: label-expression
-          name: label_exp
+          name: DIST
           values:
             - centos6.5
             - centos7
             - rhel6.5
-            - sles11sp2
             - rhel7
 
     builders:

--- a/ice-setup/build/build
+++ b/ice-setup/build/build
@@ -5,7 +5,7 @@ cd $WORKSPACE/ice-setup
 
 DEBIAN=0
 
-if [ $Dist = 'trusty' -o $Dist = 'precise' -o $Dist = 'wheezy' ] ; then
+if [ $DIST = 'trusty' -o $DIST = 'precise' -o $DIST = 'wheezy' ] ; then
     DEBIAN=1
 fi
 

--- a/ice-setup/config/definitions/ice-setup.yml
+++ b/ice-setup/config/definitions/ice-setup.yml
@@ -1,12 +1,12 @@
 - job:
     axes:
     - axis:
-        name: Arch
+        name: ARCH
         type: label-expression
         values:
         - x86_64
     - axis:
-        name: Dist
+        name: DIST
         type: label-expression
         values:
         - trusty

--- a/mariner-installer-pull-requests/config/definitions/mariner-installer-pull-requests.yml
+++ b/mariner-installer-pull-requests/config/definitions/mariner-installer-pull-requests.yml
@@ -4,7 +4,7 @@
     project-type: matrix
     axes:
       - axis:
-          name: Arch
+          name: ARCH
           type: label-expression
           values:
             - x86_64

--- a/mariner-installer-pull-requests/config/definitions/mariner-installer-pull-requests.yml
+++ b/mariner-installer-pull-requests/config/definitions/mariner-installer-pull-requests.yml
@@ -9,7 +9,7 @@
           values:
             - x86_64
       - axis:
-          name: Dist
+          name: DIST
           type: label-expression
           values:
             - trusty

--- a/mariner-installer/config/definitions/mariner-installer.yml
+++ b/mariner-installer/config/definitions/mariner-installer.yml
@@ -4,12 +4,12 @@
     project-type: matrix
     axes:
     - axis:
-        name: Arch
+        name: ARCH
         type: label-expression
         values:
         - x86_64
     - axis:
-        name: Dist
+        name: DIST
         type: label-expression
         values:
         - trusty

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -33,12 +33,12 @@
     axes:
       - axis:
           type: label-expression
-          name: Arch
+          name: ARCH
           values:
             - x86_64
       - axis:
           type: label-expression
-          name: Dist
+          name: DIST
           values:
             - wheezy
             - precise

--- a/rhcs-installer/config/definitions/rhcs-installer.yml
+++ b/rhcs-installer/config/definitions/rhcs-installer.yml
@@ -4,12 +4,12 @@
     project-type: matrix
     axes:
     - axis:
-        name: Arch
+        name: ARCH
         type: label-expression
         values:
         - x86_64
     - axis:
-        name: Dist
+        name: DIST
         type: label-expression
         values:
         - trusty

--- a/takora-pull-requests/config/definitions/takora-pull-requests.yml
+++ b/takora-pull-requests/config/definitions/takora-pull-requests.yml
@@ -4,12 +4,12 @@
     project-type: matrix
     axes:
     - axis:
-        name: Arch
+        name: ARCH
         type: label-expression
         values:
         - x86_64
     - axis:
-        name: Dist
+        name: DIST
         type: label-expression
         values:
         - trusty

--- a/takora/config/definitions/takora.yml
+++ b/takora/config/definitions/takora.yml
@@ -4,12 +4,12 @@
     project-type: matrix
     axes:
     - axis:
-        name: Arch
+        name: ARCH
         type: label-expression
         values:
         - x86_64
     - axis:
-        name: Dist
+        name: DIST
         type: label-expression
         values:
         - trusty


### PR DESCRIPTION
This allows us to finally get rid of the dependency of setting `DIST` and `BPTAG` on actual slaves, giving us flexibility to just consume whatever is set by Jenkins.

Since the configuration matrix will use `DIST` and not `Dist` it means that it will be available as an environment variable throughout.

It does some other minor cleanups as well.