### PR TITLE
Add 'rebootable' label to ceph-pull-requests

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && (centos7 || trusty)
+    node: huge && (centos7 || trusty) && rebootable
     display-name: 'ceph: Pull Requests'
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
This is to signal node selection that the job will reboot the node
after it finishes.  Without an explicit label on the node and a request
for it, any 'trusty' node would satisfy, and be rebooted; this is
a problem for nodes that 'dial in' to the Jenkins master (such as
physical slaves on the sepia network).

This corresponds with the addition of 'rebootable' tags to mita's
configuration, so that mita nodes continue to suffice for this job.

Signed-off-by: Dan Mick <dan.mick@redhat.com>