### PR TITLE
ceph-build-next: push binaries to chacra

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -32,6 +32,11 @@
     - name: jenkins api key should be present
       copy: src=files/jenkins_jobs.ini dest=/etc/jenkins_jobs/jenkins_jobs.ini
 
+    - name: Upload the .chacractl file
+      copy:
+        src: files/chacractl
+        dest: "/home/{{ jenkins_user }}/.chacractl"
+
     - name: ensure the build dir exists
       sudo: yes
       lineinfile:

--- a/ceph-build-next/build/build_deb
+++ b/ceph-build-next/build/build_deb
@@ -130,6 +130,8 @@ sudo pbuilder --clean
 bpvers=`gen_debian_version $dvers $DIST`
 echo deb vers $bpvers
 
+distro=`python -c "exec 'import platform; print platform.linux_distribution()[0].lower()'"`
+
 echo building debs for $DIST
 if [ `dpkg-architecture -qDEB_BUILD_ARCH` = "i386" ] ; then
     #  Architecture dependent, independent and source
@@ -159,12 +161,8 @@ echo "Start Time = $start_time"
 echo "  End Time = $(date)"
 
 
-#Collect Artifacts
-mkdir -p dist/debian
-cp -a release/$vers/*.changes dist/debian/.
-cp -a release/$vers/*.deb     dist/debian/.
-cp -a release/$vers/*.dsc     dist/debian/.
-cp -a release/$vers/*.diff.gz dist/debian/.
-cp -a release/$vers/*.tar.gz  dist/debian/.
+# push binaries to chacra
+find release/$vers/ | grep 'changes\|deb\|dsc\|gz' | chacractl binary create ceph/${vers}/${distro}/{$dist}/${ARCH}
+
 
 echo "End Date: $(date)"

--- a/ceph-build-next/build/build_rpm
+++ b/ceph-build-next/build/build_rpm
@@ -46,14 +46,17 @@ get_rpm_dist() {
     RedHatEnterpriseServer)
         RELEASE=`$LSB_RELEASE --short --release | cut -d. -f1`
         DIST=rhel$RELEASE
+        DISTRO=rhel
         ;;
     CentOS)
         RELEASE=`$LSB_RELEASE --short --release | cut -d. -f1`
         DIST=el$RELEASE
+        DISTRO=centos
         ;;
     Fedora)
         RELEASE=`$LSB_RELEASE --short --release`
         DIST=fc$RELEASE
+        DISTRO=fedora
         ;;
     SUSE\ LINUX)
         DESC=`$LSB_RELEASE --short --description`
@@ -61,14 +64,17 @@ get_rpm_dist() {
         case $DESC in
         *openSUSE*)
                 DIST=opensuse$RELEASE
+                DISTRO=opensuse
             ;;
         *Enterprise*)
                 DIST=sles$RELEASE
+                DISTRO=sles
                 ;;
             esac
         ;;
     *)
         DIST=unknown
+        DISTRO=unknown
         ;;
     esac
 
@@ -99,9 +105,8 @@ echo done
 # Make sure we execute at the top level directory
 cd "$WORKSPACE"
 
-#Collect Artifacts
-mkdir -p dist/rpm/${DIST}
-mv release/${vers}/rpm/*/SRPMS ./dist/rpm/${DIST}/.
-mv release/${vers}/rpm/*/RPMS/* ./dist/rpm/${DIST}/.
+# push binaries to chacra
+find release/${vers}/rpm/*/SRPMS | grep rpm | chacractl binary create ceph/${vers}/${DISTRO}/${RELEASE}/source
+find release/${vers}/rpm/*/RPMS/* | grep rpm | chacractl binary create ceph/${vers}/${DISTRO}/{$RELEASE}/${ARCH}
 
 echo "End Date: $(date)"

--- a/ceph-build-next/config/definitions/ceph-build-next.yml
+++ b/ceph-build-next/config/definitions/ceph-build-next.yml
@@ -30,14 +30,6 @@
             #- rhel6.5
             - rhel7
 
-    scm:
-      - git:
-          url: https://github.com/ceph/ceph-build.git
-          branches:
-            - origin/master
-          timeout: 20
-          wipe-workspace: true
-
     builders:
       - shell: |
           echo "Cleaning up workarea"


### PR DESCRIPTION
After deb and rpm binaries are built, push them to chacra.

Also includes ansible to upload the .chacractl file to the jenkins slaves. Because of the api credentials that actual file is not committed here.