### PR TITLE
use auto browser for Git SCMs

### DIFF
--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -44,8 +44,7 @@
           branches:
             - ${sha1}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: githubweb
-          browser-url: https://github.com/ceph/ceph-build
+          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: false

--- a/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
+++ b/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
@@ -27,8 +27,7 @@
           url: https://github.com/ceph/ceph-deploy
           branches:
             - master
-          browser: githubweb
-          browser-url: https://github.com/ceph/ceph-deploy
+          browser: auto
           skip-tag: true
           timeout: 20
 

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -9,8 +9,7 @@
           branches:
             - ${sha1}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: githubweb
-          browser-url: https://github.com/ceph/ceph-deploy
+          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: false

--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -39,8 +39,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           url: https://github.com/ceph/ceph-deploy.git
           branches:
             - $BRANCH
-          browser: githubweb
-          browser-url: http://github.com/ceph/ceph-deploy.git
+          browser: auto
           skip-tag: true
           timeout: 20
           wipe-workspace: true

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -53,8 +53,7 @@
           branches:
             - ${sha1}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: githubweb
-          browser-url: https://github.com/ceph/ceph-qa-suite
+          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: false

--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -3,7 +3,7 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph-build.git
-          browser-url: https://github.com/ceph/ceph-build
+          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: true

--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -27,8 +27,7 @@
           url: https://github.com/ceph/ceph-build
           branches:
             - master
-          browser: githubweb
-          browser-url: https://github.com/ceph/ceph-build
+          browser: auto
           timeout: 20
 
     builders:

--- a/mariner-installer-pull-requests/config/definitions/mariner-installer-pull-requests.yml
+++ b/mariner-installer-pull-requests/config/definitions/mariner-installer-pull-requests.yml
@@ -32,8 +32,7 @@
           branches:
             - ${sha1}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: githubweb
-          browser-url: https://github.com/ceph/mariner-installer
+          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: true

--- a/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
+++ b/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
@@ -56,8 +56,7 @@
           branches:
             - ${sha1}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: githubweb
-          browser-url: https://github.com/alfredodeza/merfi
+          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: true

--- a/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
+++ b/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
@@ -43,8 +43,7 @@
           branches:
             - ${sha1}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: githubweb
-          browser-url: https://github.com/ceph/radosgw-agent
+          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: false

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -26,8 +26,7 @@
           url: https://github.com/ceph/radosgw-agent.git
           branches:
             - $BRANCH
-          browser: githubweb
-          browser-url: http://github.com/ceph/radosgw-agent.git
+          browser: auto
           timeout: 20
 
     axes:

--- a/takora-pull-requests/config/definitions/takora-pull-requests.yml
+++ b/takora-pull-requests/config/definitions/takora-pull-requests.yml
@@ -32,8 +32,7 @@
           branches:
             - ${sha1}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: githubweb
-          browser-url: https://github.com/ceph/takora
+          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: true

--- a/teuthology-docs/config/definitions/teuthology-docs.yml
+++ b/teuthology-docs/config/definitions/teuthology-docs.yml
@@ -27,8 +27,7 @@
           url: https://github.com/ceph/teuthology.git
           branches:
             - master
-          browser: githubweb
-          browser-url: https://github.com/ceph/teuthology.git
+          browser: auto
           timeout: 20
 
     builders:

--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -57,8 +57,7 @@
           branches:
             - ${sha1}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: githubweb
-          browser-url: https://github.com/ceph/teuthology
+          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: true


### PR DESCRIPTION
Many jobs specified the githubweb browser and defined a specific URL to find the commits.

Reduce the duplication and rely on the Jenkins Git plugin's ability to automatically construct the URLs to the SCM commits.