### PR TITLE
ceph-build-pull-requests: check ansible syntax

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -29,3 +29,14 @@ for dir in `find . -maxdepth 1 -path ./.git -prune -o -type d -print`; do
         venv/bin/jenkins-jobs test $definitions_dir -o /tmp/output
     fi
 done
+
+# Install Ansible
+if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible; then
+    venv/bin/pip install --download-directory="$PIP_SDIST_INDEX" ansible
+    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible
+fi
+
+# Syntax-check each Ansible playbook
+for playbook in $WORKSPACE/ansible/*.yml; do
+    ansible-playbook -i '127.0.0.1,' $playbook --syntax-check
+done


### PR DESCRIPTION
With this change, the ceph-build-pull-requests job will run `ansible-playbook` with the `--syntax-check` flag on every playbook in the top-level of `./ansible/`. This will help us avoid simple Ansible syntax errors.