### PR TITLE
jenkins-job-builder: postbuildscript publisher fixes

### DIFF
--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -34,6 +34,9 @@
     builders:
       - shell: "bash jenkins-job-builder/build/build"
 
-    - postbuildscript:
-        generic-script:
-            - 'rm $HOME/.jenkins_jobs.ini'
+    publishers:
+      - postbuildscript:
+          builders:
+            - shell: 'rm $HOME/.jenkins_jobs.ini'
+        script-only-if-succeeded: false
+        script-only-if-failed: false


### PR DESCRIPTION
Prior to this commit, the JJB YAML syntax was just broken, and
jenkins-job-builder would not parse this file.

Fix the YAML syntax, make the script run properly as a "shell" step,
make it execute regardless of the build status (with the
"script-only-if-*" settings).