### PR TITLE
safer check for previously tagged 

### DIFF
--- a/ansible/release.yml
+++ b/ansible/release.yml
@@ -6,6 +6,7 @@
     version: 0-dev # e.g. 0.78
     branch: master # any existing branch on Github
     release: stable # stable, development, or rc are valid options
+    tag_name: "v{{ version}}"
     project: "ceph"
     clean: true # if re-doing a deployment this deletes the remote branch in Jenkin's git repo
     force_dch: false # if coming from a rc and wanting to release a stable you need to force dch

--- a/ansible/roles/ceph-deploy-release/tasks/clear_version.yml
+++ b/ansible/roles/ceph-deploy-release/tasks/clear_version.yml
@@ -2,7 +2,7 @@
 
 - name: undo last commit from failed release
   command: git reset --soft HEAD~1 chdir=ceph-deploy
-  when: (clean and version in last_commit.stdout)
+  when: (clean and last_commit.stdout == tag_name)
 
 - name: git checkout {{ branch }} branch
   command: git checkout {{ branch }} chdir=ceph-deploy

--- a/ansible/roles/ceph-deploy-release/tasks/main.yml
+++ b/ansible/roles/ceph-deploy-release/tasks/main.yml
@@ -26,10 +26,10 @@
   # that will rollback that commit, delete the local and remote tag, and force
   # push the new changes
 - include: clear_version.yml
-  when: (clean and version in last_commit.stdout)
+  when: (clean and last_commit.stdout == tag_name)
 
   # if the last commit wasn't one that we already did, then go ahead and make
   # the changes + tag for the release. Otherwise, just skip because it was
   # already done for this release
 - include: release.yml
-  when: (version not in last_commit.stdout)
+  when: (tag_name != last_commit.stdout)


### PR DESCRIPTION
otherwise we are going to be doing a reset to revert back to the previous commit for no reason if the version appears in the commit message (the case before this PR)