### PR TITLE
add the ability to do ceph test builds

### DIFF
--- a/ceph-build-next/build/build_deb
+++ b/ceph-build-next/build/build_deb
@@ -160,7 +160,7 @@ echo lintian --allow-root $releasedir/$cephver/*$bpvers*.deb
 echo "Start Time = $start_time"
 echo "  End Time = $(date)"
 
-[ "$TEST_BUILD" = true ] && chacra_ref="$vers" || chacra_ref="test"
+[ "$TEST" = true ] && chacra_ref="$vers" || chacra_ref="test"
 
 # push binaries to chacra
 find release/$vers/ | grep 'changes\|deb\|dsc\|gz' | chacractl binary create ceph/${chacra_ref}/${distro}/{$dist}/${ARCH}

--- a/ceph-build-next/build/build_deb
+++ b/ceph-build-next/build/build_deb
@@ -160,9 +160,10 @@ echo lintian --allow-root $releasedir/$cephver/*$bpvers*.deb
 echo "Start Time = $start_time"
 echo "  End Time = $(date)"
 
+[ "$TEST_BUILD" = true ] && chacra_ref="$vers" || chacra_ref="test"
 
 # push binaries to chacra
-find release/$vers/ | grep 'changes\|deb\|dsc\|gz' | chacractl binary create ceph/${vers}/${distro}/{$dist}/${ARCH}
+find release/$vers/ | grep 'changes\|deb\|dsc\|gz' | chacractl binary create ceph/${chacra_ref}/${distro}/{$dist}/${ARCH}
 
 
 echo "End Date: $(date)"

--- a/ceph-build-next/build/build_rpm
+++ b/ceph-build-next/build/build_rpm
@@ -105,7 +105,7 @@ echo done
 # Make sure we execute at the top level directory
 cd "$WORKSPACE"
 
-[ "$TEST_BUILD" = true ] && chacra_ref="$vers" || chacra_ref="test"
+[ "$TEST" = true ] && chacra_ref="$vers" || chacra_ref="test"
 
 # push binaries to chacra
 find release/${vers}/rpm/*/SRPMS | grep rpm | chacractl binary create ceph/${chacra_ref}/${DISTRO}/${RELEASE}/source

--- a/ceph-build-next/build/build_rpm
+++ b/ceph-build-next/build/build_rpm
@@ -105,8 +105,10 @@ echo done
 # Make sure we execute at the top level directory
 cd "$WORKSPACE"
 
+[ "$TEST_BUILD" = true ] && chacra_ref="$vers" || chacra_ref="test"
+
 # push binaries to chacra
-find release/${vers}/rpm/*/SRPMS | grep rpm | chacractl binary create ceph/${vers}/${DISTRO}/${RELEASE}/source
-find release/${vers}/rpm/*/RPMS/* | grep rpm | chacractl binary create ceph/${vers}/${DISTRO}/{$RELEASE}/${ARCH}
+find release/${vers}/rpm/*/SRPMS | grep rpm | chacractl binary create ceph/${chacra_ref}/${DISTRO}/${RELEASE}/source
+find release/${vers}/rpm/*/RPMS/* | grep rpm | chacractl binary create ceph/${chacra_ref}/${DISTRO}/{$RELEASE}/${ARCH}
 
 echo "End Date: $(date)"

--- a/ceph-next/config/definitions/ceph-next.yml
+++ b/ceph-next/config/definitions/ceph-next.yml
@@ -33,7 +33,7 @@ If this is checked, then the builds will be signed by the release key (460F3994)
 Only check this box if we will be shipping the packages as formal releases."
 
       - bool:
-          name: TEST_BUILD
+          name: TEST
           description: "
 If this is unchecked, then the builds will be pushed to chacra with the correct ref. This is the default.&lt;br/&gt;
 

--- a/ceph-next/config/definitions/ceph-next.yml
+++ b/ceph-next/config/definitions/ceph-next.yml
@@ -32,6 +32,13 @@ If this is checked, then the builds will be signed by the release key (460F3994)
 
 Only check this box if we will be shipping the packages as formal releases."
 
+      - bool:
+          name: TEST_BUILD
+          description: "
+If this is unchecked, then the builds will be pushed to chacra with the correct ref. This is the default.&lt;br/&gt;
+
+If this is checked, then the builds will be pushed to chacra under the 'test' ref."
+
     builders:
       - multijob:
           name: 'ceph setup phase'


### PR DESCRIPTION
If TEST_BUILD is checked, it'll push binaries to chacra.ceph.com under the ``test`` ref. This way we can make sure to separate testing binaries from release ones.