### PR TITLE
creates a utility to install python packages and configure chacractl

### DIFF
--- a/ceph-build/build/setup
+++ b/ceph-build/build/setup
@@ -66,9 +66,8 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
         ;;
 esac
 
-source $WORKSPACE/ceph-build/scripts/build_utils.sh
-
-install_python_packages "chacractl>=0.0.4"
+pkgs=( "chacractl>=0.0.4" )
+install_python_packages "pkgs[@]"
 
 # create the .chacractl config file using global variables
 make_chacractl_config

--- a/ceph-build/build/setup
+++ b/ceph-build/build/setup
@@ -66,24 +66,9 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
         ;;
 esac
 
-# Create the virtualenv
-virtualenv $WORKSPACE/venv
-VENV="$WORKSPACE/venv/bin"
+source $WORKSPACE/ceph-build/scripts/build_utils.sh
 
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
+install_python_packages "chacractl>=0.0.4"
 
-CHACRACTL_VERSION="chacractl>=0.0.4"
-
-# download packages to the local pip cache
-$VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
-# install packages from the local pip cache, ignoring pypi
-$VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
-
-# create the .chacractl config file
-cat > $HOME/.chacractl << EOF
-url = "$CHACRACTL_URL"
-user = "$CHACRACTL_USER"
-key = "$CHACRACTL_KEY"
-EOF
+# create the .chacractl config file using global variables
+make_chacractl_config

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -36,22 +36,15 @@
           filter: 'dist/**'
           which-build: last-successful
       - shell:
-          !include-raw ../../build/setup
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/setup
       - shell:
           !include-raw ../../build/setup_pbuilder
       - shell:
           !include-raw ../../build/build_deb
       - shell:
           !include-raw ../../build/build_rpm
-
-    scm:
-      - git:
-          url: https://github.com/ceph/ceph-build.git
-          browser-url: https://github.com/ceph/ceph-build
-          timeout: 20
-          skip-tag: true
-          wipe-workspace: true
-          basedir: "ceph-build"
 
     publishers:
       - archive:

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -44,6 +44,15 @@
       - shell:
           !include-raw ../../build/build_rpm
 
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-build.git
+          browser-url: https://github.com/ceph/ceph-build
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+          basedir: "ceph-build"
+
     publishers:
       - archive:
           artifacts: 'dist/**'

--- a/ceph-deploy/build/setup
+++ b/ceph-deploy/build/setup
@@ -17,24 +17,9 @@ if test -f /etc/redhat-release ; then
     sudo yum install -y $rpm_deps
 fi
 
-# Create the virtualenv
-virtualenv $WORKSPACE/venv
-VENV="$WORKSPACE/venv/bin"
+source $WORKSPACE/ceph-build/scripts/build_utils.sh
 
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
+install_python_packages "chacractl>=0.0.4"
 
-CHACRACTL_VERSION="chacractl>=0.0.4"
-
-# download packages to the local pip cache
-$VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
-# install packages from the local pip cache, ignoring pypi
-$VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
-
-# create the .chacractl config file
-cat > $HOME/.chacractl << EOF
-url = "$CHACRACTL_URL"
-user = "$CHACRACTL_USER"
-key = "$CHACRACTL_KEY"
-EOF
+# create the .chacractl config file using global variables
+make_chacractl_config

--- a/ceph-deploy/build/setup
+++ b/ceph-deploy/build/setup
@@ -17,9 +17,8 @@ if test -f /etc/redhat-release ; then
     sudo yum install -y $rpm_deps
 fi
 
-source $WORKSPACE/ceph-build/scripts/build_utils.sh
-
-install_python_packages "chacractl>=0.0.4"
+pkgs=( "chacractl>=0.0.4" )
+install_python_packages "pkgs[@]"
 
 # create the .chacractl config file using global variables
 make_chacractl_config

--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -1,26 +1,3 @@
-- scm:
-    name: ceph-deploy
-    scm:
-      - git:
-          url: https://github.com/ceph/ceph-deploy.git
-          branches:
-            - $BRANCH
-          browser: auto
-          skip-tag: true
-          timeout: 20
-          wipe-workspace: true
-
-- scm:
-    name: ceph-build
-    scm:
-      - git:
-          url: https://github.com/ceph/ceph-build.git
-          browser-url: https://github.com/ceph/ceph-build
-          timeout: 20
-          skip-tag: true
-          wipe-workspace: true
-          basedir: "ceph-build"
-
 - job:
     name: ceph-deploy
     node: small && trusty
@@ -57,8 +34,14 @@ If this is unchecked, then then nothing is built or pushed if they already exist
 If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
 
     scm:
-      - ceph-deploy
-      - ceph-build
+      - git:
+          url: https://github.com/ceph/ceph-deploy.git
+          branches:
+            - $BRANCH
+          browser: auto
+          skip-tag: true
+          timeout: 20
+          wipe-workspace: true
 
     axes:
       - axis:
@@ -78,7 +61,10 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - centos7
 
     builders:
-      - shell: !include-raw ../../build/setup
+      - shell:
+            !include-raw:
+              - ../../../scripts/build_utils.sh
+              - ../../build/setup
       - shell: !include-raw ../../build/build
 
     wrappers:

--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -1,3 +1,26 @@
+- scm:
+    name: ceph-deploy
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-deploy.git
+          branches:
+            - $BRANCH
+          browser: auto
+          skip-tag: true
+          timeout: 20
+          wipe-workspace: true
+
+- scm:
+    name: ceph-build
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-build.git
+          browser-url: https://github.com/ceph/ceph-build
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+          basedir: "ceph-build"
+
 - job:
     name: ceph-deploy
     node: small && trusty
@@ -34,14 +57,8 @@ If this is unchecked, then then nothing is built or pushed if they already exist
 If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
 
     scm:
