### PR TITLE
set the CEPH_BUILD_VIRTUALENV environment variable for ceph jobs

### DIFF
--- a/ceph/config/definitions/ceph.yml
+++ b/ceph/config/definitions/ceph.yml
@@ -51,6 +51,11 @@ If this is checked, binaries will be pushed to chacra using the $BRANCH-rc name,
 Defaults to un-checked"
           default: false
 
+      - string:
+          name: CEPH_BUILD_VIRTUALENV
+          description: "Base parent path for virtualenv locations, set to avoid issues with extremely long paths that are incompatible with tools like pip. Defaults to '/tmp'."
+          default: "/tmp"
+
     builders:
       - multijob:
           name: 'ceph tag phase'


### PR DESCRIPTION
Will be consumed by this change: https://github.com/ceph/ceph/pull/8250

For older builds it doesn't cause issues, it is just an environment variable 