### PR TITLE
remove -e flag because that 'execs' an ssh command and there is none

### DIFF
--- a/teuthology-docs/build/build
+++ b/teuthology-docs/build/build
@@ -21,4 +21,4 @@ fi
 # create the docs build with tox
 tox -rv -e docs
 # publish docs to docs.ceph.com/docs/teuthology
-rsync -auv --delete -e .tox/docs/tmp/html/* ubuntu@docs.front.sepia.ceph.com:/var/teuthology/docs/
+rsync -auv --delete .tox/docs/tmp/html/* ubuntu@docs.front.sepia.ceph.com:/var/teuthology/docs/


### PR DESCRIPTION
Manually changed this in Jenkins and the job was a success.

http://jenkins.ceph.com/job/teuthology-docs/608/

Signed-off-by: Alfredo Deza <adeza@redhat.com>