### PR TITLE
Make the radosgw-agent job push to chacra.ceph.com

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -37,6 +37,7 @@
         - java-1.7.0-openjdk
         - git
         #- rpm-sign
+        - rpmdevtools
       when: ansible_pkg_mgr  == "yum"
 
     - name: ensure the rpmmacros file exists to fix centos builds

--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -70,6 +70,7 @@
         - pkgconfig
         - redhat-rpm-config
         - rpm-build
+        - rpmdevtools
       when: ansible_pkg_mgr  == "yum"
 
     # Run the equivalent of "apt-get update" as a separate step

--- a/radosgw-agent/build/build
+++ b/radosgw-agent/build/build
@@ -35,13 +35,7 @@ if [[ -f /etc/redhat-release || -f /usr/bin/zypper ]] ; then
 
         chacra_endpoint="radosgw-agent/${chacra_ref}/${DISTRO}/${DISTRO_VERSION}"
 
-        $VENV/chacractl exists binaries/${chacra_endpoint}/noarch ; exists=$?
-
-        # if the binary already exists in chacra, do not rebuild
-        if [ $exists -eq 0 ] && [ "$FORCE" = false ] ; then
-            echo "The endpoint at ${chacra_endpoint}/noarch already exists and FORCE was not set, Exiting..."
-            exit 0
-        fi
+        check_binary_existence $chacra_endpoint/noarch
 
         suse=$(uname -n | grep -ic -e suse -e sles || true)
         if [ $suse -gt 0 ]
@@ -79,13 +73,7 @@ else
 
         chacra_endpoint="radosgw-agent/${chacra_ref}/${DISTRO}/${DEB_BUILD}/noarch"
 
-        $VENV/chacractl exists binaries/${chacra_endpoint} ; exists=$?
-
-        # if the binary already exists in chacra, do not rebuild
-        if [ $exists -eq 0 ] && [ "$FORCE" = false ] ; then
-            echo "The endpoint at ${chacra_endpoint} already exists and FORCE was not set, Exiting..."
-            exit 0
-        fi
+        check_binary_existence $chacra_endpoint
 
         dpkg-source -b .
         # we no longer sign the .dsc or .changes files (done by default with

--- a/radosgw-agent/build/build
+++ b/radosgw-agent/build/build
@@ -10,6 +10,14 @@ echo "  WS=$WORKSPACE"
 echo "  PWD=$(pwd)"
 ls -l
 
+
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "chacractl>=0.0.4" )
+install_python_packages "pkgs[@]"
+
+# create the .chacractl config file using global variables
+make_chacractl_config
+
 if [[ -f /etc/redhat-release || -f /usr/bin/zypper ]] ; then
         rm -rf ./dist  # Remove any previous artifacts
         mkdir -p $WORKSPACE/dist/noarch

--- a/radosgw-agent/build/build
+++ b/radosgw-agent/build/build
@@ -18,12 +18,31 @@ install_python_packages "pkgs[@]"
 # create the .chacractl config file using global variables
 make_chacractl_config
 
