### PR TITLE
remove the RELEASE checkbox on the ceph-next job

### DIFF
--- a/ceph-next/config/definitions/ceph-next.yml
+++ b/ceph-next/config/definitions/ceph-next.yml
@@ -24,18 +24,9 @@
           default: master
 
       - bool:
-          name: RELEASE
-          description: "
-If this is unchecked, then the builds will be signed with the autosign key (03C3951A). This is the default.&lt;br/&gt;
-
-If this is checked, then the builds will be signed by the release key (460F3994).&lt;br/&gt;
-
-Only check this box if we will be shipping the packages as formal releases."
-
-      - bool:
           name: TEST
           description: "
-If this is unchecked, then the builds will be pushed to chacra with the correct ref. This is the default.&lt;br/&gt;
+If this is unchecked, then the builds will be pushed to chacra with the correct ref. This is the default.
 
 If this is checked, then the builds will be pushed to chacra under the 'test' ref."
 

--- a/ceph/config/definitions/ceph.yml
+++ b/ceph/config/definitions/ceph.yml
@@ -23,15 +23,6 @@
           description: "The git branch (or tag) to build"
           default: master
 
-      - bool:
-          name: RELEASE
-          description: "
-If this is unchecked, then the builds will be signed with the autosign key (03C3951A). This is the default.&lt;br/&gt;
-
-If this is checked, then the builds will be signed by the release key (460F3994).&lt;br/&gt;
-
-Only check this box if we will be shipping the packages as formal releases."
-
     builders:
       - multijob:
           name: 'ceph setup phase'


### PR DESCRIPTION
We do not sign with jenkins anymore

Signed-off-by: Andrew Schoen <aschoen@redhat.com>