### PR TITLE
jenkins-job-builder: diagnostics and allow to run on master

### DIFF
--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -46,11 +46,11 @@ for dir in `find . -maxdepth 1 -path ./.git -prune -o -type d -print`; do
         echo "found definitions directory: $definitions_dir"
 
         # Test the definitions first
-        venv/bin/jenkins-jobs --conf $JJB_CONFIG test $definitions_dir -o /tmp/output
+        venv/bin/jenkins-jobs --log-level DEBUG --conf $JJB_CONFIG test $definitions_dir -o /tmp/output
 
         # Update Jenkins with the output if they passed the test phase
         # Note that this needs proper permissions with the right credentials to the
         # correct Jenkins instance.
-        venv/bin/jenkins-jobs --conf $JJB_CONFIG update $definitions_dir
+        venv/bin/jenkins-jobs --log-level DEBUG --conf $JJB_CONFIG update $definitions_dir
     fi
 done

--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -1,6 +1,6 @@
 - job:
     name: jenkins-job-builder
-    node: small && trusty
+    node: (small && trusty) || master
     project-type: freestyle
     defaults: global
     display-name: 'Jenkins Job Builder'


### PR DESCRIPTION
Adding --log-level DEBUG to hope to point out problems, and allow
job to run on master so it runs without mita provisioning (it's small
and should be fast)

Signed-off-by: Dan Mick <dan.mick@redhat.com>