### PR TITLE
rm date/time tracking

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -41,7 +41,7 @@ chacra_endpoint="ceph/${chacra_ref}/${distro}/${DIST}/${ARCH}"
 check_binary_existence $chacra_endpoint
 
 HOST=$(hostname --short)
-echo "Building on $(hostname) Date: $(date)"
+echo "Building on $(hostname)"
 echo "  DIST=${DIST}"
 echo "  BPTAG=${BPTAG}"
 echo "  WS=$WORKSPACE"
@@ -107,7 +107,6 @@ releasedir="./release"
 pbuilddir="/srv/debian-base"
 cephver=$vers
 
-start_time=`date`
 echo version $cephver
 
 # This used to live in a *file* on /src/ceph-build. Now it lives here because
@@ -167,13 +166,7 @@ bpvers=`gen_debian_version $dvers $DIST`
 echo lintian checks for $bpvers
 echo lintian --allow-root $releasedir/$cephver/*$bpvers*.deb
 
-echo "Start Time = $start_time"
-echo "  End Time = $(date)"
-
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 
 # push binaries to chacra
 find release/$vers/ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
-
-
-echo "End Date: $(date)"

--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -67,7 +67,7 @@ chacra_baseurl="ceph/${chacra_ref}/${DISTRO}/${RELEASE}"
 check_binary_existence $chacra_baseurl/$ARCH
 
 HOST=$(hostname --short)
-echo "Building on $(hostname) Date: $(date)"
+echo "Building on $(hostname)"
 echo "  DIST=${DIST}"
 echo "  BPTAG=${BPTAG}"
 echo "  WS=$WORKSPACE"
@@ -117,5 +117,3 @@ cd "$WORKSPACE"
 # push binaries to chacra
 find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_baseurl}/source
 find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_baseurl}/${ARCH}
-
-echo "End Date: $(date)"

--- a/ceph-build/build/setup
+++ b/ceph-build/build/setup
@@ -13,7 +13,7 @@
 #
 set -ex
 HOST=$(hostname --short)
-echo "Building on $(hostname) Date: $(date)"
+echo "Building on $(hostname)"
 echo "  DIST=${DIST}"
 echo "  BPTAG=${BPTAG}"
 echo "  KEYID=${KEYID}"

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -6,7 +6,7 @@ echo "  DIST=${DIST}"
 echo "  BPTAG=${BPTAG}"
 echo "  WS=$WORKSPACE"
 echo "  PWD=$(pwd)"
-echo "Building on Host: $(hostname) Date: $(date)"
+echo "Building on Host: $(hostname)"
 
 # remove any previous builds
 rm -rf dist


### PR DESCRIPTION
Prior to this commit, some of the build scripts would print the time and date to the console log.

As far as I can tell this is a hold-over from the original Gitbuilder scripts. Jenkins already logs the start and end times for us so there's no need to clutter the build scripts with this.

Remove the code that prints `date`.