### PR TITLE
standardize calamari URLs

### DIFF
--- a/calamari-clients-centos/config/definitions/calamari-clients-centos.yml
+++ b/calamari-clients-centos/config/definitions/calamari-clients-centos.yml
@@ -39,4 +39,4 @@
         basedir: calamari-clients
         branches:
           - '*/${BRANCH}'
-        url: git@github.com:ceph/calamari-clients.git
+        url: https://github.com/ceph/calamari-clients.git

--- a/calamari-clients-precise-vagrant/config/definitions/calamari-clients-precise-vagrant.yml
+++ b/calamari-clients-precise-vagrant/config/definitions/calamari-clients-precise-vagrant.yml
@@ -32,4 +32,4 @@
         basedir: calamari-clients
         branches:
           - '*/${BRANCH}'
-        url: git@github.com:ceph/calamari-clients.git
+        url: https://github.com/ceph/calamari-clients.git

--- a/calamari-clients-precise/config/definitions/calamari-clients-precise.yml
+++ b/calamari-clients-precise/config/definitions/calamari-clients-precise.yml
@@ -32,4 +32,4 @@
         basedir: calamari-clients
         branches:
           - ${BRANCH}
-        url: git@github.com:red-hat-storage/romana.git
+        url: https://github.com/ceph/romana.git

--- a/calamari-clients-rhel/config/definitions/calamari-clients-rhel.yml
+++ b/calamari-clients-rhel/config/definitions/calamari-clients-rhel.yml
@@ -39,4 +39,4 @@
         basedir: calamari-clients
         branches:
           - '*/${BRANCH}'
-        url: git@github.com:ceph/calamari-clients.git
+        url: https://github.com/ceph/calamari-clients.git

--- a/calamari-clients-rhel7/config/definitions/calamari-clients-rhel7.yml
+++ b/calamari-clients-rhel7/config/definitions/calamari-clients-rhel7.yml
@@ -39,4 +39,4 @@
         basedir: calamari-clients
         branches:
           - '*/${BRANCH}'
-        url: git@github.com:ceph/calamari-clients.git
+        url: https://github.com/ceph/calamari-clients.git

--- a/calamari-clients-trusty/config/definitions/calamari-clients-trusty.yml
+++ b/calamari-clients-trusty/config/definitions/calamari-clients-trusty.yml
@@ -39,4 +39,4 @@
         basedir: calamari-clients
         branches:
           - '*/${BRANCH}'
-        url: git@github.com:ceph/calamari-clients.git
+        url: https://github.com/ceph/calamari-clients.git

--- a/calamari-clients-vagrant/config/definitions/calamari-clients-vagrant.yml
+++ b/calamari-clients-vagrant/config/definitions/calamari-clients-vagrant.yml
@@ -50,7 +50,7 @@
     project-type: matrix
     properties:
     - github:
-        url: https://github.com/red-hat-storage/calamari/
+        url: https://github.com/ceph/calamari-clients
     publishers:
     - archive:
         allow-empty: false
@@ -63,4 +63,4 @@
         basedir: calamari-clients
         branches:
           - '*/$BRANCH'
-        url: git@github.com:red-hat-storage/calamari-clients.git
+        url: https://github.com/ceph/calamari-clients.git

--- a/calamari-clients-wheezy/config/definitions/calamari-clients-wheezy.yml
+++ b/calamari-clients-wheezy/config/definitions/calamari-clients-wheezy.yml
@@ -39,4 +39,4 @@
         basedir: calamari-clients
         branches:
           - '*/${BRANCH}'
-        url: git@github.com:ceph/calamari-clients.git
+        url: https://github.com/ceph/calamari-clients.git

--- a/calamari-clients/config/definitions/calamari-clients.yml
+++ b/calamari-clients/config/definitions/calamari-clients.yml
@@ -47,7 +47,7 @@
     project-type: matrix
     properties:
     - github:
-        url: https://github.com/red-hat-storage/romana/
+        url: https://github.com/ceph/romana/
     publishers:
     - archive:
         allow-empty: false
@@ -60,5 +60,5 @@
         basedir: calamari-clients
         branches:
           - $BRANCH
-        url: git@github.com:red-hat-storage/romana.git
+        url: https://github.com/ceph/calamari-clients.git
         wipe-workspace: true


### PR DESCRIPTION
Use the publicly-accessible, non-SSH URLs for Git and GitHub.