### PR TITLE
ceph-deploy-docs: misc changes

### DIFF
--- a/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
+++ b/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
@@ -20,7 +20,7 @@
       artifactNumToKeep: -1
 
     triggers:
-      - pollscm: "* * * * *"
+      - github
 
     scm:
       - git:

--- a/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
+++ b/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
@@ -24,11 +24,11 @@
 
     scm:
       - git:
-          url: https://github.com/ceph/ceph-deploy.git
+          url: https://github.com/ceph/ceph-deploy
           branches:
             - master
           browser: githubweb
-          browser-url: https://github.com/ceph/ceph-deploy.git
+          browser-url: https://github.com/ceph/ceph-deploy
           skip-tag: true
           timeout: 20
 

--- a/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
+++ b/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
@@ -15,7 +15,7 @@
           url: https://github.com/ceph/ceph-deploy
     logrotate:
       daysToKeep: -1
-      numToKeep: -1
+      numToKeep: 10
       artifactDaysToKeep: -1
       artifactNumToKeep: -1
 


### PR DESCRIPTION
* normalize the GitHub URLs
* switch to GitHub webhooks (instead of polling)
* only keep the logs for the last 10 jobs