### PR TITLE
ceph-ansible-pull-requests: use the ens3 monitor interface with xenial

### DIFF
--- a/ceph-ansible-pull-requests/build/build
+++ b/ceph-ansible-pull-requests/build/build
@@ -14,6 +14,9 @@ journal_collocation="true"
 journal_size=1024
 # both our trusty and centos nodes created in OVH use eth0
 monitor_interface="eth0"
+if [[ "$DIST" == "ceph_ansible_pr_xenial" ]]; then
+    monitor_interface="ens3"
+fi
 cluster_network="127.0.0.1/0"
 public_network="127.0.0.1/0"
 fsid="4a158d27-f750-41d5-9e7f-26ce4c9d2d45"


### PR DESCRIPTION
Signed-off-by: Andrew Schoen <aschoen@redhat.com>