### PR TITLE
ceph-pull-requests: Override processor numbers

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -46,7 +46,7 @@
           wipe-workspace: true
 
     builders:
-      - shell: "timeout 7200 ./run-make-check.sh"
+      - shell: "export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
 
     publishers:
       - github-notifier


### PR DESCRIPTION
By default, run-make-check divide by 2 the number of processors to be used
during the make process.

When building a PR on our build farm, we need to use the full potential of the
build hosts.

By overriding NPROC with the actual number of processors, we speedup the build
process and use in a more efficient way the build hosts.