### PR TITLE
explicitly sepcify a chacractl version to install

### DIFF
--- a/ceph-build-next/build/setup
+++ b/ceph-build-next/build/setup
@@ -74,11 +74,13 @@ VENV="$WORKSPACE/venv/bin"
 PIP_SDIST_INDEX="$HOME/.cache/pip"
 mkdir -p $PIP_SDIST_INDEX
 
+CHACRACTL_VERSION="chacractl>=0.0.4"
+
 # Install the package by trying with the cache first, otherwise doing a download only, and then
 # trying to install from the cache again.
-if ! $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl; then
-    $VENV/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" chacractl
-    $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl
+if ! $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
+    $VENV/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
+    $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
 fi
 
 # create the .chacractl config file

--- a/ceph-deploy/build/setup
+++ b/ceph-deploy/build/setup
@@ -25,11 +25,13 @@ source $WORKSPACE/venv/bin/activate
 PIP_SDIST_INDEX="$HOME/.cache/pip"
 mkdir -p $PIP_SDIST_INDEX
 
+CHACRACTL_VERSION="chacractl>=0.0.4"
+
 # Install the package by trying with the cache first, otherwise doing a download only, and then
 # trying to install from the cache again.
-if ! pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl; then
-    pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" chacractl
-    pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl
+if ! pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
+    pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
+    pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
 fi
 
 # create the .chacractl config file

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -20,11 +20,13 @@ VENV="$WORKSPACE/venv/bin"
 PIP_SDIST_INDEX="$HOME/.cache/pip"
 mkdir -p $PIP_SDIST_INDEX
 
+CHACRACTL_VERSION="chacractl>=0.0.4"
+
 # Install the package by trying with the cache first, otherwise doing a download only, and then
 # trying to install from the cache again.
-if ! $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl; then
-    $VENV/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" chacractl
-    $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index chacractl
+if ! $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
+    $VENV/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
+    $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
 fi
 
 # create the .chacractl config file


### PR DESCRIPTION
This fixes a bug where we don't get newer versions of chacractl
installed when we want it because of the use of the pip cache.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>