### PR TITLE
ceph-ansible-pull-requests: activate the venv for the version check

### DIFF
--- a/ceph-ansible-pull-requests/build/build
+++ b/ceph-ansible-pull-requests/build/build
@@ -4,6 +4,9 @@
 pkgs=( "ansible" )
 install_python_packages "pkgs[@]"
 
+# ceph-ansible does a check on the installed version of ansible and
+# without our virtualenv activated it can not find it and fails
+source $VENV/activate
 
 cd "$WORKSPACE"/ceph-ansible
 $VENV/ansible-playbook -i "localhost," -c local test.yml


### PR DESCRIPTION
If we don't activate our virtualenv ceph-ansible can not find ansible to
perform its version check and fails.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>