### PR TITLE
ansible: use Ubuntu UID for nginx.conf

### DIFF
--- a/ansible/roles/ansible-jenkins/templates/nginx.conf
+++ b/ansible/roles/ansible-jenkins/templates/nginx.conf
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-user nginx;
+user www-data;
 worker_processes {{ nginx_processor_count }};
 worker_rlimit_nofile 8192;
 


### PR DESCRIPTION
On CentOS, the nginx package from EPEL defaults to using the "nginx" UID.

On Ubuntu, the nginx package defaults to using the "www-data" UID.

Ideally we'd conditionalize this with Ansible variables, but I'll just hack it in for now.