### PR TITLE
ceph-ansible-pull-requests: remove os_tuning_params from extra-vars

### DIFF
--- a/ceph-ansible-pull-requests/build/build
+++ b/ceph-ansible-pull-requests/build/build
@@ -16,9 +16,6 @@ journal_size=1024
 monitor_interface="eth0"
 cluster_network="127.0.0.1/0"
 public_network="127.0.0.1/0"
-# the default settings include a setting for vm.min_free_kbytes which asks
-# for more memory than our jenkins slaves allow, so we remove it here
-os_tuning_params='[{"name": "kernel.pid_max", "value": 4194303},{"name": "fs.file-max", "value": 26234859}]'
 fsid="4a158d27-f750-41d5-9e7f-26ce4c9d2d45"
 monitor_secret="AQAWqilTCDh7CBAAawXt6kyTgLFCxSvJhTEmuw=="
 
@@ -31,7 +28,6 @@ cat > $HOME/test-vars.json << EOF
     "monitor_interface":"$monitor_interface",
     "cluster_network":"$cluster_network",
     "public_network":"$cluster_network",
-    "os_tuning_params":$os_tuning_params,
     "fsid":"$fsid",
     "monitor_secret":"$monitor_secret"
 }


### PR DESCRIPTION
The value in os_tuning_params that set vm.min_free_kybtes used to lock
up our testing slaves so we removed it from this job. However,
ceph-ansible is now attempting to auto calculate this.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>