### PR TITLE
ceph-installer coverage

### DIFF
--- a/ceph-installer-coverage/build/build
+++ b/ceph-installer-coverage/build/build
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "pytest" "pytest-coverage" )
+install_python_packages "pkgs[@]"
+
+
+# run py.test, output both junit from unit tests and coverage report (should
+# spit out a coverage.xml file)
+$VENV/py.test -v  --junitxml junit.xml --cov-report xml --cov ceph_installer

--- a/ceph-installer-coverage/config/definitions/ceph-installer-coverage.yml
+++ b/ceph-installer-coverage/config/definitions/ceph-installer-coverage.yml
@@ -1,9 +1,9 @@
 - job:
-    name: ceph-installer-merged
+    name: ceph-installer-coverage
     node: small && (trusty || centos)
     project-type: freestyle
     defaults: global
-    display-name: 'ceph-installer: master merge build'
+    display-name: 'ceph-installer: coverage'
     quiet-period: 5
     block-downstream: false
     block-upstream: false

--- a/ceph-installer-coverage/config/definitions/ceph-installer-merged.yml
+++ b/ceph-installer-coverage/config/definitions/ceph-installer-merged.yml
@@ -1,0 +1,47 @@
+- job:
+    name: ceph-installer-merged
+    node: small && (trusty || centos)
+    project-type: freestyle
+    defaults: global
+    display-name: 'ceph-installer: master merge build'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-installer
+    logrotate:
+      daysToKeep: -1
+      numToKeep: 10
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    triggers:
+      - github
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-installer
+          branches:
+            - master
+          browser: auto
+          skip-tag: true
+          timeout: 20
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+
+    publishers:
+      - cobertura:
+          results: coverage.xml
+          only-stable: "true"
+          fail-no-reports: "true"
+          targets:
+            - method:
+                healthy: 50
+      - junit:
+          results: junit.xml


### PR DESCRIPTION
It will create two reports: junit report from py.test and coverage report from pytest-coverage

Should run only on merges to master (similar to when we build docs)