### PR TITLE
remove github notifier

### DIFF
--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -78,6 +78,3 @@
     builders:
       - shell: !include-raw ../../build/setup
       - shell: "cd $WORKSPACE/ceph-deploy && sh scripts/jenkins-pull-requests-build"
-
-    publishers:
-      - github-notifier


### PR DESCRIPTION
Because the GitHub Pull Request Builder plugin handles updating the status

See https://github.com/jenkinsci/ghprb-plugin/issues/104

Signed-off-by: Alfredo Deza <adeza@redhat.com>