### PR TITLE
reconfigure ceph-pr-commits 

### DIFF
--- a/ceph-pr-commits/build/build
+++ b/ceph-pr-commits/build/build
@@ -1,60 +1,9 @@
-#!/usr/bin/env python
-from subprocess import Popen, PIPE
-import os
+#!/bin/bash
 
-target_branch = os.getenv('ghprbTargetBranch', 'master')
-source_branch = os.getenv('ghprbSourceBranch', 'HEAD')
-
-command = ['git', 'log', '--no-merges', '%s..%s' % (target_branch, source_branch)]
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "pytest" )
+install_python_packages "pkgs[@]"
 
 
-process = Popen(
-    command,
-    stdout=PIPE,
-    stderr=PIPE,
-    close_fds=True
-)
-
-returncode = process.wait()
-
-stdout = process.stdout.read()
-stderr = process.stderr.read()
-
-
-def produce_junit(**kw):
-    time = kw.get('time', 0)
-    tests = kw.get('tests', [])
-    failures = kw.get('failures', [])
-    total_tests = len(tests) or 1
-    total_failures = len(failures)
-    template = """<?xml version="1.0" encoding="utf-8"?>
-<testsuite errors="0" failures="{total_failures}" name="Signed-off-by" skips="0" tests="{total_tests}" time="0">
-</testsuite>
-    """.format(total_failures=total_failures, total_tests=total_tests)
-    path = os.path.join(os.getenv("$WORKSPACE", ""), 'report.xml')
-    print template
-    with open(path, 'w') as junit_file:
-        junit_file.write(template)
-
-
-def extract_sha(lines):
-    trim = lines.split()
-    for i in trim:
-        if i and 'commit' not in i:
-            return i
-
-# git log output goes to stdout so process that
-tests = []
-failures = []
-for chunk in stdout.split('\n\ncommit'): # we are interested in every commit chunk
-    if not chunk:
-        continue
-    tests.append(1)
-    if not 'Signed-off-by:' in chunk:
-        sha = extract_sha(chunk)
-        failures.append(sha)
-
-produce_junit(tests=tests, failures=failures)
-
-if failures:
-    raise SystemExit('A commit is missing "Signed-off-by". sha: %s' % sha)
+cd "$WORKSPACE/ceph-build/ceph-pr-commits/build"
+$VENV/py.test -v --junit="$WORKSPACE/report.xml"

--- a/ceph-pr-commits/build/test_commits.py
+++ b/ceph-pr-commits/build/test_commits.py
@@ -1,0 +1,49 @@
+from subprocess import Popen, PIPE
+import os
+
+
+def run(command):
+    path = os.getenv('WORKSPACE', '../../../ceph')
+    print "running %s" % ' '.join(command)
+    print "at path: %s" % os.path.abspath(path)
+    process = Popen(
+        command,
+        cwd=path,
+        stdout=PIPE,
+        stderr=PIPE,
+        close_fds=True
+    )
+
+    returncode = process.wait()
+
+    return process.stdout.read()
+
+
+def get_commits():
+    target_branch = os.getenv('ghprbTargetBranch', 'master')
+    source_branch = os.getenv('ghprbSourceBranch', 'HEAD')
+    command = ['git', 'log', '--no-merges', '%s..%s' % (target_branch, source_branch)]
+    output = run(command)
+    chunked_commits = []
+    for chunk in output.split('\n\ncommit'):
+        if not chunk:
+            continue
+        chunked_commits.append(chunk)
+    return chunked_commits
+
+
+commits = get_commits()
+
+
+class TestSignedOffByCommits(object):
+
+    def test_signed_off_by('commit', commits):
+        assert 'Signed-off-by:' in commit
+
+    def extract_sha(self, lines):
+        # XXX Unused for now, if py.test can spit out the hashes in verbose
+        # mode this should be removed, otherwise put to good use
+        trim = lines.split()
+        for i in trim:
+            if i and 'commit' not in i:
+                return i

--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -1,3 +1,29 @@
+- scm:
+    name: ceph
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph.git
+          branches:
+            - ${sha1}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: false
+          basedir: "ceph"
+
+- scm:
+    name: ceph-build
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-build.git
+          browser-url: https://github.com/ceph/ceph-build
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: false
+          basedir: "ceph-build"
+
+
 - job:
     name: ceph-pr-commits
     project-type: freestyle
@@ -37,19 +63,15 @@
           failure-status: "one or more commits in this PR are not signed"
 
     scm:
-      - git:
-          url: https://github.com/ceph/ceph.git
-          branches:
-            - ${sha1}
-          refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: auto
-          timeout: 20
-          skip-tag: true
-          wipe-workspace: true
+      - ceph
+      - ceph-build
+
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     publishers:
       - junit:


### PR DESCRIPTION
So that they can just use py.test and spit out the report.xml file