### PR TITLE
ceph pr fixes

### DIFF
--- a/ceph-pr-commits/build/build
+++ b/ceph-pr-commits/build/build
@@ -6,4 +6,4 @@ install_python_packages "pkgs[@]"
 
 
 cd "$WORKSPACE/ceph-build/ceph-pr-commits/build"
-$VENV/py.test -v --junit="$WORKSPACE/report.xml"
+$VENV/py.test -v --junitxml="$WORKSPACE/report.xml"

--- a/ceph-pr-commits/build/test_commits.py
+++ b/ceph-pr-commits/build/test_commits.py
@@ -1,5 +1,6 @@
 from subprocess import Popen, PIPE
 import os
+import pytest
 
 
 def run(command):
@@ -37,7 +38,8 @@ commits = get_commits()
 
 class TestSignedOffByCommits(object):
 
-    def test_signed_off_by('commit', commits):
+    @pytest.mark.parametrize('commit', commits)
+    def test_signed_off_by(self, commit):
         assert 'Signed-off-by:' in commit
 
     def extract_sha(self, lines):

--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -17,6 +17,8 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph-build.git
+          branches:
+            - origin/master
           browser-url: https://github.com/ceph/ceph-build
           timeout: 20
           skip-tag: true


### PR DESCRIPTION
So that we use the master branch in ceph-build (it was defaulting to something else, because it was not specified).

It fixes the junit flag used in py.test and fixes the correct parametrize invocation.