### PR TITLE
ceph-build: do not rely on apt-mirror.sepia.ceph.com

### DIFF
--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -31,15 +31,9 @@ os="debian"
 [ "$DIST" = "trusty" ] && os="ubuntu"
 
 if [ $os = "debian" ]; then
-    # We used to consume from an internal mirror
-    # ("http://apt-mirror.sepia.ceph.com/ftp.us.debian.org/debian") but given
-    # that it has caused us issues before (e.g. packages out of date) and that
-    # it currently does not have Jessie we are going to use a public mirror.
     mirror="http://www.gtlib.gatech.edu/pub/debian"
-    othermirror=""
 else
-    mirror=""
-    othermirror="deb http://apt-mirror.sepia.ceph.com/archive.ubuntu.com/ubuntu $DIST main restricted universe multiverse"
+    mirror="http://us.archive.ubuntu.com/ubuntu"
 fi
 
 # ensure that the tgz is valid, otherwise remove it so that it can be recreated
@@ -63,13 +57,11 @@ if [ -e $basedir/$DIST.tgz ]; then
     sudo pbuilder update \
     --basetgz $basedir/$DIST.tgz \
     --distribution $DIST \
-    --mirror "$mirror" \
-    --othermirror "$othermirror"
+    --mirror "$mirror"
 else
     echo building $DIST base.tgz
     sudo pbuilder create \
     --basetgz $basedir/$DIST.tgz \
     --distribution $DIST \
-    --mirror "$mirror" \
-    --othermirror "$othermirror"
+    --mirror "$mirror"
 fi


### PR DESCRIPTION
The pbuilder steps in the ceph-build job relied on apt-mirror.sepia.ceph.com. Remove this dependency, and point at the main alias for the US-based Ubuntu mirrors instead.