### PR TITLE
ceph-pull-requests: use a postbuildscript to only reboot on failure

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -47,7 +47,11 @@
 
     builders:
       - shell: "./run-make-check.sh"
-      - shell: "sudo reboot"
 
     publishers:
       - github-notifier
+      - postbuildscript:
+          script-only-if-succeeded: False
+          script-only-if-failed: True
+          builders:
+            - shell: "sudo reboot"


### PR DESCRIPTION
This way we can report the correct status to github and still reboot the node on failure.  Before this change the node would never reboot if the make check failed.