### PR TITLE
default to number of executors to just 1

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -104,3 +104,5 @@
         host: "{{ ansible_default_ipv4.address }}"
         credentialsId: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
         remoteFS: '/home/{{ jenkins_user }}/build'
+        # XXX this should be configurable, not all nodes should have one executor
+        executors: 1

--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -140,3 +140,5 @@
         host: "{{ ansible_default_ipv4.address }}"
         credentialsId: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
         remoteFS: '/home/{{ jenkins_user }}/build'
+        # XXX this should be configurable, not all nodes should have one executor
+        executors: 1


### PR DESCRIPTION
So that we don't get nodes rebooted by script like make-check.sh while we are doing a release.

This is why rebooting a node because a test requires it is not just a matter of slapping "sudo reboot" on a script.

This option should at some point be made optional so that mita can toggle it with `huge` nodes only.