### PR TITLE
ceph-build-os: Adding ceph-build-os job

### DIFF
--- a/ceph-build-os/build/build
+++ b/ceph-build-os/build/build
@@ -18,3 +18,4 @@ if [ -z "$REPOSITORY" ]; then
 fi
 
 sudo make ceph-builders DIST=${DIST} DVER=${DVER} VERSION=${VERSION} VIRTUALIZED=ceph-builders.virt NO_MGNIDS=True NO_COMPRESSED_FILE=True REPOSITORY=${REPOSITORY} KEEP_PKGMNGR=True COMPRESSED=yes && DVER=${DVER} VERSION=${VERSION} upload.sh
+

--- a/ceph-build-os/build/build
+++ b/ceph-build-os/build/build
@@ -1,6 +1,32 @@
 #!/bin/bash
 
+upload() {
+	IMAGE=$(ls /var/lib/debootstrap/install/$DISTRO_RELEASE-$VERSION/*qcow2)
+	if [ -z "$IMAGE" ]; then
+	   echo "upload: No IMAGE found in /var/lib/debootstrap/install/$DISTRO_RELEASE-$VERSION/, Exiting"
+	   exit 1
+	fi
+
+	IMAGE_NAME=$(basename `echo $IMAGE | sed -e "s/\.img\.qcow2//g"`)
+
+	echo "upload: About to upload $IMAGE as $IMAGE_NAME"
+
+	# If the same image already exists, let's delete it
+	openstack image list -f csv | grep -qw "$IMAGE_NAME" && echo "upload: Deleting remote image" && openstack image delete "$IMAGE_NAME"
+
+	# Upload the image
+	echo "upload: Uploading $IMAGE"
+	openstack image create $IMAGE_NAME --disk-format qcow2 --container-format bare --file $IMAGE
+}
+
 set +x
+
+export OS_AUTH_URL="$OVH_AUTH_URL"
+export OS_TENANT_ID="$OVH_TENANT_ID"
+export OS_TENANT_NAME="$OVH_TENANT_NAME"
+export OS_USERNAME="$OVH_USERNAME"
+export OS_PASSWORD="$OVH_PASSWORD"
+export OS_REGION_NAME="$OVH_REGION"
 
 if [ -z $DIST ]; then
     echo "build: No DIST found, exiting !"
@@ -14,6 +40,36 @@ fi
 
 if [ -z $VERSION ]; then
     echo "build: No VERSION found, exiting !"
+    exit 1
+fi
+
+if [ -z "$OS_AUTH_URL" ]; then
+    echo "upload: Cannot find any valid OS_AUTH_URL"
+    exit 1
+fi
+
+if [ -z "$OS_TENANT_ID" ]; then
+    echo "build: Cannot find any valid OS_TENANT_ID"
+    exit 1
+fi
+
+if [ -z "$OS_TENANT_NAME" ]; then
+    echo "build: Cannot find any valid OS_TENANT_NAME"
+    exit 1
+fi
+
+if [ -z "$OS_USERNAME" ]; then
+    echo "build: Cannot find any valid OS_USERNAME"
+    exit 1
+fi
+
+if [ -z "$OS_PASSWORD" ]; then
+    echo "build: Cannot find any valid OS_PASSWORD"
+    exit 1
+fi
+
+if [ -z "$OS_REGION_NAME" ]; then
+    echo "build: Cannot find any valid OS_REGION_NAME"
     exit 1
 fi
 
@@ -37,7 +93,7 @@ if [ -z "$REPO_URL" ]; then
     echo "build: Using repository $REPO_URL"
 fi
 
+
 sudo edeploy activate-pkgmngr
 
-sudo make ceph-builders DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} VIRTUALIZED=ceph-builders.virt NO_MGNIDS=True NO_COMPRESSED_FILE=True REPOSITORY=${REPO_URL} KEEP_PKGMNGR=True COMPRESSED=yes && DVER=${DISTRO_RELEASE} VERSION=${VERSION} upload.sh
-
+sudo make ceph-builders DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} VIRTUALIZED=ceph-builders.virt NO_MGNIDS=True NO_COMPRESSED_FILE=True REPOSITORY=${REPO_URL} KEEP_PKGMNGR=True COMPRESSED=yes && upload

--- a/ceph-build-os/build/build
+++ b/ceph-build-os/build/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-sudo edeploy activate-pkgmngr;
-cd build;
+sudo edeploy activate-pkgmngr; 
+cd build; 
 
 if [ -z "$REPOSITORY" ]; then
     case "$DIST" in

--- a/ceph-build-os/build/build
+++ b/ceph-build-os/build/build
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+sudo edeploy activate-pkgmngr;
+cd build;
+
+if [ -z "$REPOSITORY" ]; then
+    case "$DIST" in
+        "xenial"|"trusty")
+            REPOSITORY="http://ubuntu.mirrors.ovh.net/ubuntu/"
+        ;;
+        "jessie")
+            REPOSITORY="http://debian.mirrors.ovh.net/debian/"
+        ;;
+        "centos")
+            REPOSITORY="http://centos.mirrors.ovh.net/ftp.centos.org/7/os/x86_64/Packages/centos-release-7-2.1511.el7.centos.2.10.x86_64.rpm"
+        ;;
+    esac
+fi
+
+sudo make ceph-builders DIST=${DIST} DVER=${DVER} VERSION=${VERSION} VIRTUALIZED=ceph-builders.virt NO_MGNIDS=True NO_COMPRESSED_FILE=True REPOSITORY=${REPOSITORY} KEEP_PKGMNGR=True COMPRESSED=yes && DVER=${DVER} VERSION=${VERSION} upload.sh

--- a/ceph-build-os/build/build
+++ b/ceph-build-os/build/build
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-sudo edeploy activate-pkgmngr; 
-cd build; 
-
 if [ -z "$REPOSITORY" ]; then
     case "$DIST" in
         "xenial"|"trusty")

--- a/ceph-build-os/build/build
+++ b/ceph-build-os/build/build
@@ -7,8 +7,8 @@ if [ -z $DIST ]; then
     exit 1
 fi
 
-if [ -z $DVER ]; then
-    echo "build: No DVER found, exiting !"
+if [ -z $DISTRO_RELEASE ]; then
+    echo "build: No DISTRO_RELEASE found, exiting !"
     exit 1
 fi
 
@@ -19,23 +19,23 @@ fi
 
 echo "build: Environment is correct"
 
-if [ -z "$REPOSITORY" ]; then
+if [ -z "$REPO_URL" ]; then
     case "$DIST" in
         "xenial"|"trusty")
-            REPOSITORY="http://ubuntu.mirrors.ovh.net/ubuntu/"
+            REPO_URL="http://ubuntu.mirrors.ovh.net/ubuntu/"
         ;;
         "jessie")
-            REPOSITORY="http://debian.mirrors.ovh.net/debian/"
+            REPO_URL="http://debian.mirrors.ovh.net/debian/"
         ;;
         "centos")
-            REPOSITORY="http://centos.mirrors.ovh.net/ftp.centos.org/7/os/x86_64/Packages/centos-release-7-2.1511.el7.centos.2.10.x86_64.rpm"
+            REPO_URL="http://centos.mirrors.ovh.net/ftp.centos.org/7/os/x86_64/Packages/centos-release-7-2.1511.el7.centos.2.10.x86_64.rpm"
         ;;
         *)
             echo "build: no known favorite repository for $DIST"
         ;;
     esac
-    echo "build: Using repository $REPOSITORY"
+    echo "build: Using repository $REPO_URL"
 fi
 
-sudo make ceph-builders DIST=${DIST} DVER=${DVER} VERSION=${VERSION} VIRTUALIZED=ceph-builders.virt NO_MGNIDS=True NO_COMPRESSED_FILE=True REPOSITORY=${REPOSITORY} KEEP_PKGMNGR=True COMPRESSED=yes && DVER=${DVER} VERSION=${VERSION} upload.sh
+sudo make ceph-builders DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} VIRTUALIZED=ceph-builders.virt NO_MGNIDS=True NO_COMPRESSED_FILE=True REPOSITORY=${REPO_URL} KEEP_PKGMNGR=True COMPRESSED=yes && DVER=${DISTRO_RELEASE} VERSION=${VERSION} upload.sh
 

--- a/ceph-build-os/build/build
+++ b/ceph-build-os/build/build
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+set +x
+
+if [ -z $DIST ]; then
+    echo "build: No DIST found, exiting !"
+    exit 1
+fi
+
+if [ -z $DVER ]; then
+    echo "build: No DVER found, exiting !"
+    exit 1
+fi
+
+if [ -z $VERSION ]; then
+    echo "build: No VERSION found, exiting !"
+    exit 1
+fi
+
+echo "build: Environment is correct"
+
 if [ -z "$REPOSITORY" ]; then
     case "$DIST" in
         "xenial"|"trusty")
@@ -11,7 +30,11 @@ if [ -z "$REPOSITORY" ]; then
         "centos")
             REPOSITORY="http://centos.mirrors.ovh.net/ftp.centos.org/7/os/x86_64/Packages/centos-release-7-2.1511.el7.centos.2.10.x86_64.rpm"
         ;;
+        *)
+            echo "build: no known favorite repository for $DIST"
+        ;;
     esac
+    echo "build: Using repository $REPOSITORY"
 fi
 
 sudo make ceph-builders DIST=${DIST} DVER=${DVER} VERSION=${VERSION} VIRTUALIZED=ceph-builders.virt NO_MGNIDS=True NO_COMPRESSED_FILE=True REPOSITORY=${REPOSITORY} KEEP_PKGMNGR=True COMPRESSED=yes && DVER=${DVER} VERSION=${VERSION} upload.sh

--- a/ceph-build-os/build/build
+++ b/ceph-build-os/build/build
@@ -37,5 +37,7 @@ if [ -z "$REPO_URL" ]; then
     echo "build: Using repository $REPO_URL"
 fi
 
+sudo edeploy activate-pkgmngr
+
 sudo make ceph-builders DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} VIRTUALIZED=ceph-builders.virt NO_MGNIDS=True NO_COMPRESSED_FILE=True REPOSITORY=${REPO_URL} KEEP_PKGMNGR=True COMPRESSED=yes && DVER=${DISTRO_RELEASE} VERSION=${VERSION} upload.sh
 

--- a/ceph-build-os/config/definitions/ceph-build-os.yml
+++ b/ceph-build-os/config/definitions/ceph-build-os.yml
@@ -1,3 +1,27 @@
+- scm:
+    name: ceph-build
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-build.git
+          browser-url: https://github.com/ceph/ceph-build
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: false
+          basedir: "ceph-build"
+- scm:
+    name: edeploy
+    scm:
+      - git:
+          url: https://github.com/ErwanAliasr1/edeploy.git
+          branches:
+            - ceph-builders
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+          basedir: "edeploy"
+
 - job:
     name: ceph-build-os
     project-type: freestyle
@@ -36,15 +60,8 @@
             description: "Optional URL of a package repository to override the default one like (http://debian.mirrors.ovh.net/debian/ or http://centos.mirrors.ovh.net/ftp.centos.org/7/os/x86_64/Packages/centos-release-7-2.1511.el7.centos.2.10.x86_64.rpm"
 
     scm:
-      - git:
-          url: https://github.com/ErwanAliasr1/edeploy.git
-          branches:
-            - ceph-builders
-          refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: auto
-          timeout: 20
-          skip-tag: true
-          wipe-workspace: true
+      - ceph-build
+      - edeploy
 
     builders:
       - shell: "../../build/build DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPO_URL}"

--- a/ceph-build-os/config/definitions/ceph-build-os.yml
+++ b/ceph-build-os/config/definitions/ceph-build-os.yml
@@ -68,10 +68,10 @@
 
     publishers:
       - postbuildscript:
-          script-only-if-succeeded: True
+          script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell: "sudo poweroff"
+            - shell: "sudo reboot"
 
     wrappers:
       - inject-passwords:

--- a/ceph-build-os/config/definitions/ceph-build-os.yml
+++ b/ceph-build-os/config/definitions/ceph-build-os.yml
@@ -24,7 +24,7 @@
             description: "The distribution codename like xenial,centos,jessie"
 
         - string:
-            name: DVER
+            name: DISTRO_RELEASE
             description: "The distribution codename like C7.2, U16.04, D8"
 
         - string:
@@ -47,7 +47,7 @@
           wipe-workspace: true
 
     builders:
-      - shell: "sudo edeploy activate-pkgmngr; cd build; sudo make ceph-builders DIST=${DIST} DVER=${DVER} VERSION=${VERSION} VIRTUALIZED=ceph-builders.virt NO_MGNIDS=True NO_COMPRESSED_FILE=True REPOSITORY=${REPOSITORY} KEEP_PKGMNGR=True && DVER=${DVER} VERSION=${VERSION} upload.sh"
+        - shell: !include-raw ../../build/build DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPOSITORY}"
 
     publishers:
       - postbuildscript:

--- a/ceph-build-os/config/definitions/ceph-build-os.yml
+++ b/ceph-build-os/config/definitions/ceph-build-os.yml
@@ -64,7 +64,7 @@
       - edeploy
 
     builders:
-      - shell: "../../build/build DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPO_URL}"
+      - shell: "cd edeploy/build; ../../ceph-build/ceph-build-os/build/build DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPO_URL}"
 
     publishers:
       - postbuildscript:

--- a/ceph-build-os/config/definitions/ceph-build-os.yml
+++ b/ceph-build-os/config/definitions/ceph-build-os.yml
@@ -1,0 +1,62 @@
+- job:
+    name: ceph-build-os
+    project-type: freestyle
+    defaults: global
+    concurrent: true
+    node: huge && (ceph_build_xenial) && rebootable
+    display-name: 'ceph: Build OS'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph/
+    logrotate:
+      daysToKeep: 15
+      numToKeep: 300
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    parameters:
+        - string:
+            name: DIST
+            description: "The distribution codename like xenial,centos,jessie"
+
+        - string:
+            name: DVER
+            description: "The distribution codename like C7.2, U16.04, D8"
+
+        - string:
+            name: VERSION
+            description: "The release of that particular build : 1.0.0, 1.1.0, ..."
+
+        - string:
+            name: REPOSITORY
+            description: "URL of the package repository, like http://debian.mirrors.ovh.net/debian/"
+
+    scm:
+      - git:
+          url: https://github.com/ErwanAliasr1/edeploy.git
+          branches:
+            - ceph-builders
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+
+    builders:
+      - shell: "sudo edeploy activate-pkgmngr; cd build; sudo make ceph-builders DIST=${DIST} DVER=${DVER} VERSION=${VERSION} VIRTUALIZED=ceph-builders.virt NO_MGNIDS=True NO_COMPRESSED_FILE=True REPOSITORY=${REPOSITORY} KEEP_PKGMNGR=True && DVER=${DVER} VERSION=${VERSION} upload.sh"
+
+    publishers:
+      - postbuildscript:
+          script-only-if-succeeded: True
+          script-only-if-failed: True
+          builders:
+            - shell: "sudo poweroff"
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true

--- a/ceph-build-os/config/definitions/ceph-build-os.yml
+++ b/ceph-build-os/config/definitions/ceph-build-os.yml
@@ -64,7 +64,7 @@
       - edeploy
 
     builders:
-      - shell: "cd edeploy/build; DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPO_URL} ../../ceph-build/ceph-build-os/build/build"
+      - shell: "cd edeploy/build; DIST=${DIST} DISTRO_RELEASE=${DISTRO_RELEASE} VERSION=${VERSION} REPO_URL=${REPO_URL} ../../ceph-build/ceph-build-os/build/build"
 
     publishers:
       - postbuildscript:

--- a/ceph-build-os/config/definitions/ceph-build-os.yml
+++ b/ceph-build-os/config/definitions/ceph-build-os.yml
@@ -47,7 +47,7 @@
           wipe-workspace: true
 
     builders:
-        - shell: !include-raw ../../build/build DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPO_URL}"
+      - shell: "../../build/build DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPO_URL}"
 
     publishers:
       - postbuildscript:

--- a/ceph-build-os/config/definitions/ceph-build-os.yml
+++ b/ceph-build-os/config/definitions/ceph-build-os.yml
@@ -32,8 +32,8 @@
             description: "The release of that particular build : 1.0.0, 1.1.0, ..."
 
         - string:
-            name: REPOSITORY
-            description: "URL of the package repository, like http://debian.mirrors.ovh.net/debian/"
+            name: REPO_URL
+            description: "Optional URL of a package repository to override the default one like (http://debian.mirrors.ovh.net/debian/ or http://centos.mirrors.ovh.net/ftp.centos.org/7/os/x86_64/Packages/centos-release-7-2.1511.el7.centos.2.10.x86_64.rpm"
 
     scm:
       - git:
@@ -47,7 +47,7 @@
           wipe-workspace: true
 
     builders:
-        - shell: !include-raw ../../build/build DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPOSITORY}"
+        - shell: !include-raw ../../build/build DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPO_URL}"
 
     publishers:
       - postbuildscript:

--- a/ceph-build-os/config/definitions/ceph-build-os.yml
+++ b/ceph-build-os/config/definitions/ceph-build-os.yml
@@ -64,7 +64,7 @@
       - edeploy
 
     builders:
-      - shell: "cd edeploy/build; ../../ceph-build/ceph-build-os/build/build DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPO_URL}"
+      - shell: "cd edeploy/build; DIST=${DIST} DVER=${DISTRO_RELEASE} VERSION=${VERSION} REPOSITORY=${REPO_URL} ../../ceph-build/ceph-build-os/build/build"
 
     publishers:
       - postbuildscript:


### PR DESCRIPTION
This new job is about building VM image intented to build Ceph base code.

It uses the edeploy project to define the content of the VM by defining :
- the distro
- the distro version
- a release version of that build

The ceph-builder target of edeploy intent to create xfs-based VMs that have all
the usual packages required to build ceph or edeploy.

This will save time at build-time as most of the deps will be already installed.
