### PR TITLE
ceph-build: fix mirror url for xenial

### DIFF
--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -29,6 +29,7 @@ os="debian"
 [ "$DIST" = "precise" ] && os="ubuntu"
 [ "$DIST" = "saucy" ] && os="ubuntu"
 [ "$DIST" = "trusty" ] && os="ubuntu"
+[ "$DIST" = "xenial" ] && os="ubuntu"
 
 if [ $os = "debian" ]; then
     mirror="http://www.gtlib.gatech.edu/pub/debian"


### PR DESCRIPTION
Without this change xenial builds were using the debian mirror.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>