### PR TITLE
install dev packges for libssl and libffi on rpm and deb sytems

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -65,6 +65,8 @@
         - redhat-rpm-config
         - rpm-build
         - rpmdevtools
+        - openssl-devel
+        - libffi-devel
       when: ansible_pkg_mgr  == "yum"
 
     # Run the equivalent of "apt-get update" as a separate step
@@ -102,6 +104,7 @@
         - libmysqlclient-dev
         - libevent-dev
         - libffi-dev
+        - libssl-dev
       when: ansible_pkg_mgr  == "apt"
 
     - name: Add the Debian Jessie Key


### PR DESCRIPTION
These are needed to pip install ansible.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>