### PR TITLE
do not install dpkg and dpkg-dev on yum based jenkins slaves

### DIFF
--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -63,8 +63,6 @@
         - pkgconfig
         - redhat-rpm-config
         - rpm-build
-        - dpkg
-        - dpkg-dev
       when: ansible_pkg_mgr  == "yum"
 
     # Run the equivalent of "apt-get update" as a separate step


### PR DESCRIPTION
These packages were failing to install on CentOS 7, we do not think they
are needed anyway.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>