### PR TITLE
teuthology-pull-requests: change node to trusty&&amd64&&small

### DIFF
--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -1,6 +1,6 @@
 - job:
     name: teuthology-pull-requests 
-    node: trusty
+    node: trusty && amd64 && small
     project-type: freestyle
     defaults: global
     display-name: 'Teuthology: Pull Requests'


### PR DESCRIPTION
This fixes a bug where the job incorrectly picks an arm64 node, which
does not compile gevent correctly causing the job to fail.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>