### PR TITLE
pull requests that need to be concurrent

### DIFF
--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -3,6 +3,7 @@
     node: trusty
     project-type: freestyle
     defaults: global
+    concurrent: true
     display-name: 'ceph-build: Pull Requests'
     quiet-period: 5
     block-downstream: false

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -32,6 +32,7 @@
     node: trusty
     project-type: freestyle
     defaults: global
+    concurrent: true
     display-name: 'ceph-deploy: Pull Requests'
     quiet-period: 5
     block-downstream: false

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -3,6 +3,7 @@
     node: trusty
     project-type: freestyle
     defaults: global
+    concurrent: true
     display-name: 'ceph-qa-suite: Pull Requests'
     quiet-period: 5
     block-downstream: false

--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -3,6 +3,7 @@
     node: trusty && amd64 && small
     project-type: freestyle
     defaults: global
+    concurrent: true
     display-name: 'Teuthology: Pull Requests'
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
Most pull request jobs need to be concurrent. This is because projects that have lots of pull requests will otherwise pile up waiting for the previous check to be finished.

The low-traffic PR jobs like the radosgw-agent have not been updated.