### PR TITLE
use the right credentials id user for git ceph-releases

### DIFF
--- a/ceph-setup-next/config/definitions/ceph-setup-next.yml
+++ b/ceph-setup-next/config/definitions/ceph-setup-next.yml
@@ -26,6 +26,7 @@
     scm:
       - git:
           url: git@github.com:ceph/ceph-releases.git
+          credentials-id: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
           branches:
             - $BRANCH
           skip-tag: true


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>