-      - git:
-          url: https://github.com/ceph/ceph-deploy.git
-          branches:
-            - $BRANCH
-          browser: auto
-          skip-tag: true
-          timeout: 20
-          wipe-workspace: true
+      - ceph-deploy
+      - ceph-build
 
     axes:
       - axis:

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -12,27 +12,12 @@ echo "Building on Host: $(hostname) Date: $(date)"
 rm -rf dist
 rm -rf RPMBUILD
 
-# Create the virtualenv
-virtualenv $WORKSPACE/venv
-VENV="$WORKSPACE/venv/bin"
+source $WORKSPACE/ceph-build/scripts/build_utils.sh
 
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
+install_python_packages "chacractl>=0.0.4"
 
-CHACRACTL_VERSION="chacractl>=0.0.4"
-
-# download packages to the local pip cache
-$VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" $CHACRACTL_VERSION
-# install packages from the local pip cache, ignoring pypi
-$VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index $CHACRACTL_VERSION
-
-# create the .chacractl config file
-cat > $HOME/.chacractl << EOF
-url = "$CHACRACTL_URL"
-user = "$CHACRACTL_USER"
-key = "$CHACRACTL_KEY"
-EOF
+# create the .chacractl config file using global variables
+make_chacractl_config
 
 # What are we building ?
 

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -12,9 +12,8 @@ echo "Building on Host: $(hostname) Date: $(date)"
 rm -rf dist
 rm -rf RPMBUILD
 
-source $WORKSPACE/ceph-build/scripts/build_utils.sh
-
-install_python_packages "chacractl>=0.0.4"
+pkgs=( "chacractl>=0.0.4" )
+install_python_packages "pkgs[@]"
 
 # create the .chacractl config file using global variables
 make_chacractl_config

--- a/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
+++ b/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
@@ -25,6 +25,15 @@ If this is unchecked, then then nothing is built or pushed if they already exist
 
 If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
 
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-build.git
+          browser-url: https://github.com/ceph/ceph-build
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+          basedir: "ceph-build"
+
     axes:
       - axis:
           type: label-expression

--- a/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
+++ b/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
@@ -25,15 +25,6 @@ If this is unchecked, then then nothing is built or pushed if they already exist
 
 If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
 
-    scm:
-      - git:
-          url: https://github.com/ceph/ceph-build.git
-          browser-url: https://github.com/ceph/ceph-build
-          timeout: 20
-          skip-tag: true
-          wipe-workspace: true
-          basedir: "ceph-build"
-
     axes:
       - axis:
           type: label-expression
@@ -50,7 +41,9 @@ If this is checked, then the binaries will be built and pushed to chacra even if
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     wrappers:
       - inject-passwords:

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -30,3 +30,12 @@ install_python_packages () {
         $VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index $package
     done
 }
+
+make_chacractl_config () {
+    # create the .chacractl config file
+    cat > $HOME/.chacractl << EOF
+    url = "$CHACRACTL_URL"
+    user = "$CHACRACTL_USER"
+    key = "$CHACRACTL_KEY"
+    EOF
+}

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -6,14 +6,13 @@ VENV="$WORKSPACE/venv/bin"
 
 install_python_packages () {
     # Use this function to create a virtualenv and install
-    # python packages. Pass either a single package name or a list
-    # of package names. Usage:
+    # python packages. Pass a list of package names.
     #
-    #   install_python_packages "ansible"
+    # Usage:
     #
     #   to_install=( "ansible" "chacractl>=0.0.4" )
     #   install_python_packages "to_install[@]" 
-    #
+
     # Create the virtualenv
     virtualenv $WORKSPACE/venv
 
@@ -32,10 +31,10 @@ install_python_packages () {
 }
 
 make_chacractl_config () {
-    # create the .chacractl config file
-    cat > $HOME/.chacractl << EOF
-    url = "$CHACRACTL_URL"
-    user = "$CHACRACTL_USER"
-    key = "$CHACRACTL_KEY"
-    EOF
+# create the .chacractl config file
+cat > $HOME/.chacractl << EOF
+url = "$CHACRACTL_URL"
+user = "$CHACRACTL_USER"
+key = "$CHACRACTL_KEY"
+EOF
 }

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -ex
+
+VENV="$WORKSPACE/venv/bin"
+
+install_python_packages () {
+    # Use this function to create a virtualenv and install
+    # python packages. Pass either a single package name or a list
+    # of package names. Usage:
+    #
+    #   install_python_packages "ansible"
+    #
+    #   to_install=( "ansible" "chacractl>=0.0.4" )
+    #   install_python_packages "to_install[@]" 
+    #
+    # Create the virtualenv
+    virtualenv $WORKSPACE/venv
+
+    # Define and ensure the PIP cache
+    PIP_SDIST_INDEX="$HOME/.cache/pip"
+    mkdir -p $PIP_SDIST_INDEX
+
+    pkgs=("${!1}")
+    for package in ${pkgs[@]}; do
+        echo $package
+        # download packages to the local pip cache
+        $VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" $package
+        # install packages from the local pip cache, ignoring pypi
+        $VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index $package
+    done
+}

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -31,8 +31,8 @@ install_python_packages () {
 }
 
 make_chacractl_config () {
-# create the .chacractl config file
-cat > $HOME/.chacractl << EOF
+    # create the .chacractl config file
+    cat > $HOME/.chacractl << EOF
 url = "$CHACRACTL_URL"
 user = "$CHACRACTL_USER"
 key = "$CHACRACTL_KEY"


### PR DESCRIPTION
This way we can have a single bit of code that installs python packages and configures chacractl as these are very common steps in our build jobs.

This also ports ceph-build, ceph-deploy and ceph-release-rpm to use these utils.