### PR TITLE
add ssh creds back to be able to push tags 

### DIFF
--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -45,3 +45,7 @@
       - inject-passwords:
           global: true
           mask-password-params: true
+      - ssh-agent-credentials:
+          # "jenkins-build" SSH key, needed so we can push to
+          # ceph-deploy.git
+          user: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'


### PR DESCRIPTION
This reverts commit f4398ab8df10e6fef419e742afc9547634c1c214.

Currently failing with:

    "stderr": "Warning: Permanently added the RSA host key for IP address '192.30.252.123' to the list of known hosts.\r\nPermission denied (publickey).\r\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists."