### PR TITLE
ansible: do not pre-populate an SSH key for docs.ceph.com

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -83,14 +83,6 @@
       sudo: true
       pip: name=python-jenkins
 
-    - name: add docs.ceph.com host key
-      sudo: true
-      known_hosts:
-        path: '/etc/ssh/ssh_known_hosts'
-        name: 'docs.ceph.com'
-        # docs.ceph.com.pub is the output of `ssh-keyscan docs.ceph.com`
-        key: "{{ lookup('file', 'ssh/hostkeys/docs.ceph.com.pub') }}"
-
     - name: add github.com host key
       sudo: true
       known_hosts:

--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -117,13 +117,6 @@
       # https://bugs.launchpad.net/python-jenkins/+bug/1500898
       pip: name=python-jenkins version=0.4.7
 
-    - name: add docs.ceph.com host key
-      sudo: true
-      known_hosts: path='/etc/ssh/ssh_known_hosts'
-      name='docs.ceph.com'
-      # docs.ceph.com.pub is the output of `ssh-keyscan docs.ceph.com`
-      key="{{ lookup('file', 'ssh/hostkeys/docs.ceph.com.pub') }}"
-
     - name: add github.com host key
       sudo: true
       known_hosts:


### PR DESCRIPTION
The new docs VM is moving behind a firewall / reverse-proxy, so it will
not be directly accessible from the internet. We will to run the
documentation jobs directly on the docs VM as a Jenkins slave, and we
will stop using rsync over SSH for publishing the docs.

Since there's no direct SSH access to the docs VM any more, remove the
SSH host key from the slaves.

(My Ansible syntax in slave.yml.j2 was broken anyway.)