### PR TITLE
always destroy the slave after a ceph-ansible-pull-requests job

### DIFF
--- a/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
+++ b/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
@@ -63,7 +63,7 @@
     publishers:
       - github-notifier
       - postbuildscript:
-          script-only-if-succeeded: True
-          script-only-if-failed: True
+          script-only-if-succeeded: False
+          script-only-if-failed: False
           builders:
             - shell: !include-raw ../../build/teardown


### PR DESCRIPTION
Setting both script-only-if-succeeded and script-only-if-failed to True
makes is so that this postbuildscript is never ran.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>