### PR TITLE
Remove ssh-agent credentials

### DIFF
--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -47,7 +47,3 @@
       - inject-passwords:
           global: true
           mask-password-params: true
-      - ssh-agent-credentials:
-          # "jenkins-build" SSH key, needed for access to ceph-releases.git
-          users:
-            - '39fa150b-b2a1-416e-b334-29a9a2c0b32d'

--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -45,7 +45,3 @@
       - inject-passwords:
           global: true
           mask-password-params: true
-      - ssh-agent-credentials:
-          # "jenkins-build" SSH key, needed so we can push to
-          # ceph-deploy.git
-          user: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'


### PR DESCRIPTION
To avoid conflicts in Jenkins for these jobs. After removing them manually both ceph-tag and ceph-setup were able to complete.

    java.lang.ClassCastException: org.acegisecurity.providers.UsernamePasswordAuthenticationToken cannot be cast to org.jenkinsci.plugins.GithubAuthenticationToken