### PR TITLE
ansible: Enforce rights on /home/jenkins-build

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -34,8 +34,8 @@
     - name: ensure the build dir exists
       file: path=/home/{{ jenkins_user }}/build state=directory owner={{ jenkins_user }}
 
-    - name: ensure the build dir has the right owner permissions
-      file: path=/home/{{ jenkins_user }}/build state=directory owner={{ jenkins_user }}
+    - name: ensure the home dir has the right owner permissions
+      file: path=/home/{{ jenkins_user }} state=directory owner={{ jenkins_user }} group={{ jenkins_user }} recurse=yes
 
     - name: Install RPM requirements
       sudo: yes


### PR DESCRIPTION
On a fresh new image, the /home/jenkins-build relies to root.root making ccache
failing at creating a file here.

That means that anything trying to write a file in the home dir will fail.

This patch simply enfore the user/group of the home dir