### PR TITLE
remove unneeded tasks from slave.yml and slave.yml.j2

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -16,27 +16,6 @@
     - name: set the authorized keys
       authorized_key: user=jenkins-build key="{{ lookup('file', 'files/ssh/keys/jenkins_build.pub') }}"
 
-    # FIXME: this doesn't work right now as we aren't pushing private keys
-    # around in public repos
-    - name: ensure private key is present
-      copy: src=files/ssh/keys/jenkins_build dest=/home/{{ jenkins_user }}/.ssh/id_rsa mode=0600
-
-    - name: ensure public key is present
-      copy: src=files/ssh/keys/jenkins_build.pub dest=/home/{{ jenkins_user }}/.ssh/id_rsa.pub mode=0600
-
-    - name: /etc/jenkins_jobs should exist as a dir
-      file:
-        path: /etc/jenkins_jobs
-        state: directory
-
-    - name: jenkins api key should be present
-      copy: src=files/jenkins_jobs.ini dest=/etc/jenkins_jobs/jenkins_jobs.ini
-
-    - name: Upload the .chacractl file
-      copy:
-        src: files/chacractl
-        dest: "/home/{{ jenkins_user }}/.chacractl"
-
     - name: ensure the build dir exists
       sudo: yes
       lineinfile:

--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -22,22 +22,6 @@
     - name: set the authorized keys
       authorized_key: user=jenkins-build key="{{ lookup('file', 'playbook/files/ssh/keys/jenkins_build.pub') }}"
 
-    # FIXME: this doesn't work right now as we aren't pushing private keys
-    # around in public repos
-    - name: ensure private key is present
-      copy: src=playbook/files/ssh/keys/jenkins_build dest=/home/{{ jenkins_user }}/.ssh/id_rsa mode=0600
-
-    - name: ensure public key is present
-      copy: src=playbook/files/ssh/keys/jenkins_build.pub dest=/home/{{ jenkins_user }}/.ssh/id_rsa.pub mode=0600
-
-    - name: /etc/jenkins_jobs should exist as a dir
-      file:
-        path: /etc/jenkins_jobs
-        state: directory
-
-    - name: jenkins api key should be present
-      copy: src=playbook/files/jenkins_jobs.ini dest=/etc/jenkins_jobs/jenkins_jobs.ini
-
     - name: ensure jenkins-build can sudo without a prompt
       sudo: yes
       lineinfile:


### PR DESCRIPTION
We're not going to worry about the private keys anymore and the
jenkins_job.ini and .chacractl files are going to be created using the
mask-passwords plugin for jenkins.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>