### PR TITLE
ansible: don't enable ldap plugin

### DIFF
--- a/ansible/master.yml
+++ b/ansible/master.yml
@@ -10,7 +10,6 @@
     - nginx_connections: 2048
     - ansible_ssh_port: 2222
     - plugins:
-      - 'ldap'
       - 'github'
       - 'translation'
       - 'preSCMbuildstep'


### PR DESCRIPTION
not needed on jenkins.ceph.com