### PR TITLE
Base url fix

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -58,11 +58,12 @@ gen_debian_version() {
 bpvers=`gen_debian_version $debian_version $DIST`
 
 # look for a specific package to tell if we can avoid the build
-chacra_endpoint="ceph/${chacra_ref}/${distro}/${DIST}/${ARCH}/librados2_${vers}-${bpvers}_${ARCH}.deb"
+chacra_endpoint="ceph/${chacra_ref}/${distro}/${DIST}/${ARCH}"
+chacra_check_url="${chacra_endpoint}/librados2_${vers}-${bpvers}_${ARCH}.deb"
 
 if [ "$THROWAWAY" = false ] ; then
     # this exists in scripts/build_utils.sh
-    check_binary_existence $chacra_endpoint
+    check_binary_existence $chacra_check_url
 fi
 
 HOST=$(hostname --short)

--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -61,11 +61,14 @@ vers=`cat ./dist/version`
 # slap -rc to the ref if we are doing a release-candidate build
 [ "$RC" = true ] && chacra_ref="$BRANCH-rc" || chacra_ref="$BRANCH"
 [ "$TEST" = true ] && chacra_ref="test"
-chacra_baseurl="ceph/${chacra_ref}/${DISTRO}/${RELEASE}/${ARCH}/librados2-${vers}-0.${DIST}.${ARCH}.rpm"
+
+chacra_endpoint="ceph/${chacra_ref}/${DISTRO}/${RELEASE}"
+chacra_check_url="${chacra_endpoint}/${ARCH}/librados2-${vers}-0.${DIST}.${ARCH}.rpm"
+
 
 if [ "$THROWAWAY" = false ] ; then
     # this exists in scripts/build_utils.sh
-    check_binary_existence $chacra_baseurl
+    check_binary_existence $chacra_check_url
 fi
 
 HOST=$(hostname --short)
@@ -116,6 +119,6 @@ cd "$WORKSPACE"
 
 if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
-    find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_baseurl}/source
-    find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_baseurl}/${ARCH}
+    find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
+    find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
 fi


### PR DESCRIPTION
define a `check_url` and an `endpoint` one for chacra interactions

This fixes the issue where the same url would be used to check DEB (or RPM) binary existence
and to POST new binaries causing this:

POST /binaries/ceph/jewel/ubuntu/trusty/x86_64/librados2_10.2.0-10.2.0-1trusty_x86_64.deb/ HTTP/1.1" 400

Which is the wrong URL for DEB binaries. Similar problem was for RPMs
