### PR TITLE
ansible: set HSTS header in nginx

### DIFF
--- a/ansible/roles/ansible-jenkins/templates/jenkins.conf
+++ b/ansible/roles/ansible-jenkins/templates/jenkins.conf
@@ -9,6 +9,7 @@ server {
     ssl_certificate     /etc/ssl/certs/{{ ansible_fqdn }}-bundled.crt;
     ssl_certificate_key /etc/ssl/private/{{ ansible_fqdn }}.key;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    add_header Strict-Transport-Security "max-age=31536000";
 
     access_log  /var/log/nginx/jenkins_access.log;
     error_log  /var/log/nginx/jenkins_error.log;


### PR DESCRIPTION
This will cause a browser to automatically load the "https://" URL when the user enters "jenkins.ceph.com" into the browser.

We are using HTTP redirects from HTTP -> HTTPS already on jenkins.ceph.com, but this change should make it a bit more secure.

See https://www.owasp.org/index.php/HTTP_Strict_Transport_Security for more information