### PR TITLE
install the debian keys so pbuilder will work with newer distros

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -91,6 +91,7 @@
         - libtool
         - autotools-dev
         - automake
+        - debian-archive-keyring
         # jenkins-job-builder job:
         - libyaml-dev
         # ceph-docs job:


### PR DESCRIPTION
To avoid the error: 

    E: Release signed by unknown key (key id 8B48AD6246925553)