### PR TITLE
Path fixes

### DIFF
--- a/ceph-pr-commits/build/build
+++ b/ceph-pr-commits/build/build
@@ -5,5 +5,5 @@ pkgs=( "pytest" )
 install_python_packages "pkgs[@]"
 
 
-cd "$WORKSPACE/ceph-build/ceph-pr-commits/build"
-$VENV/py.test -v --junitxml="$WORKSPACE/report.xml"
+cd "$WORKSPACE"
+$VENV/py.test -v --junitxml="$WORKSPACE/report.xml" "$WORKSPACE/ceph-build/ceph-pr-commits/build/test_commits.py"

--- a/ceph-pr-commits/build/test_commits.py
+++ b/ceph-pr-commits/build/test_commits.py
@@ -1,15 +1,22 @@
 from subprocess import Popen, PIPE
 import os
+from os.path import dirname
 import pytest
+
+# ceph-pr-commits/build
+current_directory = dirname(os.path.abspath(__file__))
+
+# workspace directory
+workspace = os.getenv('WORKSPACE', None) or dirname(dirname(dirname(current_directory)))
+
+# ceph checkout path
+ceph_checkout = os.path.join(workspace, 'ceph')
 
 
 def run(command):
-    path = os.getenv('WORKSPACE', '../../../ceph')
-    print "running %s" % ' '.join(command)
-    print "at path: %s" % os.path.abspath(path)
     process = Popen(
         command,
-        cwd=path,
+        cwd=ceph_checkout,
         stdout=PIPE,
         stderr=PIPE,
         close_fds=True


### PR DESCRIPTION
For ceph-pr-commits. We were getting a bunch of "skipped" tests because we were looking in the wrong path for commits 