### PR TITLE
[DNM] use new GPG key for releases

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -29,7 +29,7 @@ get_bptag() {
 BPTAG=`get_bptag $DIST`
 
 export GNUPGHOME=/home/jenkins-build/build/gnupg.ceph-release/
-export KEYID=17ED316D
+export KEYID=9DCEEEAD
 HOST=$(hostname --short)
 echo "Building on $(hostname) Date: $(date)"
 echo "  DIST=${DIST}"

--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -6,7 +6,7 @@ if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then
 fi
 
 export GNUPGHOME=/home/jenkins-build/build/gnupg.ceph-release/
-export KEYID=17ED316D
+export KEYID=9DCEEEAD
 HOST=$(hostname --short)
 echo "Building on $(hostname) Date: $(date)"
 echo "  DIST=${DIST}"

--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -10,7 +10,7 @@ set -e
 if $RELEASE ; then
         # This is a formal release. Sign it with the release key.
         export GNUPGHOME=/home/jenkins-build/build/gnupg.ceph-release/
-        export KEYID=17ED316D
+        export KEYID=9DCEEEAD
 else
         # This is an automatic build. Sign it with the autobuild key.
         export GNUPGHOME=/home/jenkins-build/build/gnupg.autobuild/

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -2,7 +2,7 @@
 
 #export GNUPGHOME=/home/jenkins-build/build/gnupg.autobuild/
 export GNUPGHOME=/home/jenkins-build/build/gnupg.ceph-release/
-export KEYID=17ED316D
+export KEYID=9DCEEEAD
 HOST=$(hostname --short)
 echo "Building on ${HOST}"
 echo "  DIST=${DIST}"

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -2,7 +2,7 @@
 
 #export GNUPGHOME=/home/jenkins-build/build/gnupg.autobuild/
 export GNUPGHOME=/home/jenkins-build/build/gnupg.ceph-release/
-export KEYID=17ED316D
+export KEYID=9DCEEEAD
 HOST=$(hostname --short)
 echo "Building on ${HOST}"
 echo "  DIST=${DIST}"

--- a/ceph/config/definitions/ceph.yml
+++ b/ceph/config/definitions/ceph.yml
@@ -28,7 +28,7 @@
           description: "
 If this is unchecked, then the builds will be signed with the autosign key (03C3951A). This is the default.&lt;br/&gt;
 
-If this is checked, then the builds will be signed by the release key (17ED316D).&lt;br/&gt;
+If this is checked, then the builds will be signed by the release key (9DCEEEAD).&lt;br/&gt;
 
 Only check this box if we will be shipping the packages as formal releases."
 

--- a/do_release.sh
+++ b/do_release.sh
@@ -3,7 +3,7 @@
 set -e
 
 xterm=${xterm:-0}	# set to 1 to use xterm for remote sessions
-gpgkey='17ED316D'
+gpgkey='9DCEEEAD'
 
 bindir=`dirname $0`
 

--- a/kmod/sign-and-sync-from-jenkins
+++ b/kmod/sign-and-sync-from-jenkins
@@ -20,7 +20,7 @@ BUILD=lastSuccessful
 ROOT=/home2/jenkins/jobs/${JOB}/configurations/axis-label
 
 #KEYID=${KEYID:-03C3951A}  # default is autobuild keyid
-KEYID=${KEYID:-17ED316D}  # default is release keyid
+KEYID=${KEYID:-9DCEEEAD}  # default is release keyid
 
 if gpg --list-keys 2>/dev/null | grep -q ${KEYID} ; then
     echo "Signing packages and repo with ${KEYID}"

--- a/push_to_rpm_repo.sh
+++ b/push_to_rpm_repo.sh
@@ -6,7 +6,7 @@ releasedir=$1
 repo=$2
 cephvers=$3
 
-keyid=17ED316D
+keyid=9DCEEEAD
 
 usage() {
     echo "usage: $0 releasedir repodir version component"

--- a/radosgw-agent/build/build
+++ b/radosgw-agent/build/build
@@ -6,7 +6,7 @@ set -ex
 if $RELEASE ; then
         # This is a formal release. Sign it with the release key.
         export GNUPGHOME=/home/jenkins-build/build/gnupg.ceph-release/
-        export KEYID=17ED316D
+        export KEYID=9DCEEEAD
 else
         # This is an automatic build. Sign it with the autobuild key.
         export GNUPGHOME=/home/jenkins-build/build/gnupg.autobuild/

--- a/sign_and_index_rpm_repo.sh
+++ b/sign_and_index_rpm_repo.sh
@@ -6,7 +6,7 @@ releasedir=$1
 repo=$2
 cephvers=$3
 
-keyid=17ED316D
+keyid=9DCEEEAD
 
 usage() {
     echo "usage: $0 releasedir repodir version"

--- a/tag_release.sh
+++ b/tag_release.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-git tag -s $1 -u 17ED316D -m $1
+git tag -s $1 -u 9DCEEEAD -m $1


### PR DESCRIPTION
See
http://ceph.com/releases/important-security-notice-regarding-signing-key-and-binary-downloads-of-ceph/

17ED316D is the old key

9DCEEEAD is the new key

(This key change probably needs more than simply swapping the key-id, but this PR is a start)