### PR TITLE
prevent an early exit from a non-zero exit status

### DIFF
--- a/ceph-build-next/build/build_deb
+++ b/ceph-build-next/build/build_deb
@@ -36,7 +36,8 @@ vers=`cat ./dist/version`
 distro=`python -c "exec 'import platform; print platform.linux_distribution()[0].lower()'"`
 chacra_endpoint="ceph/${chacra_ref}/${distro}/${DIST}/${ARCH}"
 
-chacractl exists binaries/${chacra_endpoint}; exists=$? || true
+# prevent early exit from a non-zero exit because we use `set -e`
+! chacractl exists binaries/${chacra_endpoint}; exists=$? || true
 
 # if the binary already exists in chacra, do not rebuild
 if [ $exists -eq 0 ] && [ "$FORCE" = false ] ; then

--- a/ceph-build-next/build/build_rpm
+++ b/ceph-build-next/build/build_rpm
@@ -62,7 +62,8 @@ vers=`cat ./dist/version`
 [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
 chacra_baseurl="ceph/${chacra_ref}/${DISTRO}/${RELEASE}"
 
-chacractl exists binaries/${chacra_baseurl}/${ARCH}; exists=$? || true
+# prevent early exit from a non-zero exit because we use `set -e`
+! chacractl exists binaries/${chacra_baseurl}/${ARCH}; exists=$? || true
 
 # if the binary already exists in chacra, do not rebuild
 if [ $exists -eq 0 ] && [ "$FORCE" = false ]; then


### PR DESCRIPTION
This was edited in-place for the Infernalis build and is now working. Before it would just error out regardless of the `|| true`