### PR TITLE
use --upgrade when installing chacractl

### DIFF
--- a/ceph-build-next/build/setup
+++ b/ceph-build-next/build/setup
@@ -78,9 +78,9 @@ CHACRACTL_VERSION="chacractl>=0.0.4"
 
 # Install the package by trying with the cache first, otherwise doing a download only, and then
 # trying to install from the cache again.
-if ! $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
-    $VENV/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
-    $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
+if ! $VENV/pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
+    $VENV/pip install --upgrade --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
+    $VENV/pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
 fi
 
 # create the .chacractl config file

--- a/ceph-deploy/build/setup
+++ b/ceph-deploy/build/setup
@@ -29,9 +29,9 @@ CHACRACTL_VERSION="chacractl>=0.0.4"
 
 # Install the package by trying with the cache first, otherwise doing a download only, and then
 # trying to install from the cache again.
-if ! pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
-    pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
-    pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
+if ! pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
+    pip install --upgrade --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
+    pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
 fi
 
 # create the .chacractl config file

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -24,9 +24,9 @@ CHACRACTL_VERSION="chacractl>=0.0.4"
 
 # Install the package by trying with the cache first, otherwise doing a download only, and then
 # trying to install from the cache again.
-if ! $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
-    $VENV/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
-    $VENV/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
+if ! $VENV/pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
+    $VENV/pip install --upgrade --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
+    $VENV/pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
 fi
 
 # create the .chacractl config file


### PR DESCRIPTION
This will allow us to not have to change the CHACRACTL_VERSION variable
each time we release a new version of chacractl.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>