### PR TITLE
ensure the current hostname is defined in /etc/hosts

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -125,6 +125,14 @@
         line: '%dist .el{{ ansible_distribution_major_version }}'
       when: ansible_pkg_mgr  == "yum"
 
+    - name: ensure that the current host is in /etc/hosts. Yes this is a thing.
+      sudo: true
+      replace:
+        backup: yes
+        dest: /etc/hosts
+        regexp: '^(127\.0\.1\.1(?!.*\b{{ ansible_hostname }}\b).*)$'
+        replace: '\1 {{ ansible_hostname }}'
+
     - name: install six, latest one
       sudo: true
       pip: name=six state=latest


### PR DESCRIPTION
This will prevent errors from builders with improper hostnames:

    sudo: unable to resolve host vm