### PR TITLE
make ceph-ansible-pull-requests request nodes specific to the job

### DIFF
--- a/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
+++ b/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
@@ -27,20 +27,10 @@
     axes:
       - axis:
           type: label-expression
-          name: MACHINE_SIZE
-          values:
-            - small
-      - axis:
-          type: label-expression
-          name: UNIQUE
-          values:
-            - unique
-      - axis:
-          type: label-expression
           name: DIST
           values:
-            - trusty
-            - centos7
+            - ceph_ansible_pr_trusty
+            - ceph_ansible_pr_centos7
     logrotate:
       daysToKeep: 15
       numToKeep: 30


### PR DESCRIPTION
When the labels were more generic other jobs would pick them up and run
the risk of being destroyed by the ceph-ansible-pull-requests job after
a run. There was also an issue were jobs that didn't need a node with an
extra device would provision one of the 'unique' nodes because the
labels also included 'small' and 'trusty'. Making the labels this
specific ensures that only this job will use those node types.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>