### PR TITLE
do not activate virtualenv when building

### DIFF
--- a/ceph-build-next/build/build_deb
+++ b/ceph-build-next/build/build_deb
@@ -6,8 +6,7 @@ if test -f /etc/redhat-release ; then
     exit 0
 fi
 
-# activate the virtualenv
-source $WORKSPACE/venv/bin/activate
+VENV="$WORKSPACE/venv/bin"
 
 get_bptag() {
     dist=$1
@@ -36,7 +35,7 @@ vers=`cat ./dist/version`
 distro=`python -c "exec 'import platform; print platform.linux_distribution()[0].lower()'"`
 chacra_endpoint="ceph/${chacra_ref}/${distro}/${DIST}/${ARCH}"
 
-chacractl exists binaries/${chacra_endpoint} ; exists=$?
+$VENV/chacractl exists binaries/${chacra_endpoint} ; exists=$?
 
 # if the binary already exists in chacra, do not rebuild
 if [ $exists -eq 0 ] && [ "$FORCE" = false ] ; then
@@ -178,7 +177,7 @@ echo "  End Time = $(date)"
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 
 # push binaries to chacra
-find release/$vers/ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | chacractl binary ${chacra_flags} create ${chacra_endpoint}
+find release/$vers/ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
 
 
 echo "End Date: $(date)"

--- a/ceph-build-next/build/build_rpm
+++ b/ceph-build-next/build/build_rpm
@@ -5,8 +5,7 @@ if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then
     exit 0
 fi
 
-# activate the virtualenv
-source $WORKSPACE/venv/bin/activate
+VENV="$WORKSPACE/venv/bin"
 
 get_rpm_dist() {
     LSB_RELEASE=/usr/bin/lsb_release
@@ -62,7 +61,7 @@ vers=`cat ./dist/version`
 [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
 chacra_baseurl="ceph/${chacra_ref}/${DISTRO}/${RELEASE}"
 
-chacractl exists binaries/${chacra_baseurl}/${ARCH} ; exists=$?
+$VENV/chacractl exists binaries/${chacra_baseurl}/${ARCH} ; exists=$?
 
 # if the binary already exists in chacra, do not rebuild
 if [ $exists -eq 0 ] && [ "$FORCE" = false ]; then
@@ -119,7 +118,7 @@ cd "$WORKSPACE"
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 
 # push binaries to chacra
-find release/${vers}/rpm/*/SRPMS | grep rpm | chacractl binary ${chacra_flags} create ${chacra_baseurl}/source
-find release/${vers}/rpm/*/RPMS/* | grep rpm | chacractl binary ${chacra_flags} create ${chacra_baseurl}/${ARCH}
+find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_baseurl}/source
+find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_baseurl}/${ARCH}
 
 echo "End Date: $(date)"

--- a/ceph-build-next/build/setup
+++ b/ceph-build-next/build/setup
@@ -68,7 +68,7 @@ esac
 
 # Create the virtualenv
 virtualenv $WORKSPACE/venv
-source $WORKSPACE/venv/bin/activate
+VENV="$WORKSPACE/venv/bin"
 
 # Define and ensure the PIP cache
 PIP_SDIST_INDEX="$HOME/.cache/pip"
@@ -76,9 +76,9 @@ mkdir -p $PIP_SDIST_INDEX
 
 # Install the package by trying with the cache first, otherwise doing a download only, and then
 # trying to install from the cache again.
-if ! pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl; then
-    pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" chacractl
-    pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl
+if ! $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl; then
+    $VENV/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" chacractl
+    $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl
 fi
 
 # create the .chacractl config file


### PR DESCRIPTION
So that we avoid these things:

   $ rpm -qpR ceph-9.2.0-0.el7.x86_64.rpm
   /bin/bash
   /bin/sh
   /bin/sh
   /bin/sh
   /bin/sh
   /bin/sh
   /home/jenkins-build/build/workspace/ceph-build-next/ARCH/x86_64/DIST/centos7/venv/bin/python
   /usr/bin/env
   ...
