### PR TITLE
jenkins-job-builder: set default value for FORCE param

### DIFF
--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -16,6 +16,7 @@
     parameters:
       - bool:
           name: FORCE
+          default: false
           description: "
 If this is unchecked, then JJB will use its cache to update jobs. This makes this JJB job run faster, but it could cause JJB to fail to update some Jenkins jobs if the jobs have been changed outside of this JJB job's workflow. (This is the default.)
 


### PR DESCRIPTION
It's not totally clear from the JJB documentation whether we need this or not, but I'm seeing an issue with our helga-jenkins plugin when we leave this parameter out of the "!ci build jenkins-job-builder" invocation.  Explicitly set a default, just to see if this makes a difference.