### PR TITLE
allow nodes to be configured as 'exclusive'

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -5,6 +5,7 @@
   user: ubuntu
   vars:
    - jenkins_user: 'jenkins-build'
+   - exclusive: false
   tasks:
     - name: create a {{ jenkins_user }} user
       user: name={{ jenkins_user }} comment="Jenkins Build Slave User" home="/home/{{ jenkins_user }}"
@@ -113,3 +114,4 @@
         remoteFS: '/home/{{ jenkins_user }}/build'
         # XXX this should be configurable, not all nodes should have one executor
         executors: 1
+        exclusive: "{{ exclusive }}"

--- a/ansible/slave.yml.j2
+++ b/ansible/slave.yml.j2
@@ -11,6 +11,7 @@
    - api_uri: 'https://jenkins.ceph.com'
    - nodename: '${nodename}'
    - labels: '${labels}'
+   - exclusive: '${exclusive}'
   tasks:
     - name: create a {{ jenkins_user }} user
       user: name={{ jenkins_user }} comment="Jenkins Build Slave User"
@@ -151,3 +152,4 @@
         remoteFS: '/home/{{ jenkins_user }}/build'
         # XXX this should be configurable, not all nodes should have one executor
         executors: 1
+        exclusive: "{{ exclusive }}"


### PR DESCRIPTION
In Jenkins lingo: "exclusive" means that it will only be used on jobs with
label restrictions matching the node (vs. the normal which is 'use this node as
much as possible')

Signed-off-by: Alfredo Deza <adeza@redhat.com>