### PR TITLE
ceph-ansible-pull-requests: use json for --extra-vars

### DIFF
--- a/ceph-ansible-pull-requests/build/build
+++ b/ceph-ansible-pull-requests/build/build
@@ -9,4 +9,4 @@ install_python_packages "pkgs[@]"
 source $VENV/activate
 
 cd "$WORKSPACE"/ceph-ansible
-$VENV/ansible-playbook -vv -i tests/inventories/single-machine.yml -c local test.yml --extra-vars="osd_auto_discovery=true ceph_stable=true journal_collocation=true journal_size=1024 monitor_interface=ETH cluster_network=127.0.0.1/0 public_network=127.0.0.1/0"
+$VENV/ansible-playbook -vv -i tests/inventories/single-machine.yml -c local test.yml --extra-vars='{"devices":["/dev/vdb"], "ceph_stable":true, "journal_collocation":true, "journal_size":1024, "monitor_interface":"eth1", "cluster_network":"127.0.0.1/0", "public_network":"127.0.0.1/0"}'


### PR DESCRIPTION
This allows us to pass a list of devices to --extra-vars. The key=value
method of using --extra-vars doesn't allow for complex data types like a
list or a hash.

This also sets monitor_interface to eth1

Signed-off-by: Andrew Schoen <aschoen@redhat.com>