### PR TITLE
Ssh user fix

### DIFF
--- a/ceph-deploy-tag/config/definitions/ceph-tag.yml
+++ b/ceph-deploy-tag/config/definitions/ceph-tag.yml
@@ -37,10 +37,9 @@
 
     wrappers:
       - ssh-agent-credentials:
-          users:
-            # "jenkins-build" SSH key, needed so we can push to
-            # ceph-deploy.git
-            - '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
+          # "jenkins-build" SSH key, needed so we can push to
+          # ceph-deploy.git
+          user: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
 
     builders:
       - shell:

--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -36,10 +36,9 @@
 
     wrappers:
       - ssh-agent-credentials:
-          users:
-            # "jenkins-build" SSH key, needed so we can push to
-            # ceph-releases.git
-            - '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
+          # "jenkins-build" SSH key, needed so we can push to
+          # ceph-deploy.git
+          user: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
 
     builders:
       - shell:


### PR DESCRIPTION
According to docs we were using an old style of configuring the ssh-credentials plugin:

    The users with one value in list equals to the user. In this case old style XML will be generated. Use this format if you use SSH-Agent plugin < 1.5.

https://jenkins-job-builder.readthedocs.org/en/latest/wrappers.html#wrappers.ssh-agent-credentials

For some reason this meant that the credentials was not being used making tagging/cloning fail