### PR TITLE
do not source the venv in ceph-deploy and ceph-release-rpm jobs

### DIFF
--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -19,8 +19,7 @@ echo "  BRANCH=$BRANCH"
 rpm_dists="rhel centos6 centos7 centos"
 deb_dists="precise wheezy squeeze trusty jessie"
 
-# activate the virtualenv
-source $WORKSPACE/venv/bin/activate
+VENV="$WORKSPACE/venv/bin"
 
 # A helper to match an item in a list of items, like python's `if item in list`
 listcontains() {
@@ -84,7 +83,7 @@ then
         [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
         chacra_endpoint="ceph-deploy/${chacra_ref}/${DISTRO}/${DISTRO_VERSION}"
 
-        chacractl exists binaries/${chacra_endpoint}/${ARCH} ; exists=$?
+        $VENV/chacractl exists binaries/${chacra_endpoint}/${ARCH} ; exists=$?
 
         # if the binary already exists in chacra, do not rebuild
         if [ $exists -eq 0 ] && [ "$FORCE" = false ] ; then
@@ -110,8 +109,8 @@ then
 
         [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 
-        find ${BUILDAREA}/SRPMS | grep rpm | chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
-        find ${BUILDAREA}/RPMS/* | grep rpm | chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
+        find ${BUILDAREA}/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
+        find ${BUILDAREA}/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
 
         exit 0
 
@@ -132,7 +131,7 @@ then
     [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
     chacra_endpoint="ceph-deploy/${chacra_ref}/${DISTRO}/${DEB_BUILD}/${ARCH}"
 
-    chacractl exists binaries/${chacra_endpoint} ; exists=$?
+    $VENV/chacractl exists binaries/${chacra_endpoint} ; exists=$?
 
     # if the binary already exists in chacra, do not rebuild
     if [ $exists -eq 0 ] && [ "$FORCE" = false ] ; then
@@ -167,7 +166,7 @@ then
 
     # push binaries to chacra
     # the binaries are created in one directory up from $WORKSPACE
-    find ../ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | chacractl binary ${chacra_flags} create ${chacra_endpoint}
+    find ../ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
 
     echo "Done"
 

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -14,7 +14,7 @@ rm -rf RPMBUILD
 
 # Create the virtualenv
 virtualenv $WORKSPACE/venv
-source $WORKSPACE/venv/bin/activate
+VENV="$WORKSPACE/venv/bin"
 
 # Define and ensure the PIP cache
 PIP_SDIST_INDEX="$HOME/.cache/pip"
@@ -22,9 +22,9 @@ mkdir -p $PIP_SDIST_INDEX
 
 # Install the package by trying with the cache first, otherwise doing a download only, and then
 # trying to install from the cache again.
-if ! pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl; then
-    pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" chacractl
-    pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl
+if ! $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl; then
+    $VENV/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" chacractl
+    $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl
 fi
 
 # create the .chacractl config file
@@ -53,7 +53,7 @@ if [ "$target" = "sles11sp2" ] ; then
 fi
 echo "Target directory is: $target"
 
-chacractl exists binaries/${chacra_baseurl}/${ARCH}; exists=$? || true
+$VENV/chacractl exists binaries/${chacra_baseurl}/${ARCH}; exists=$? || true
 
 # if the binary already exists in chacra, do not rebuild
 if [ $exists -eq 0 ] && [ "$FORCE" = false ]; then
@@ -176,6 +176,6 @@ EOF
 rpmbuild -ba --define "_topdir ${BUILDAREA}" --define "_unpackaged_files_terminate_build 0" ${BUILDAREA}/SPECS/ceph-release.spec
 if [ $? -eq 0 ] ; then
     # we actually do noarch stuff here
-    find $BUILDAREA/RPMS/* | grep noarch | grep rpm | chacractl binary ${chacra_flags} create ${chacra_baseurl}/noarch
-    find $BUILDAREA/SRPMS | grep rpm | chacractl binary ${chacra_flags} create ${chacra_baseurl}/source
+    find $BUILDAREA/RPMS/* | grep noarch | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_baseurl}/noarch
+    find $BUILDAREA/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_baseurl}/source
 fi


### PR DESCRIPTION
When we source the virtualenv the virtualenv path is linked within the
binaries.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>