### PR TITLE
ansible: add mask-passwords plugin

### DIFF
--- a/ansible/master.yml
+++ b/ansible/master.yml
@@ -29,6 +29,7 @@
       - 'credentials'
       - 'copyartifact'
       - 'github-oauth'
+      - 'mask-passwords'
 
     - port: 8080
     - prefix: '/build'


### PR DESCRIPTION
https://wiki.jenkins-ci.org/display/JENKINS/Mask+Passwords+Plugin

Currently the jenkins-job-builder job relies on a static /etc/jenkins_jobs.ini config file that we put into place on a slave by hand. We do that to avoid exposing the account password that JJB uses.

The mask-passwords Jenkins plugin will allow us to dynamically write passwords in to files on the fly. This means that we can construct JJB's config file on the fly, or chacractl's config file, etc. It allows us to avoid storing cryptographic secrets (passwords) on the slaves, since the secret material will only be stored on the master.