### PR TITLE
use docs.ceph.com slave for docs jobs

### DIFF
--- a/ceph-deploy-docs/build/build
+++ b/ceph-deploy-docs/build/build
@@ -21,5 +21,5 @@ fi
 # create the docs build with tox
 tox -rv -e docs
 
-# publish docs to docs.ceph.com/docs/ceph-deploy
-rsync -auv --delete .tox/docs/tmp/html/* jenkins-publish@newdocs.ceph.com:/var/ceph-deploy/docs/
+# publish docs to http://docs.ceph.com/docs/ceph-deploy
+rsync -auv --delete .tox/docs/tmp/html/* /var/ceph-deploy/docs/

--- a/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
+++ b/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-deploy-docs
-    node: trusty
+    node: docs
     project-type: freestyle
     defaults: global
     disabled: false
@@ -31,12 +31,6 @@
           browser-url: https://github.com/ceph/ceph-deploy
           skip-tag: true
           timeout: 20
-
-    wrappers:
-      - ssh-agent-credentials:
-          users:
-            # "jenkins-publish" SSH key, needed for rsync to docs.ceph.com:
-            - 'fa9ca012-6731-4c7d-be74-eda748e36ee8'
 
     builders:
       - shell:

--- a/ceph-docs/build/build
+++ b/ceph-docs/build/build
@@ -19,6 +19,6 @@ mkdir -p docs.raw/ref/
 ln -s ../sha1/$REV "docs.raw/ref/$BRANCH"
 
 # Publish this sha1's contents first:
-rsync -a -v docs.raw/sha1/$REV jenkins-publish@newdocs.ceph.com:/var/docs.raw/sha1/
+rsync -a -v docs.raw/sha1/$REV /var/docs.raw/sha1/
 # Now point the ref symlink at the newly-uploaded sha1.
-rsync -a -v docs.raw/ref/$BRANCH jenkins-publish@newdocs.ceph.com:/var/docs.raw/ref/
+rsync -a -v docs.raw/ref/$BRANCH /var/docs.raw/ref/

--- a/ceph-docs/config/definitions/ceph-docs.yml
+++ b/ceph-docs/config/definitions/ceph-docs.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-docs
-    node: trusty
+    node: docs
     project-type: freestyle
     defaults: global
     concurrent: false
@@ -31,12 +31,6 @@
           skip-tag: true
           timeout: 20
           wipe-workspace: true
-
-    wrappers:
-      - ssh-agent-credentials:
-          users:
-            # "jenkins-publish" SSH key, needed for rsync to docs.ceph.com:
-            - 'fa9ca012-6731-4c7d-be74-eda748e36ee8'
 
     builders:
       - shell:

--- a/teuthology-docs/build/build
+++ b/teuthology-docs/build/build
@@ -20,5 +20,5 @@ fi
 
 # create the docs build with tox
 tox -rv -e docs
-# publish docs to docs.ceph.com/docs/teuthology
-rsync -auv --delete .tox/docs/tmp/html/* jenkins-publish@newdocs.ceph.com:/var/teuthology/docs/
+# publish docs to http://docs.ceph.com/docs/teuthology
+rsync -auv --delete .tox/docs/tmp/html/* /var/teuthology/docs/

--- a/teuthology-docs/config/definitions/teuthology-docs.yml
+++ b/teuthology-docs/config/definitions/teuthology-docs.yml
@@ -1,6 +1,6 @@
 - job:
     name: teuthology-docs
-    node: trusty
+    node: docs
     project-type: freestyle
     defaults: global
     disabled: false
@@ -30,12 +30,6 @@
           browser: githubweb
           browser-url: https://github.com/ceph/teuthology.git
           timeout: 20
-
-    wrappers:
-      - ssh-agent-credentials:
-          users:
-            # "jenkins-publish" SSH key, needed for rsync to docs.ceph.com:
-            - 'fa9ca012-6731-4c7d-be74-eda748e36ee8'
 
     builders:
       - shell:


### PR DESCRIPTION
Now that we're running a dedicated Jenkins slave for the docs jobs, there are some cleanups we can do.

No need to rsync over SSH, or even use ssh-agent with the jenkins-publish credentials. We can just rsync the job's output directly into the proper location in /var.

Update the "node" setting to make the job run on the node labeled "docs".