### PR TITLE
use publish-over-ssh plugin for docs jobs

### DIFF
--- a/ceph-deploy-docs/build/build
+++ b/ceph-deploy-docs/build/build
@@ -20,5 +20,3 @@ fi
 
 # create the docs build with tox
 tox -rv -e docs
-# publish docs to ceph.com/ceph-deploy/docs
-rsync -auv --delete -e "ssh -i /home/jenkins-build/.ssh/cephdocs_id_rsa -o StrictHostKeyChecking=no" .tox/docs/tmp/html/* cephdocs@ceph.newdream.net:/home/ceph_site/ceph.com/ceph-deploy/docs/

--- a/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
+++ b/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
@@ -35,3 +35,11 @@
     builders:
       - shell:
           !include-raw ../../build/build
+
+    # publish docs to docs.ceph.com/ceph-deploy/docs
+    publishers:
+      - ssh:
+          site: 'docs.ceph.com'
+          target: 'ceph-deploy/docs/'
+          source: '.tox/docs/tmp/html/**'
+          remove-prefix: '.tox/docs/tmp/html/'

--- a/teuthology-docs/build/build
+++ b/teuthology-docs/build/build
@@ -20,5 +20,3 @@ fi
 
 # create the docs build with tox
 tox -rv -e docs
-# publish docs to docs.ceph.com/docs/teuthology
-rsync -auv --delete .tox/docs/tmp/html/* ubuntu@docs.front.sepia.ceph.com:/var/teuthology/docs/

--- a/teuthology-docs/config/definitions/teuthology-docs.yml
+++ b/teuthology-docs/config/definitions/teuthology-docs.yml
@@ -34,3 +34,11 @@
     builders:
       - shell:
           !include-raw ../../build/build
+
+    # publish docs to docs.ceph.com/teuthology/docs
+    publishers:
+      - ssh:
+          site: 'docs.ceph.com'
+          target: 'teuthology/docs/'
+          source: '.tox/docs/tmp/html/**'
+          remove-prefix: '.tox/docs/tmp/html/'


### PR DESCRIPTION
We will move docs.ceph.com to DreamCompute and publish docs directly to it.