### PR TITLE
fix project type to multijob

### DIFF
--- a/ceph-deploy/config/definitions/ceph-deploy.yml
+++ b/ceph-deploy/config/definitions/ceph-deploy.yml
@@ -1,7 +1,6 @@
 - job:
     name: ceph-deploy
-    node: small && trusty
-    project-type: matrix
+    project-type: multijob
     defaults: global
     display-name: 'ceph-deploy'
     concurrent: true


### PR DESCRIPTION
because ceph-deploy is no longer a matrix job, but rather, a multijob. This should now really fix how ceph-deploy looks in jenkins