### PR TITLE
Revert dynamic axis

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -23,15 +23,16 @@
             - x86_64
             - arm64
       - axis:
-          # the dynamic axis is implemented **oddly** in jenkins job builder.
-          # It will pick just the first item in `values` and assign that to the
-          # 'variable name' that is where `DIST` would get expanded too. This
-          # is not documented. This means that DIST_VERSIONS will need to exist
-          # as an environment variable passed onto this job.
-          type: dynamic
+          type: label-expression
           name: DIST
           values:
-            - DIST_VERSIONS
+            - jessie
+            #- wheezy
+            #- precise
+            - trusty
+            - xenial
+            #- centos6
+            - centos7
 
     builders:
       - shell: |

--- a/ceph/config/definitions/ceph.yml
+++ b/ceph/config/definitions/ceph.yml
@@ -69,11 +69,6 @@ Defaults to un-checked"
           description: "Base parent path for virtualenv locations, set to avoid issues with extremely long paths that are incompatible with tools like pip. Defaults to '/tmp/' (note the trailing slash, which is required)."
           default: "/tmp/"
 
-      - string:
-          name: DIST_VERSIONS
-          description: "Populates the `DIST` environment variable so that it can dynamically alter the Matrix axis, multiple values should be space-separated."
-          default: "jessie trusty xenial centos7"
-
     builders:
       - multijob:
           name: 'ceph tag phase'


### PR DESCRIPTION
It messed up the builds picking Centos7 instead of say, Jessie.

See: https://jenkins.ceph.com/job/ceph-build/90/ARCH=x86_64,DIST=jessie,MACHINE_SIZE=huge/console