### PR TITLE
ceph-setup-next should request a huge trusty node

### DIFF
--- a/ceph-setup-next/config/definitions/ceph-setup-next.yml
+++ b/ceph-setup-next/config/definitions/ceph-setup-next.yml
@@ -3,7 +3,7 @@
     description: "This job step checks out the branch and builds the tarballs, diffs, and dsc that are passed to the ceph-build step.\r\n\r\nNotes:\r\nJob needs to run on a releatively recent debian system.  The Restrict where run feature is used to specifiy an appropriate label.\r\nThe clear workspace before checkout box for the git plugin is used."
     # we do not need to pin this to trusty anymore for the new jenkins instance
     # FIXME: unpin when this gets ported over
-    node: trusty
+    node: huge && trusty
     disabled: false
     display-name: 'ceph-setup-next'
     concurrent: false


### PR DESCRIPTION
We've updated our tagging scheme, so now this job should request a slave
that's tagged with both 'huge' and 'trusty'.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>