### PR TITLE
Add Debian Jessie GPG Key

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -104,6 +104,11 @@
         - libffi-dev
       when: ansible_pkg_mgr  == "apt"
 
+    - name: Add the Debian Jessie Key
+      sudo: yes
+      when: ansible_pkg_mgr  == "apt"
+      apt_key: id=518E17E1 url=https://ftp-master.debian.org/keys/archive-key-8.0.asc keyring=/etc/apt/trusted.gpg.d/jessie.gpg state=present
+
     - name: correct java version selected
       alternatives: name=java path=/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
       when:


### PR DESCRIPTION
Regardless of the machine, since we are usually building on Trusty, this will
allow that type of server to build and avoid the "Release signed by unknown
key" issue.

Signed-off-by: Alfredo Deza <adeza@redhat.com>