### PR TITLE
ansible: use "ceph-jenkins" as API user

### DIFF
--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -6,7 +6,7 @@
   vars:
    - jenkins_user: 'jenkins-build'
    # jenkins API credentials:
-   - api_user: 'prado'
+   - api_user: 'ceph-jenkins'
    - token: '${token}'
    - api_uri: 'https://jenkins.ceph.com'
    - nodename: '${nodename}'


### PR DESCRIPTION
Jenkins authorizes this user account to add or remove slaves. In order to have permission to add or remove slaves, we have to give this account administrator rights to Jenkins.

Prior to this change, we had a system user "prado" in Jenkins with administrator rights.

Since we do not control this user account on GitHub.com, it is better to use a GitHub.com user account that we control.