### PR TITLE
Newer setuptools across all python-using jobs

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -2,23 +2,9 @@
 
 set -e
 
-# Create the virtualenv
-virtualenv venv
-. venv/bin/activate
-
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
-
-# upgrade setuptools because the world breaks otherwise :(
-venv/bin/pip install -U setuptools
-
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index jenkins-job-builder; then
-    venv/bin/pip install --download-directory="$PIP_SDIST_INDEX" jenkins-job-builder
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index jenkins-job-builder
-fi
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "ansible" "jenkins-job-builder" )
+install_python_packages "pkgs[@]"
 
 
 # Test every definition if available in the current repository and update the jobs
@@ -29,22 +15,16 @@ for dir in `find . -maxdepth 1 -path ./.git -prune -o -type d -print`; do
         echo "found definitions directory: $definitions_dir"
 
         # Test the definitions
-        venv/bin/jenkins-jobs test $definitions_dir -o /tmp/output
+        $VENV/jenkins-jobs test $definitions_dir -o /tmp/output
     fi
 done
 
-# Install Ansible
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible; then
-    venv/bin/pip install --download-directory="$PIP_SDIST_INDEX" ansible
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible
-fi
-
 # install ansible-galaxy roles for playbook syntax check
 for reqs in $WORKSPACE/ansible/requirements/*; do
-    ansible-galaxy install -r $reqs -p $WORKSPACE/ansible/roles --force
+    $VENV/ansible-galaxy install -r $reqs -p $WORKSPACE/ansible/roles --force
 done
 
 # Syntax-check each Ansible playbook
 for playbook in $WORKSPACE/ansible/*.yml; do
-    ansible-playbook -i '127.0.0.1,' $playbook --syntax-check
+    $VENV/ansible-playbook -i '127.0.0.1,' $playbook --syntax-check
 done

--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -50,7 +50,9 @@
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     publishers:
       - github-notifier

--- a/ceph-deploy-docs/build/build
+++ b/ceph-deploy-docs/build/build
@@ -2,24 +2,12 @@
 
 set -ex
 
-# Create the virtualenv
-virtualenv venv
-. venv/bin/activate
-
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
-
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox; then
-    venv/bin/pip install --download-directory="$PIP_SDIST_INDEX" tox
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox
-fi
-
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "tox" )
+install_python_packages "pkgs[@]"
 
 # create the docs build with tox
-tox -rv -e docs
+$VENV/tox -rv -e docs
 
 # publish docs to http://docs.ceph.com/docs/ceph-deploy
 rsync -auv --delete .tox/docs/tmp/html/* /var/ceph-deploy/docs/

--- a/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
+++ b/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
@@ -31,4 +31,6 @@
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build

--- a/ceph-qa-suite-pull-requests/build/build
+++ b/ceph-qa-suite-pull-requests/build/build
@@ -2,23 +2,12 @@
 
 set -ex
 
-# Create the virtualenv
-virtualenv venv
-. venv/bin/activate
-
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
-
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox; then
-    venv/bin/pip install --download-directory="$PIP_SDIST_INDEX" tox
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox
-fi
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "tox" )
+install_python_packages "pkgs[@]"
 
 
 # run tox by recreating the environment and in verbose mode
 # by default this will run all environments defined, although currently
 # it is just flake8
-tox -rv
+$VENV/tox -rv

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -59,7 +59,9 @@
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     publishers:
       - github-notifier

--- a/ceph-tag/build/build
+++ b/ceph-tag/build/build
@@ -7,25 +7,11 @@ if [ "$TAG" = false ] ; then
     exit 0
 fi
 
-# Create the virtualenv
-virtualenv venv
-. venv/bin/activate
-
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
-
-# The setup for this job ensures that a copy of ceph-build will be available
-# for this script
-
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible; then
-    venv/bin/pip install --exists-action=i --download-directory="$PIP_SDIST_INDEX" ansible
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index ansible
-fi
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "ansible" )
+install_python_packages "pkgs[@]"
 
 # run ansible to do all the tagging and release specifying
 # a local connection and 'localhost' as the host where to execute
 cd "$WORKSPACE/ceph-build/ansible/"
-ansible-playbook -i "localhost," -c local release.yml --extra-vars="version=$VERSION branch=$BRANCH force_version=$FORCE_VERSION release=stable clean=true project=ceph"
+$VENV/ansible-playbook -i "localhost," -c local release.yml --extra-vars="version=$VERSION branch=$BRANCH force_version=$FORCE_VERSION release=stable clean=true project=ceph"

--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -37,7 +37,9 @@
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     wrappers:
       - inject-passwords:

--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -8,23 +8,12 @@
 
 set -ex
 
-# Create the virtualenv
-virtualenv venv
-. venv/bin/activate
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "jenkins-job-builder" )
+install_python_packages "pkgs[@]"
 
 # Wipe out JJB's cache if $FORCE is set.
 [ "$FORCE" = true ] && rm -rf "$HOME/.cache/jenkins_jobs/"
-
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
-
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index jenkins-job-builder; then
-    venv/bin/pip install --download-directory="$PIP_SDIST_INDEX" jenkins-job-builder
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index jenkins-job-builder
-fi
 
 # workaround for https://issues.jenkins-ci.org/browse/JENKINS-16225
 JENKINS_URL=${JENKINS_URL:-"https://jenkins.ceph.com/"}
@@ -46,11 +35,11 @@ for dir in `find . -maxdepth 1 -path ./.git -prune -o -type d -print`; do
         echo "found definitions directory: $definitions_dir"
 
         # Test the definitions first
-        venv/bin/jenkins-jobs --log_level DEBUG --conf $JJB_CONFIG test $definitions_dir -o /tmp/output
+        $VENV/jenkins-jobs --log_level DEBUG --conf $JJB_CONFIG test $definitions_dir -o /tmp/output
 
         # Update Jenkins with the output if they passed the test phase
         # Note that this needs proper permissions with the right credentials to the
         # correct Jenkins instance.
-        venv/bin/jenkins-jobs --log_level DEBUG --conf $JJB_CONFIG update $definitions_dir
+        $VENV/jenkins-jobs --log_level DEBUG --conf $JJB_CONFIG update $definitions_dir
     fi
 done

--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -39,7 +39,10 @@ If this is checked, JJB will wipe out its cache and force each job to align with
           timeout: 20
 
     builders:
-      - shell: "bash jenkins-job-builder/build/build"
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     publishers:
       - postbuildscript:

--- a/merfi-pull-requests/build/build
+++ b/merfi-pull-requests/build/build
@@ -2,22 +2,10 @@
 
 set -ex
 
-# Create the virtualenv
-virtualenv venv
-. venv/bin/activate
-
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
-
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox; then
-    venv/bin/pip install --download-directory="$PIP_SDIST_INDEX" tox
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox
-fi
-
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "tox" )
+install_python_packages "pkgs[@]"
 
 # run tox by recreating the environment and in verbose mode
 # by default this will run all environments defined
-tox -rv
+$VENV/tox -rv

--- a/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
+++ b/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
@@ -59,7 +59,9 @@
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     publishers:
       - github-notifier

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -21,6 +21,9 @@ install_python_packages () {
     PIP_SDIST_INDEX="$HOME/.cache/pip"
     mkdir -p $PIP_SDIST_INDEX
 
+    echo "Updating setuptools"
+    $VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" setuptools
+
     echo "Ensuring latest pip is installed"
     $VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" pip
     $VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index pip

--- a/teuthology-docs/build/build
+++ b/teuthology-docs/build/build
@@ -2,23 +2,12 @@
 
 set -ex
 
-# Create the virtualenv
-virtualenv venv
-. venv/bin/activate
-
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
-
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox; then
-    venv/bin/pip install --download-directory="$PIP_SDIST_INDEX" tox
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox
-fi
-
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "tox" )
+install_python_packages "pkgs[@]"
 
 # create the docs build with tox
-tox -rv -e docs
+$VENV/tox -rv -e docs
+
 # publish docs to http://docs.ceph.com/docs/teuthology
 rsync -auv --delete .tox/docs/tmp/html/* /var/teuthology/docs/

--- a/teuthology-docs/config/definitions/teuthology-docs.yml
+++ b/teuthology-docs/config/definitions/teuthology-docs.yml
@@ -30,4 +30,6 @@
 
     builders:
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build

--- a/teuthology-pull-requests/build/build
+++ b/teuthology-pull-requests/build/build
@@ -2,22 +2,10 @@
 
 set -ex
 
-# Create the virtualenv
-virtualenv venv
-. venv/bin/activate
-
-# Define and ensure the PIP cache
-PIP_SDIST_INDEX="$HOME/.cache/pip"
-mkdir -p $PIP_SDIST_INDEX
-
-# Install the package by trying with the cache first, otherwise doing a download only, and then
-# trying to install from the cache again.
-if ! venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox; then
-    venv/bin/pip install --download-directory="$PIP_SDIST_INDEX" tox
-    venv/bin/pip install --find-links="file://$PIP_SDIST_INDEX" --no-index tox
-fi
-
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "tox" )
+install_python_packages "pkgs[@]"
 
 # run tox by recreating the environment and in verbose mode
 # by default this will run all environments defined
-tox -rv
+$VENV/tox -rv

--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -1,5 +1,5 @@
 - job:
-    name: teuthology-pull-requests 
+    name: teuthology-pull-requests
     node: trusty && amd64 && small
     project-type: freestyle
     defaults: global
@@ -63,9 +63,13 @@
 
     builders:
       - shell:
-          !include-raw ../../setup/setup
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../setup/setup
       - shell:
-          !include-raw ../../build/build
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
 
     publishers:
       - github-notifier


### PR DESCRIPTION
This sets the upgrade to setuptools in just one place: `build_utils.sh` and makes all jobs use that utility (before this only a few used the util).

It drastically reduces the code copy/pasta by reusing the utility script.