### PR TITLE
ceph-deploy: use methods from build_utils.sh

### DIFF
--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -45,13 +45,8 @@ then
         [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
         chacra_endpoint="ceph-deploy/${chacra_ref}/${DISTRO}/${DISTRO_VERSION}"
 
-        $VENV/chacractl exists binaries/${chacra_endpoint}/${ARCH} ; exists=$?
-
-        # if the binary already exists in chacra, do not rebuild
-        if [ $exists -eq 0 ] && [ "$FORCE" = false ] ; then
-            echo "The endpoint at ${chacra_endpoint}/${ARCH} already exists and FORCE was not set, Exiting..."
-            exit 0
-        fi
+        # this exists in scripts/build_utils.sh
+        check_binary_existence $chacra_endpoint/$ARCH
 
         if [ ! -e setup.py ] ; then
             echo "Are we in the right directory"
@@ -93,13 +88,8 @@ then
     [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
     chacra_endpoint="ceph-deploy/${chacra_ref}/${DISTRO}/${DEB_BUILD}/${ARCH}"
 
-    $VENV/chacractl exists binaries/${chacra_endpoint} ; exists=$?
-
-    # if the binary already exists in chacra, do not rebuild
-    if [ $exists -eq 0 ] && [ "$FORCE" = false ] ; then
-        echo "The endpoint at ${chacra_endpoint} already exists and FORCE was not set, Exiting..."
-        exit 0
-    fi
+    # this exists in scripts/build_utils.sh
+    check_binary_existence $chacra_endpoint
 
     if [ ! -d debian ] ; then
         echo "Are we in the right directory"

--- a/ceph-deploy/build/build
+++ b/ceph-deploy/build/build
@@ -34,45 +34,7 @@ then
         # Tag tree and update version number in change log and
         # in setup.py before building.
 
-        get_rpm_dist() {
-            LSB_RELEASE=/usr/bin/lsb_release
-            [ ! -x $LSB_RELEASE ] && echo unknown && exit
-
-            ID=`$LSB_RELEASE --short --id`
-
-            case $ID in
-            RedHatEnterpriseServer)
-                DISTRO_VERSION=`$LSB_RELEASE --short --release | cut -d. -f1`
-                DISTRO=rhel
-                ;;
-            CentOS)
-                DISTRO_VERSION=`$LSB_RELEASE --short --release | cut -d. -f1`
-                DISTRO=centos
-                ;;
-            Fedora)
-                DISTRO_VERSION=`$LSB_RELEASE --short --release`
-                DISTRO=fedora
-                ;;
-            SUSE\ LINUX)
-                DESC=`$LSB_RELEASE --short --description`
-                DISTRO_VERSION=`$LSB_RELEASE --short --release`
-                case $DESC in
-                *openSUSE*)
-                        DISTRO=opensuse
-                    ;;
-                *Enterprise*)
-                        DISTRO=sles
-                        ;;
-                    esac
-                ;;
-            *)
-                DIST=unknown
-                DISTRO=unknown
-                ;;
-            esac
-
-        }
-
+        # this exists in scripts/build_utils.sh
         get_rpm_dist
 
         REPO=rpm-repo

--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -65,7 +65,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             !include-raw:
               - ../../../scripts/build_utils.sh
               - ../../build/setup
-      - shell: !include-raw ../../build/build
+              - ../../build/build
 
     wrappers:
       - inject-passwords:


### PR DESCRIPTION
This branch tested out fine here: https://jenkins.ceph.com/job/ceph-deploy/22/