+# set chacra variables
+[ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
+[ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
+
 if [[ -f /etc/redhat-release || -f /usr/bin/zypper ]] ; then
         rm -rf ./dist  # Remove any previous artifacts
         mkdir -p $WORKSPACE/dist/noarch
         mkdir -p $WORKSPACE/dist/SRPMS
         mkdir -p $WORKSPACE/dist/SPECS
         mkdir -p $WORKSPACE/dist/SOURCES
+
+        # create the DISTRO and DISTRO_VERSION variables
+        # get_rpm_dist is located in scripts/build_utils.sh
+        get_rpm_dist
+
+        chacra_endpoint="radosgw-agent/${chacra_ref}/${DISTRO}/${DISTRO_VERSION}"
+
+        $VENV/chacractl exists binaries/${chacra_endpoint}/noarch ; exists=$?
+
+        # if the binary already exists in chacra, do not rebuild
+        if [ $exists -eq 0 ] && [ "$FORCE" = false ] ; then
+            echo "The endpoint at ${chacra_endpoint}/noarch already exists and FORCE was not set, Exiting..."
+            exit 0
+        fi
+
         suse=$(uname -n | grep -ic -e suse -e sles || true)
         if [ $suse -gt 0 ]
         then
@@ -31,8 +50,8 @@ if [[ -f /etc/redhat-release || -f /usr/bin/zypper ]] ; then
             python setup.py bdist_rpm
             if [ $? -eq 0 ]
             then
-                mv dist/*.noarch.rpm $WORKSPACE/dist/noarch/.
-                mv dist/*.src.rpm $WORKSPACE/dist/SRPMS
+                find dist -name "*.noarch.rpm" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/noarch
+                find dist -name "*.src.rpm" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
             fi
         else
             python setup.py clean
@@ -45,7 +64,8 @@ if [[ -f /etc/redhat-release || -f /usr/bin/zypper ]] ; then
             if [ $? -ne 0 ] ; then
                 rm -Rvf $WORKSPACE/dist/${DIST}/
             else
-                cp -avf $HOME/rpmbuild/* $WORKSPACE/dist/
+                find $HOME/rpmbuild -name "*.noarch.rpm" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/noarch
+                find $HOME/rpmbuild -name "*.src.rpm" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
             fi
         fi
 else

--- a/radosgw-agent/build/build
+++ b/radosgw-agent/build/build
@@ -73,6 +73,20 @@ else
         DEB_VERSION=$(dpkg-parsechangelog | sed -rne 's,^Version: (.*),\1, p')
         BP_VERSION=${DEB_VERSION}${BPTAG}
         DEBEMAIL="adeza@redhat.com" dch -D $DIST --force-distribution -b -v "$BP_VERSION" "$comment"
+
+        DEB_BUILD=$(lsb_release -s -c)
+        DISTRO=`python -c "exec 'import platform; print platform.linux_distribution()[0].lower()'"`
+
+        chacra_endpoint="radosgw-agent/${chacra_ref}/${DISTRO}/${DEB_BUILD}/noarch"
+
+        $VENV/chacractl exists binaries/${chacra_endpoint} ; exists=$?
+
+        # if the binary already exists in chacra, do not rebuild
+        if [ $exists -eq 0 ] && [ "$FORCE" = false ] ; then
+            echo "The endpoint at ${chacra_endpoint} already exists and FORCE was not set, Exiting..."
+            exit 0
+        fi
+
         dpkg-source -b .
         # we no longer sign the .dsc or .changes files (done by default with
         # the `-k$KEYID` flag), so explicitly tell the tool not to sign them
@@ -80,8 +94,9 @@ else
         RC=$?
         if [ $RC -eq 0 ] ; then
             cd $WORKSPACE
-            mkdir -p dist
-            mv ../*.changes ../*.dsc ../*.deb ../*.tar.gz dist/.
 
+            # push binaries to chacra
+            # the binaries are created in one directory up from $WORKSPACE
+            find ../ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
         fi
 fi

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -65,12 +65,6 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - ../../../scripts/build_utils.sh
             - ../../build/build
 
-    publishers:
-      - archive:
-          artifacts: '*-repo/**, dist/**'
-          allow-empty: true
-          latest-only: false
-
     wrappers:
       - inject-passwords:
           global: true

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -1,6 +1,6 @@
 - job:
     name: radosgw-agent
-    node: trusty
+    node: small && trusty
     project-type: matrix
     defaults: global
     display-name: 'radosgw-agent'

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -47,7 +47,9 @@
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     publishers:
       - archive:

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -54,3 +54,8 @@
           artifacts: '*-repo/**, dist/**'
           allow-empty: true
           latest-only: false
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -19,6 +19,20 @@
           name: RELEASE
           description: "If checked, it will use the key for releases, otherwise it will use the autosign one."
 
+      - bool:
+          name: TEST
+          description: "
+If this is unchecked, then the builds will be pushed to chacra with the correct ref. This is the default.
+
+If this is checked, then the builds will be pushed to chacra under the 'test' ref."
+
+      - bool:
+          name: FORCE
+          description: "
+If this is unchecked, then then nothing is built or pushed if they already exist in chacra. This is the default.
+
+If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
+
     scm:
       - git:
           skip-tag: true

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -80,3 +80,18 @@ get_rpm_dist() {
     esac
 
 }
+
+check_binary_existence () {
+    url=$1
+
+    # we have to use ! here so thet -e will ignore the error code for the command
+    # because of this, the exit code is also reversed
+    ! $VENV/chacractl exists binaries/${url} ; exists=$?
+
+    # if the binary already exists in chacra, do not rebuild
+    if [ $exists -eq 1 ] && [ "$FORCE" = false ] ; then
+        echo "The endpoint at ${chacra_endpoint} already exists and FORCE was not set, Exiting..."
+        exit 0
+    fi
+
+}

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -38,3 +38,45 @@ user = "$CHACRACTL_USER"
 key = "$CHACRACTL_KEY"
 EOF
 }
+
+get_rpm_dist() {
+    # creates a DISTRO_VERSION and DISTRO global variable for
+    # use in constructing chacra urls for rpm distros
+
+    LSB_RELEASE=/usr/bin/lsb_release
+    [ ! -x $LSB_RELEASE ] && echo unknown && exit
+
+    ID=`$LSB_RELEASE --short --id`
+
+    case $ID in
+    RedHatEnterpriseServer)
+        DISTRO_VERSION=`$LSB_RELEASE --short --release | cut -d. -f1`
+        DISTRO=rhel
+        ;;
+    CentOS)
+        DISTRO_VERSION=`$LSB_RELEASE --short --release | cut -d. -f1`
+        DISTRO=centos
+        ;;
+    Fedora)
+        DISTRO_VERSION=`$LSB_RELEASE --short --release`
+        DISTRO=fedora
+        ;;
+    SUSE\ LINUX)
+        DESC=`$LSB_RELEASE --short --description`
+        DISTRO_VERSION=`$LSB_RELEASE --short --release`
+        case $DESC in
+        *openSUSE*)
+                DISTRO=opensuse
+            ;;
+        *Enterprise*)
+                DISTRO=sles
+                ;;
+            esac
+        ;;
+    *)
+        DIST=unknown
+        DISTRO=unknown
+        ;;
+    esac
+
+}


### PR DESCRIPTION
This also moves a few more things into build_utils.sh. I'll make another PR to use those methods in the other jobs that need them.

This branch was tested here: https://jenkins.ceph.com/job/radosgw-agent/8/