### PR TITLE
radosgw-agent-pull-requests: remove github-notifier

### DIFF
--- a/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
+++ b/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
@@ -73,6 +73,3 @@
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
-
-    publishers:
-      - github-notifier


### PR DESCRIPTION
Because it causes issues when notifying github when more than one SCM is used:

    Setting commit status on GitHub for https://github.com/ceph/radosgw-agent/commit/70c05dab3a2087580dcbec5e50541a0df1a51587
    ERROR: Build step failed with exception
    org.jenkinsci.plugins.github.common.CombineErrorHandler$ErrorHandlingException: java.io.FileNotFoundException: {"message":"No commit found for SHA: 70c05dab3a2087580dcbec5e50541a0df1a51587"
