### PR TITLE
make sure that venv is always removed prior to creating it

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -14,6 +14,7 @@ install_python_packages () {
     #   install_python_packages "to_install[@]"
 
     # Create the virtualenv
+    rm -rf "$WORKSPACE/venv"
     virtualenv $WORKSPACE/venv
 
     # Define and ensure the PIP cache


### PR DESCRIPTION
Because otherwise it causes issues when re-using it (jenkins doesn't wipe this out).

There is a plugin that wipes out top-level $WORKSPACE but that would also mean going through each project that uses the build script (vs. just fixing it there)