### PR TITLE
ceph-build: separate deb build scripts from rpm build scripts

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -35,12 +35,21 @@
           project: ceph-setup
           filter: 'dist/**'
           which-build: last-successful
+      # general setup
       - shell:
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
+      # debian build scripts
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
             - ../../build/setup_pbuilder
             - ../../build/build_deb
+      # rpm build scripts
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
             - ../../build/build_rpm
 
     publishers:


### PR DESCRIPTION
We need these specific scripts grouped into their own shell directives
so that if setup_deb exits on a centos node then setup_rpm will still be
ran against that same node.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>