### PR TITLE
ansible: add description-setter plugin

### DIFF
--- a/ansible/master.yml
+++ b/ansible/master.yml
@@ -30,6 +30,7 @@
       - 'copyartifact'
       - 'github-oauth'
       - 'mask-passwords'
+      - 'description-setter'
 
     - port: 8080
     - prefix: '/build'


### PR DESCRIPTION
Some jobs use this plugin. Add it to our master's Ansible configuration.