### PR TITLE
ceph-pull-request: Increasing ccache size

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -46,7 +46,7 @@
           wipe-workspace: true
 
     builders:
-      - shell: "export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
+      - shell: "ccache -M 5G; export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
 
     publishers:
       - github-notifier

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -46,7 +46,7 @@
           wipe-workspace: true
 
     builders:
-      - shell: "ccache -M 5G; export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
+      - shell: "ccache -M 5G; ccache -z; export NPROC=$(nproc); timeout 7200 ./run-make-check.sh; ccache -s"
 
     publishers:
       - github-notifier


### PR DESCRIPTION
By default, ccache is now configured and uses only 1G of space.
While monitoring the build it appears that if we would have a larger cache, more
hits could be done making a faster build process.

This patch simply makes the ccache bigger up to 5G which is fine regarding the
openstack flavor we have.