### PR TITLE
ceph-setup-arm64: tweaks for building unreleased branches

### DIFF
--- a/ceph-setup-arm64/build/build
+++ b/ceph-setup-arm64/build/build
@@ -84,9 +84,6 @@ echo current version $cephver
 
 srcdir=`pwd`
 
-if [ -d "$releasedir/$cephver" ]; then
-    echo "$releasedir/$cephver already exists; reuse that release tarball"
-else
     echo building tarball
     rm ceph-*.tar.gz || true
     rm ceph-*.tar.bz2 || true
@@ -97,25 +94,23 @@ else
     echo tarball vers $vers
 
     echo extracting
-    mkdir -p $releasedir/$cephver/rpm
-    cp rpm/*.patch $releasedir/$cephver/rpm || true
-    cd $releasedir/$cephver
+    mkdir -p $releasedir/$vers/rpm
+    cp rpm/*.patch $releasedir/$vers/rpm || true
+    cd $releasedir/$vers
 
     tar zxf $srcdir/ceph-$vers.tar.gz
-    [ "$vers" != "$cephver" ] && mv ceph-$vers ceph-$cephver
 
-    tar zcf ceph_$cephver.orig.tar.gz ceph-$cephver
-    cp -a ceph_$cephver.orig.tar.gz ceph-$cephver.tar.gz
+    tar zcf ceph_$vers.orig.tar.gz ceph-$vers
+    cp -a ceph_$vers.orig.tar.gz ceph-$vers.tar.gz
 
-    tar jcf ceph-$cephver.tar.bz2 ceph-$cephver
+    tar jcf ceph-$vers.tar.bz2 ceph-$vers
 
     # copy debian dir, too
     cp -a $srcdir/debian debian
     cd $srcdir
 
     # copy in spec file, too
-    cp ceph.spec $releasedir/$cephver
-fi
+    cp ceph.spec $releasedir/$vers
 
 if [ -n "$versionfile" ]; then
     echo $cephver > $versionfile

--- a/ceph-setup-arm64/config/definitions/ceph-setup.yml
+++ b/ceph-setup-arm64/config/definitions/ceph-setup.yml
@@ -23,7 +23,7 @@
 
     scm:
       - git:
-          url: git@github.com:ceph/ceph-releases.git
+          url: git@github.com:ceph/ceph.git
           # Use the SSH key attached to the ceph-jenkins GitHub account.
           credentials-id: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
           branches:


### PR DESCRIPTION
- pull from ceph.git, not ceph-releases
- always rebuild tarball
- name all source tars by $vers (x.y.z), not $cephvers (x.y.z-N-gSHA1)

Signed-off-by: Dan Mick <dan.mick@redhat.com>