### PR TITLE
always update the pip cache before installing packages

### DIFF
--- a/ceph-build-next/build/setup
+++ b/ceph-build-next/build/setup
@@ -76,12 +76,10 @@ mkdir -p $PIP_SDIST_INDEX
 
 CHACRACTL_VERSION="chacractl>=0.0.4"
 
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! $VENV/pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
-    $VENV/pip install --upgrade --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
-    $VENV/pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
-fi
+# download packages to the local pip cache
+$VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
+# install packages from the local pip cache, ignoring pypi
+$VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
 
 # create the .chacractl config file
 cat > $HOME/.chacractl << EOF

--- a/ceph-deploy/build/setup
+++ b/ceph-deploy/build/setup
@@ -19,7 +19,7 @@ fi
 
 # Create the virtualenv
 virtualenv $WORKSPACE/venv
-source $WORKSPACE/venv/bin/activate
+VENV="$WORKSPACE/venv/bin"
 
 # Define and ensure the PIP cache
 PIP_SDIST_INDEX="$HOME/.cache/pip"
@@ -27,12 +27,10 @@ mkdir -p $PIP_SDIST_INDEX
 
 CHACRACTL_VERSION="chacractl>=0.0.4"
 
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
-    pip install --upgrade --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
-    pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
-fi
+# download packages to the local pip cache
+$VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
+# install packages from the local pip cache, ignoring pypi
+$VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
 
 # create the .chacractl config file
 cat > $HOME/.chacractl << EOF

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -22,12 +22,10 @@ mkdir -p $PIP_SDIST_INDEX
 
 CHACRACTL_VERSION="chacractl>=0.0.4"
 
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! $VENV/pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION; then
-    $VENV/pip install --upgrade --exists-action=i --download-directory="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
-    $VENV/pip install --upgrade --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
-fi
+# download packages to the local pip cache
+$VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
+# install packages from the local pip cache, ignoring pypi
+$VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
 
 # create the .chacractl config file
 cat > $HOME/.chacractl << EOF


### PR DESCRIPTION
We do this to get around a bug in the previous code that would never go
out to look for new packages if something in the cache satisfied the
requirements. Specifically, we wanted chacractl==0.0.5 installed, but
because 0.0.4 exists in the cache and satisified the requirement of
>=0.0.4 the cache was never updated to include 0.0.5.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>