### PR TITLE
prado playbook updates

### DIFF
--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -124,7 +124,7 @@
         path: '/etc/ssh/ssh_known_hosts'
         name: 'github.com'
         # github.com.pub is the output of `ssh-keyscan github.com`
-        key: "{{ lookup('file', 'ssh/hostkeys/github.com.pub') }}"
+        key: "{{ lookup('file', 'playbook/files/ssh/hostkeys/github.com.pub') }}"
 
     - name: register the new slave to jenkins master
       jenkins-node:

--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -122,7 +122,8 @@
       sudo: true
       known_hosts:
         path: '/etc/ssh/ssh_known_hosts'
-        name: 'github.com'
+        # we need to use 'host' here because prado currently uses ansible-playbook==1.9.1
+        host: 'github.com'
         # github.com.pub is the output of `ssh-keyscan github.com`
         key: "{{ lookup('file', 'playbook/files/ssh/hostkeys/github.com.pub') }}"
 


### PR DESCRIPTION
Fixes the path to the github.com.pub file and makes a fix for ansible-playbook==1.9.1 version compatibility.