### PR TITLE
ansible: nginx configs for HTTPS

### DIFF
--- a/ansible/roles/ansible-jenkins/templates/jenkins.conf
+++ b/ansible/roles/ansible-jenkins/templates/jenkins.conf
@@ -1,10 +1,9 @@
 # {{ ansible_managed }}
 
 server {
-    listen       80;
+    listen       80 default_server;
 
-    # FIXME
-    server_name  localhost;
+    server_name  localhost {{ ansible_fqdn }};
 
     access_log  /var/log/nginx/jenkins_access.log;
     error_log  /var/log/nginx/jenkins_error.log;

--- a/ansible/roles/ansible-jenkins/templates/jenkins.conf
+++ b/ansible/roles/ansible-jenkins/templates/jenkins.conf
@@ -2,8 +2,13 @@
 
 server {
     listen       80 default_server;
+    listen       443 default_server ssl;
 
     server_name  localhost {{ ansible_fqdn }};
+
+    ssl_certificate     /etc/ssl/certs/{{ ansible_fqdn }}-bundled.crt;
+    ssl_certificate_key /etc/ssl/private/{{ ansible_fqdn }}.key;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
     access_log  /var/log/nginx/jenkins_access.log;
     error_log  /var/log/nginx/jenkins_error.log;
@@ -17,5 +22,9 @@ server {
       proxy_pass          http://127.0.0.1:8080;
       proxy_read_timeout  90;
 
+      # Redirect all plaintext HTTP to HTTPS
+      if ($scheme != "https") {
+         rewrite ^ https://$host$uri permanent;
+      }
     }
 }


### PR DESCRIPTION
Add HTTPS to the jenkins web server to protect authentication.

The key and certificate files are managed outside of Ansible.