### PR TITLE
Adds a new job to update the ceph-ansible galaxy repos on merge

### DIFF
--- a/ceph-ansible-galaxy/build/build
+++ b/ceph-ansible-galaxy/build/build
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# the following method exists in scripts/build_utils.sh
+pkgs=( "ansible" )
+install_python_packages "pkgs[@]"
+
+cd "$WORKSPACE"/ceph-ansible
+# propagates the change in the necessary Ansible Galaxy repos.
+# i.e. https://github.com/ceph/ansible-ceph-common
+$VENV/ansible-playbook -i dummy-ansible-hosts contrib/splitup.yml --tags update 

--- a/ceph-ansible-galaxy/config/definitions/ceph-ansible-galaxy.yml
+++ b/ceph-ansible-galaxy/config/definitions/ceph-ansible-galaxy.yml
@@ -1,0 +1,36 @@
+- job:
+    name: ceph-ansible-galaxy 
+    node: small && trusty 
+    project-type: freestyle
+    defaults: global
+    display-name: 'ceph-ansible: Update galaxy roles'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-ansible
+    logrotate:
+      daysToKeep: -1
+      numToKeep: -1
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    triggers:
+      - github
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-ansible.git
+          branches:
+            - master
+          browser: auto
+          basedir: "ceph-ansible"
+          timeout: 20
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build


### PR DESCRIPTION
When new code is merged to master of ceph-ansible a command is run to
update the individual role repos with the changes for Ansible Galaxy.

See the first request of https://github.com/ceph/ceph-ansible/issues/507

Signed-off-by: Andrew Schoen <aschoen@redhat.com>