### PR TITLE
ansible: add jobConfigHistory plugin

### DIFF
--- a/ansible/master.yml
+++ b/ansible/master.yml
@@ -32,6 +32,7 @@
       - 'mask-passwords'
       - 'description-setter'
       - 'postbuildscript'
+      - 'jobConfigHistory'
 
     - port: 8080
     - prefix: '/build'


### PR DESCRIPTION
https://wiki.jenkins-ci.org/display/JENKINS/JobConfigHistory+Plugin

This plugin tracks changes in each job. Among other features, the Build History widget will show an icon of a wrench with the tooltip "Config changed since last build", indicating that the config has changed from one build to the next.