### PR TITLE
ansible: install libyaml-dev on the slaves

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -60,6 +60,8 @@
         - python-dev
         - python-pip
         - python-virtualenv
+        # jenkins-job-builder job:
+        - libyaml-dev
         # ceph-docs job:
         - doxygen
         - ditaa

--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -89,6 +89,8 @@
         - libtool
         - autotools-dev
         - automake
+        # jenkins-job-builder job:
+        - libyaml-dev
         # ceph-docs job:
         - doxygen
         - ditaa


### PR DESCRIPTION
The jenkins-job-builder module on PyPI requires this package.