### PR TITLE
Jessie mirror

### DIFF
--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -41,7 +41,7 @@ fi
 # ensure that the tgz is valid, otherwise remove it so that it can be recreated
 # again
 pbuild_tar="$basedir/$DIST.tgz"
-is_not_tar=`python -c "exec 'try: import tarfile;print not int(tarfile.is_tarfile(\"$pbuild_tar\"))\nexcept IOError: print 1'"`
+is_not_tar=`python -c "exec 'try: import tarfile;print int(not int(tarfile.is_tarfile(\"$pbuild_tar\")))\nexcept IOError: print 1'"`
 
 if $is_not_tar; then
     rm -f "$pbuild_tar/$DIST.tgz"

--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -42,9 +42,14 @@ fi
 # again
 pbuild_tar="$basedir/$DIST.tgz"
 is_not_tar=`python -c "exec 'try: import tarfile;print int(not int(tarfile.is_tarfile(\"$pbuild_tar\")))\nexcept IOError: print 1'"`
+file_size_kb=`du -k "$pbuild_tar" | cut -f1`
 
 if $is_not_tar; then
     rm -f "$pbuild_tar/$DIST.tgz"
+fi
+
+if [ $file_size_kb -lt 1 ]; then
+    sudo rm -f "$pbuild_tar"
 fi
 
 sudo pbuilder --clean

--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -45,7 +45,7 @@ is_not_tar=`python -c "exec 'try: import tarfile;print int(not int(tarfile.is_ta
 file_size_kb=`du -k "$pbuild_tar" | cut -f1`
 
 if $is_not_tar; then
-    rm -f "$pbuild_tar/$DIST.tgz"
+    sudo rm -f "$pbuild_tar"
 fi
 
 if [ $file_size_kb -lt 1 ]; then

--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -31,7 +31,11 @@ os="debian"
 [ "$DIST" = "trusty" ] && os="ubuntu"
 
 if [ $os = "debian" ]; then
-    mirror="http://apt-mirror.sepia.ceph.com/ftp.us.debian.org/debian"
+    # We used to consume from an internal mirror
+    # ("http://apt-mirror.sepia.ceph.com/ftp.us.debian.org/debian") but given
+    # that it has caused us issues before (e.g. packages out of date) and that
+    # it currently does not have Jessie we are going to use a public mirror.
+    mirror="http://www.gtlib.gatech.edu/pub/debian"
     othermirror=""
 else
     mirror=""


### PR DESCRIPTION
Fixes invalid use of paths for removing tgz files.

Corrects the call to Python to verify a file is a valid tgz file. Adds `sudo` to the `rm` call (it totally didn't work before) and uses the GTECH Debian mirror because the internal mirror doesn't know about Jessie and we should not wait for a full sync of the Jessie repo to run this build.

The changes are currently in place and building http://jenkins.ceph.com/job/ceph-build/ARCH=x86_64,DIST=jessie/410/console