### PR TITLE
ansible: add lxml deps for docs.ceph.com builds

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -73,6 +73,8 @@
         - doxygen
         - ditaa
         - ant
+        - libxml2-dev
+        - libxslt1-dev
         # teuthology-docs job:
         - libmysqlclient-dev
         - libevent-dev

--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -103,6 +103,8 @@
         - doxygen
         - ditaa
         - ant
+        - libxml2-dev
+        - libxslt1-dev
         # teuthology-docs job:
         - libmysqlclient-dev
         - libevent-dev


### PR DESCRIPTION
The docs require these two packages in order to build.