### PR TITLE
mirror the ceph repo

### DIFF
--- a/ceph-mirror/build/build
+++ b/ceph-mirror/build/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -ex
+
+git remote -v

--- a/ceph-mirror/config/definitions/ceph-mirror.yml
+++ b/ceph-mirror/config/definitions/ceph-mirror.yml
@@ -1,0 +1,31 @@
+- job:
+    name: ceph-mirror
+    project-type: freestyle
+    defaults: global
+    disabled: false
+    display-name: 'ceph-mirror: Repo mirror from ceph/ceph to ceph/ceph-releases'
+    concurrent: false
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-releases/
+    logrotate:
+      daysToKeep: 15
+      numToKeep: 30
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    triggers:
+      - pollscm: "* * * * *"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph.git
+          remotes: ['git@github.com:ceph/ceph-releases.git']
+          timeout: 20
+
+    builders:
+      - shell: !include-raw ../../build/build


### PR DESCRIPTION
Initially it will just list the remotes because reading the docs I couldn't see how to 'name' a remote. This doesn't do anything just yet.