### PR TITLE
remove redundant slaves from matrix

### DIFF
--- a/ceph-deploy-build/config/definitions/ceph-deploy-build.yml
+++ b/ceph-deploy-build/config/definitions/ceph-deploy-build.yml
@@ -30,8 +30,6 @@
           type: label-expression
           name: DIST
           values:
-            - wheezy
-            - precise
             - trusty
             - jessie
             - centos6


### PR DESCRIPTION
since we are building 'generic' ceph-deploy, we really need 1 for ubuntu and 1 for debian. We could do 1 for both but it might be odd to push them just for debian and not ubuntu and vice versa 

For now we push to both. This doesn't affect the repo building because it will just skip it if it already exists