### PR TITLE
port ceph-deploy-pull-requests to use new utitlies

### DIFF
--- a/ceph-deploy-pull-requests/build/setup
+++ b/ceph-deploy-pull-requests/build/setup
@@ -1,24 +1,9 @@
 #!/bin/bash
 
-set -ex
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "ansible" "tox" )
+install_python_packages "pkgs[@]"
 
-# Create the virtualenv
-virtualenv venv
-. venv/bin/activate
-
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
-
-# The setup for this job ensures that a copy of ceph-build will be available
-# for this script
-
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible; then
-    venv/bin/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" ansible
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible
-fi
 
 # run ansible to get this current host to meet our requirements, specifying
 # a local connection and 'localhost' as the host where to execute

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -76,5 +76,8 @@
       - ceph-build
 
     builders:
-      - shell: !include-raw ../../build/setup
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/setup
       - shell: "cd $WORKSPACE/ceph-deploy && $WORKSPACE/venv/bin/tox -rv"

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -77,4 +77,4 @@
 
     builders:
       - shell: !include-raw ../../build/setup
-      - shell: "cd $WORKSPACE/ceph-deploy && sh scripts/jenkins-pull-requests-build"
+      - shell: "cd $WORKSPACE/ceph-deploy && $WORKSPACE/venv/bin/tox -rv"


### PR DESCRIPTION
It fixes the issues we've had when the "jenkins" script was not found in ceph-deploy.