### PR TITLE
include the build utils for ceph-installer prs

### DIFF
--- a/ceph-installer-pull-requests/config/definitions/ceph-installer-pull-requests.yml
+++ b/ceph-installer-pull-requests/config/definitions/ceph-installer-pull-requests.yml
@@ -52,7 +52,9 @@
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     publishers:
       - github-notifier


### PR DESCRIPTION
So that it doesn't break like:

    [ceph-installer-pull-requests] $ /bin/bash /tmp/hudson6743631504151945894.sh
    /tmp/hudson6743631504151945894.sh: line 5: install_python_packages: command not found
    /tmp/hudson6743631504151945894.sh: line 7: /tox: No such file or directory
    Build step 'Execute shell' marked build as failure