### PR TITLE
ceph-build: remove jessie

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -22,7 +22,6 @@
           name: DIST
           values:
             - wheezy
-            - jessie
             - precise
             - trusty
             - centos6.5


### PR DESCRIPTION
The Jessie builder is offline at the moment. Don't hold up all the builds because of this.

(this reverts commit ddb77546e58501edbf01a20c4971445a46ae2351)