### PR TITLE
ceph-ansible-pull-requests: add a xenial instance when testing

### DIFF
--- a/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
+++ b/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
@@ -30,6 +30,7 @@
           name: DIST
           values:
             - ceph_ansible_pr_trusty
+            - ceph_ansible_pr_xenial
             - ceph_ansible_pr_centos7
     logrotate:
       daysToKeep: 15


### PR DESCRIPTION
Requires https://github.com/ceph/mita/pull/62 to be merged+deployed before this.

This would take care of https://github.com/ceph/ceph-ansible/issues/507
