### PR TITLE
jenkins-job-builder: rm jenkins_jobs.ini after build

### DIFF
--- a/ansible/master.yml
+++ b/ansible/master.yml
@@ -31,6 +31,7 @@
       - 'github-oauth'
       - 'mask-passwords'
       - 'description-setter'
+      - 'postbuildscript'
 
     - port: 8080
     - prefix: '/build'

--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -33,3 +33,7 @@
 
     builders:
       - shell: "bash jenkins-job-builder/build/build"
+
+    - postbuildscript:
+        generic-script:
+            - 'rm $HOME/.jenkins_jobs.ini'


### PR DESCRIPTION
Clean up this file after each run, to make it less likely other jobs will have access to it.