### PR TITLE
ansible: merge back in Ubuntu support

### DIFF
--- a/ansible/roles/ansible-jenkins/tasks/config.yml
+++ b/ansible/roles/ansible-jenkins/tasks/config.yml
@@ -2,7 +2,7 @@
 
 - name: Configure Jenkins Port
   lineinfile:
-    dest: /etc/sysconfig/jenkins
+    dest: '{{ jenkins.apt.config_file }}'
     regexp: ^HTTP_PORT=
     line: HTTP_PORT={{port}}
     backrefs: yes
@@ -30,7 +30,7 @@
 - name: Configure Jenkins Prefix
   when: prefix is defined
   lineinfile:
-    dest: /etc/sysconfig/jenkins
+    dest: '{{ jenkins.apt.config_file }}'
     regexp: ^PREFIX=
     line: PREFIX={{prefix}}
     backrefs: yes
@@ -38,7 +38,7 @@
 - name: Set the amount of RAM
   when: xmx is defined
   lineinfile:
-    dest: /etc/sysconfig/jenkins
+    dest: '{{ jenkins.apt.config_file }}'
     regexp: ^JENKINS_JAVA_OPTIONS
     line: 'JENKINS_JAVA_OPTIONS="-Xmx{{xmx}}m -Djava.awt.headless=true"'
     backrefs: yes
@@ -54,6 +54,7 @@
 
 - name: Tell SELinux that we should allow Nginx to talk to Jenkins
   seboolean: name=httpd_can_network_connect state=yes persistent=yes
+  when: ansible_pkg_mgr  == "yum"
 
 - name: copy JJB config file to {{ jenkins_jobs }}
   synchronize:

--- a/ansible/roles/ansible-jenkins/tasks/dependencies.yml
+++ b/ansible/roles/ansible-jenkins/tasks/dependencies.yml
@@ -1,0 +1,16 @@
+---
+
+- name: epel-release install
+  yum: name=epel-release
+       state=present
+  when: ansible_pkg_mgr  == "yum"
+
+- name: Install RPM dependencies
+  yum: name={{ item }} state=installed
+  with_items: jenkins.{{ ansible_pkg_mgr }}.dependencies
+  when: ansible_pkg_mgr  == "yum"
+
+- name: Install DEB dependencies
+  apt: name={{ item }} state=installed
+  with_items: jenkins.{{ ansible_pkg_mgr }}.dependencies
+  when: ansible_pkg_mgr  == "apt"

--- a/ansible/roles/ansible-jenkins/tasks/dependencies_yum.yml
+++ b/ansible/roles/ansible-jenkins/tasks/dependencies_yum.yml
@@ -1,8 +1,0 @@
----
-
-- name: epel-release install
-  yum: name=epel-release
-       state=present
-- name: Install dependencies
-  yum: name={{ item }} state=installed
-  with_items: jenkins.yum.dependencies

--- a/ansible/roles/ansible-jenkins/tasks/jenkins.yml
+++ b/ansible/roles/ansible-jenkins/tasks/jenkins.yml
@@ -1,15 +1,19 @@
 ---
 - include: repo.yml
-  when: ansible_pkg_mgr  == "yum"
 
-- include: dependencies_yum.yml
-  when: ansible_pkg_mgr  == "yum"
+- include: dependencies.yml
 
 - include: nginx.yml
 
-- name: Install Jenkins
+- name: Install Jenkins with Yum
   yum: name=jenkins state=present
   register: jenkins_install
+  when: ansible_pkg_mgr  == "yum"
+
+- name: Install Jenkins with Apt
+  apt: name=jenkins state=present
+  register: jenkins_install
+  when: ansible_pkg_mgr  == "apt"
 
 - include: config.yml
 

--- a/ansible/roles/ansible-jenkins/tasks/repo.yml
+++ b/ansible/roles/ansible-jenkins/tasks/repo.yml
@@ -1,12 +1,18 @@
 ---
+
+# Yum
+
 - name: Install python-devel
   yum: name=python-devel state=present
+  when: ansible_pkg_mgr  == "yum"
 
 - name: Install python-pycurl
   yum: name=python-pycurl state=present
+  when: ansible_pkg_mgr  == "yum"
 
 - name: Add Jenkins GPG Key
   rpm_key: state=present key=https://jenkins-ci.org/redhat/jenkins-ci.org.key
+  when: ansible_pkg_mgr  == "yum"
 
 - name: Create the repo file for Jenkins
   copy: src=jenkins.repo
@@ -14,3 +20,19 @@
         owner=root
         group=root
         mode=0644
+  when: ansible_pkg_mgr  == "yum"
+
+# Apt
+
+- name: Add Jenkins GPG Key
+  apt_key:
+    url: "https://jenkins-ci.org/debian/jenkins-ci.org.key"
+    state: present
+  when: ansible_pkg_mgr  == "apt"
+
+- name: Add the jenkins repo
+  apt_repository:
+    repo: 'deb http://pkg.jenkins-ci.org/debian binary/'
+    state: present
+    update_cache: true
+  when: ansible_pkg_mgr  == "apt"

--- a/ansible/roles/ansible-jenkins/vars/main.yml
+++ b/ansible/roles/ansible-jenkins/vars/main.yml
@@ -11,5 +11,12 @@ jenkins:
       - 'git'
       - 'curl'
       - 'nginx'
+    config_file: '/etc/sysconfig/jenkins'
+  apt:
+    dependencies: # Jenkins dependencies
+      - 'git'
+      - 'curl'
+      - 'nginx'
+    config_file: '/etc/default/jenkins'
   cli_dest: '{{ jenkins_dest }}/jenkins-cli.jar' # Jenkins CLI destination
   updates_dest: '{{ jenkins_dest }}/updates_jenkins.json' # Jenkins updates file


### PR DESCRIPTION
We originally copied this role from https://github.com/ICTO/ansible-jenkins, and then modified it to support CentOS.

As it turns out, our master runs on Ubuntu (Trusty), so we still need the Ubuntu bits. Add them back in here.