### PR TITLE
implement a ceph-deploy-tag job

### DIFF
--- a/ceph-deploy-tag/build/build
+++ b/ceph-deploy-tag/build/build
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+if [ "$TAG" = false ] ; then
+    echo "Assuming tagging process has succeeded before because TAG was set to false"
+    exit 0
+fi
+
+# Create the virtualenv
+virtualenv venv
+. venv/bin/activate
+
+# Define and ensure the PIP cache
+PIP_SDIST_INDEX="$HOME/.cache/pip"
+mkdir -p $PIP_SDIST_INDEX
+
+# The setup for this job ensures that a copy of ceph-build will be available
+# for this script
+
+# Install the package by trying with the cache first, otherwise doing a download only, and then
+# trying to install from the cache again.
+if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible; then
+    venv/bin/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" ansible
+    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible
+fi
+
+# run ansible to do all the tagging and release specifying
+# a local connection and 'localhost' as the host where to execute
+cd "$WORKSPACE/ceph-build/ansible/"
+ansible-playbook -i "localhost," -c local release.yml --extra-vars="version=$VERSION branch=$BRANCH release=stable clean=true project=ceph-deploy"

--- a/ceph-deploy-tag/build/build
+++ b/ceph-deploy-tag/build/build
@@ -7,23 +7,9 @@ if [ "$TAG" = false ] ; then
     exit 0
 fi
 
-# Create the virtualenv
-virtualenv venv
-. venv/bin/activate
-
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
-
-# The setup for this job ensures that a copy of ceph-build will be available
-# for this script
-
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible; then
-    venv/bin/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" ansible
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible
-fi
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "ansible" )
+install_python_packages "pkgs[@]"
 
 # run ansible to do all the tagging and release specifying
 # a local connection and 'localhost' as the host where to execute

--- a/ceph-deploy-tag/config/definitions/ceph-tag.yml
+++ b/ceph-deploy-tag/config/definitions/ceph-tag.yml
@@ -1,0 +1,52 @@
+- scm:
+    name: ceph-build
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-build.git
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+          basedir: "ceph-build"
+
+- job:
+    name: ceph-deploy-tag
+    description: "This job clones ceph-deploy and sets the right version from the tag, pushing back to ceph-deploy.git"
+    display-name: 'ceph-deploy-tag'
+    logrotate:
+      daysToKeep: -1
+      numToKeep: 25
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+    block-downstream: false
+    block-upstream: false
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-deploy
+
+    parameters:
+      - string:
+          name: BRANCH
+          description: "The git branch (or tag) to build"
+          default: "master"
+      - string:
+          name: VERSION
+          description: "The version for release, e.g. 1.5.30"
+    scm:
+      - ceph-build
+
+    wrappers:
+      - ssh-agent-credentials:
+          users:
+            # "jenkins-build" SSH key, needed so we can push to
+            # ceph-deploy.git
+            - '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
+
+    builders:
+      - shell:
+          !include-raw ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true

--- a/ceph-deploy-tag/config/definitions/ceph-tag.yml
+++ b/ceph-deploy-tag/config/definitions/ceph-tag.yml
@@ -44,7 +44,9 @@
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     wrappers:
       - inject-passwords:

--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -13,11 +13,8 @@
     parameters:
       - string:
           name: BRANCH
-          description: "The git branch or tag to build"
-
-      - bool:
-          name: RELEASE
-          description: "If checked, it will use the key for releases, otherwise it will use the autosign one."
+          description: "The git branch or tag to build. Defaults to master"
+          default: "master"
 
       - bool:
           name: TEST
@@ -27,11 +24,21 @@ If this is unchecked, then the builds will be pushed to chacra with the correct 
 If this is checked, then the builds will be pushed to chacra under the 'test' ref."
 
       - bool:
+          name: TAG
+          description: "When this is checked, Jenkins will remove the previous tag and recreate it again, changing the control files and committing again. When this is unchecked, Jenkins will not do any commit or tag operations. If you've already created the private tag separately, then leave this unchecked.
+Defaults to checked."
+          default: true
+
+      - bool:
           name: FORCE
           description: "
 If this is unchecked, then then nothing is built or pushed if they already exist in chacra. This is the default.
 
 If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
+
+      - string:
+          name: VERSION
+          description: "The version for release, e.g. 0.94.4"
 
     scm:
       - git:
@@ -61,6 +68,14 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - centos7
 
     builders:
+      - multijob:
+          name: 'ceph-deploy tag phase'
+          condition: SUCCESSFUL
+          projects:
+            - name: ceph-deploy-tag
+              current-parameters: true
+              exposed-scm: false
+
       - shell:
             !include-raw:
               - ../../../scripts/build_utils.sh


### PR DESCRIPTION
So that it runs before the actual ceph-deploy release job, using the new ansible playbooks and allowing us to basically release with a single, push-button action.