### PR TITLE
ceph-setup-next: correct $BRANCH variable in output

### DIFF
--- a/ceph-setup-next/build/build
+++ b/ceph-setup-next/build/build
@@ -13,7 +13,7 @@ if [ -x "$BRANCH" ] ; then
     exit 1
 fi
 
-echo "Building version $(git describe) Branch $Branch"
+echo "Building version $(git describe) Branch $BRANCH"
 
 rm -rf dist
 rm -rf release


### PR DESCRIPTION
$Branch is undefined. Use $BRANCH.

arior to this change, Jenkins would not print the branch name to the
console log during the "ceph-setup-next" job.