### PR TITLE
typo fix on debian gpg key for jessie

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -107,7 +107,7 @@
     - name: Add the Debian Jessie Key
       sudo: yes
       when: ansible_pkg_mgr  == "apt"
-      apt_key: id=518E17E1 url=https://ftp-master.debian.org/keys/archive-key-8.0.asc keyring=/etc/apt/trusted.gpg.d/jessie.gpg state=present
+      apt_key: id=518E17E1 url=https://ftp-master.debian.org/keys/archive-key-8.asc keyring=/etc/apt/trusted.gpg.d/jessie.gpg state=present
 
     - name: correct java version selected
       alternatives: name=java path=/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java


### PR DESCRIPTION
It was getting a 404 before this :(