### PR TITLE
ansible: Enforce rights on /home/jenkins-build

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -16,6 +16,9 @@
     - name: create a {{ jenkins_user }} user
       user: name={{ jenkins_user }} comment="Jenkins Build Slave User"
 
+    - name: ensure the user dir is tied to the jenkins_user
+      file: path=/home/{{ jenkins_user }}/ state=directory owner={{ jenkins_user }} recurse=yes
+
     - name: Create .ssh directory
       file: path=/home/{{ jenkins_user }}/.ssh
             state=directory
@@ -32,9 +35,6 @@
         validate: 'visudo -cf %s'
 
     - name: ensure the build dir exists
-      file: path=/home/{{ jenkins_user }}/build state=directory owner={{ jenkins_user }}
-
-    - name: ensure the build dir has the right owner permissions
       file: path=/home/{{ jenkins_user }}/build state=directory owner={{ jenkins_user }}
 
     - name: Install RPM requirements


### PR DESCRIPTION
On a fresh new image, the /home/jenkins-build relies to root.root making ccache
failing at creating a file here.

That means that anything trying to write a file in the home dir will fail.

This patch simply enfore the user/group of the home dir