### PR TITLE
jenkins-job-builder: add FORCE parameter

### DIFF
--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -12,6 +12,9 @@ set -ex
 virtualenv venv
 . venv/bin/activate
 
+# Wipe out JJB's cache if $FORCE is set.
+[ "$FORCE" = true ] && rm -rf "$HOME/.cache/jenkins_jobs/"
+
 # Define and ensure the PIP cache
 PIP_SDIST_INDEX="$HOME/.cache/pip"
 mkdir -p $PIP_SDIST_INDEX

--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -13,6 +13,14 @@
       - github:
           url: https://github.com/ceph/ceph-build
 
+    parameters:
+      - bool:
+          name: FORCE
+          description: "
+If this is unchecked, then JJB will use its cache to update jobs. This makes this JJB job run faster, but it could cause JJB to fail to update some Jenkins jobs if the jobs have been changed outside of this JJB job's workflow. (This is the default.)
+
+If this is checked, JJB will wipe out its cache and force each job to align with the configurations in master."
+
     triggers:
       - github
 


### PR DESCRIPTION
This will wipe out JJB's cache if set. It is useful for wiping out changes that may have occurred outside of GitHub's master branch.

For example, if I make a change to a job on a local branch, and I apply my JJB changes locally, I want to force this jenkins-job-builder job to wipe out my changes later.