### PR TITLE
jenkins-job-builder: run on "small" nodes

### DIFF
--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -1,6 +1,6 @@
 - job:
     name: jenkins-job-builder
-    node: trusty
+    node: small && trusty
     project-type: freestyle
     defaults: global
     display-name: 'Jenkins Job Builder'


### PR DESCRIPTION
To avoid running on huge / arm nodes.