### PR TITLE
ceph-pr-commits: only check for divergent commits from master

### DIFF
--- a/ceph-pr-commits/build/test_commits.py
+++ b/ceph-pr-commits/build/test_commits.py
@@ -32,7 +32,7 @@ def get_commits():
     target_branch = os.getenv('ghprbTargetBranch', 'master')
     # we use 'HEAD' here because the PR is already checked out on the right branch
     source_branch = 'HEAD'
-    command = ['git', 'log', '--no-merges', 'origin/%s..%s' % (target_branch, source_branch)]
+    command = ['git', 'log', '--no-merges', '^origin/%s %s' % (target_branch, source_branch)]
     output = run(command)
     chunked_commits = []
     for chunk in output.split('\n\ncommit'):


### PR DESCRIPTION
We are currently checking all the commits, which causes failure due to
a single commit that wasnt signed. Check only the commits in the pr vs
master for now

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>