### PR TITLE
fix calamari jobs' "branches" definition

### DIFF
--- a/calamari-clients-precise-vagrant/config/definitions/calamari-clients-precise-vagrant.yml
+++ b/calamari-clients-precise-vagrant/config/definitions/calamari-clients-precise-vagrant.yml
@@ -30,5 +30,6 @@
     scm:
     - git:
         basedir: calamari-clients
-        branches: '*/${BRANCH}'
+        branches:
+          - '*/${BRANCH}'
         url: git@github.com:ceph/calamari-clients.git

--- a/calamari-clients-precise/config/definitions/calamari-clients-precise.yml
+++ b/calamari-clients-precise/config/definitions/calamari-clients-precise.yml
@@ -30,5 +30,6 @@
     scm:
     - git:
         basedir: calamari-clients
-        branches: ${BRANCH}
+        branches:
+          - ${BRANCH}
         url: git@github.com:red-hat-storage/romana.git

--- a/calamari-clients-rhel/config/definitions/calamari-clients-rhel.yml
+++ b/calamari-clients-rhel/config/definitions/calamari-clients-rhel.yml
@@ -37,5 +37,6 @@
     scm:
     - git:
         basedir: calamari-clients
-        branches: '*/${BRANCH}'
+        branches:
+          - '*/${BRANCH}'
         url: git@github.com:ceph/calamari-clients.git

--- a/calamari-clients-rhel7/config/definitions/calamari-clients-rhel7.yml
+++ b/calamari-clients-rhel7/config/definitions/calamari-clients-rhel7.yml
@@ -37,5 +37,6 @@
     scm:
     - git:
         basedir: calamari-clients
-        branches: '*/${BRANCH}'
+        branches:
+          - '*/${BRANCH}'
         url: git@github.com:ceph/calamari-clients.git

--- a/calamari-clients-trusty/config/definitions/calamari-clients-trusty.yml
+++ b/calamari-clients-trusty/config/definitions/calamari-clients-trusty.yml
@@ -37,5 +37,6 @@
     scm:
     - git:
         basedir: calamari-clients
-        branches: '*/${BRANCH}'
+        branches:
+          - '*/${BRANCH}'
         url: git@github.com:ceph/calamari-clients.git

--- a/calamari-clients-vagrant/config/definitions/calamari-clients-vagrant.yml
+++ b/calamari-clients-vagrant/config/definitions/calamari-clients-vagrant.yml
@@ -61,5 +61,6 @@
     scm:
     - git:
         basedir: calamari-clients
-        branches: '*/$BRANCH'
+        branches:
+          - '*/$BRANCH'
         url: git@github.com:red-hat-storage/calamari-clients.git

--- a/calamari-clients-wheezy/config/definitions/calamari-clients-wheezy.yml
+++ b/calamari-clients-wheezy/config/definitions/calamari-clients-wheezy.yml
@@ -37,5 +37,6 @@
     scm:
     - git:
         basedir: calamari-clients
-        branches: '*/${BRANCH}'
+        branches:
+          - '*/${BRANCH}'
         url: git@github.com:ceph/calamari-clients.git

--- a/calamari-server-centos/config/definitions/calamari-server-centos.yml
+++ b/calamari-server-centos/config/definitions/calamari-server-centos.yml
@@ -33,5 +33,6 @@
     scm:
     - git:
         basedir: Diamond
-        branches: '*/calamari'
+        branches:
+          - '*/calamari'
         url: git@github.com:ceph/Diamond

--- a/calamari-server-precise/config/definitions/calamari-server-precise.yml
+++ b/calamari-server-precise/config/definitions/calamari-server-precise.yml
@@ -33,5 +33,6 @@
     scm:
     - git:
         basedir: Diamond
-        branches: '*/calamari'
+        branches:
+          - '*/calamari'
         url: git@github.com:ceph/Diamond

--- a/calamari-server-rhel/config/definitions/calamari-server-rhel.yml
+++ b/calamari-server-rhel/config/definitions/calamari-server-rhel.yml
@@ -33,5 +33,6 @@
     scm:
     - git:
         basedir: Diamond
-        branches: '*/calamari'
+        branches:
+          - '*/calamari'
         url: git@github.com:ceph/Diamond

--- a/calamari-server-rhel7/config/definitions/calamari-server-rhel7.yml
+++ b/calamari-server-rhel7/config/definitions/calamari-server-rhel7.yml
@@ -33,5 +33,6 @@
     scm:
     - git:
         basedir: Diamond
-        branches: '*/calamari'
+        branches:
+          - '*/calamari'
         url: git@github.com:ceph/Diamond

--- a/calamari-server-trusty/config/definitions/calamari-server-trusty.yml
+++ b/calamari-server-trusty/config/definitions/calamari-server-trusty.yml
@@ -33,5 +33,6 @@
     scm:
     - git:
         basedir: Diamond
-        branches: '*/calamari'
+        branches:
+          - '*/calamari'
         url: git@github.com:ceph/Diamond

--- a/calamari-server-vagrant/config/definitions/calamari-server-vagrant.yml
+++ b/calamari-server-vagrant/config/definitions/calamari-server-vagrant.yml
@@ -50,5 +50,6 @@
     scm:
     - git:
         basedir: Diamond
-        branches: '*/calamari'
+        branches:
+          - '*/calamari'
         url: git@github.com:ceph/Diamond

--- a/calamari-server-wheezy/config/definitions/calamari-server-wheezy.yml
+++ b/calamari-server-wheezy/config/definitions/calamari-server-wheezy.yml
@@ -33,5 +33,6 @@
     scm:
     - git:
         basedir: Diamond
-        branches: '*/calamari'
+        branches:
+          - '*/calamari'
         url: git@github.com:ceph/Diamond

--- a/calamari-server/config/definitions/calamari-server.yml
+++ b/calamari-server/config/definitions/calamari-server.yml
@@ -60,5 +60,6 @@
     scm:
     - git:
         basedir: Diamond
-        branches: '*/calamari'
+        branches:
+          - '*/calamari'
         url: git@github.com:ceph/Diamond


### PR DESCRIPTION
A bug in jenkins-job-wrecker screwed up the "branches" settings when we
imported these jobs from the internal Calamari jenkins server. Fix this.