### PR TITLE
removes the deprecated github-notifier publisher from all jobs

### DIFF
--- a/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
+++ b/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
@@ -68,7 +68,6 @@
             - ../../build/build
 
     publishers:
-      - github-notifier
       - postbuildscript:
           script-only-if-succeeded: False
           script-only-if-failed: False

--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -53,6 +53,3 @@
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
-
-    publishers:
-      - github-notifier

--- a/ceph-installer-pull-requests/config/definitions/ceph-installer-pull-requests.yml
+++ b/ceph-installer-pull-requests/config/definitions/ceph-installer-pull-requests.yml
@@ -55,6 +55,3 @@
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
-
-    publishers:
-      - github-notifier

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -49,7 +49,6 @@
       - shell: "ccache -M 5G; ccache -z; export NPROC=$(nproc); timeout 7200 ./run-make-check.sh; ccache -s"
 
     publishers:
-      - github-notifier
       - postbuildscript:
           script-only-if-succeeded: False
           script-only-if-failed: True

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -62,6 +62,3 @@
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
-
-    publishers:
-      - github-notifier

--- a/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
+++ b/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
@@ -62,6 +62,3 @@
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
-
-    publishers:
-      - github-notifier

--- a/takora-pull-requests/config/definitions/takora-pull-requests.yml
+++ b/takora-pull-requests/config/definitions/takora-pull-requests.yml
@@ -55,6 +55,3 @@
     - shell:
         # Note that we're including the main "takora" job's build steps here.
         !include-raw ../../../takora/build/build
-
-    publishers:
-      - github-notifier

--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -70,6 +70,3 @@
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
-
-    publishers:
-      - github-notifier


### PR DESCRIPTION
This publisher is not needed as the github-pull-requests trigger takes care of
updating the status on the pull request.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>