### PR TITLE
teuthology-docs: Move package dependencies into the job definition

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -99,11 +99,6 @@
         - doxygen
         - ditaa
         - ant
-        # teuthology-docs job:
-        - libmysqlclient-dev
-        - libevent-dev
-        - libffi-dev
-        - libssl-dev
       when: ansible_pkg_mgr  == "apt"
 
     - name: Add the Debian Jessie Key

--- a/teuthology-docs/config/definitions/teuthology-docs.yml
+++ b/teuthology-docs/config/definitions/teuthology-docs.yml
@@ -32,4 +32,5 @@
       - shell:
           !include-raw:
             - ../../../scripts/build_utils.sh
+            - ../../setup/setup
             - ../../build/build

--- a/teuthology-docs/setup/setup
+++ b/teuthology-docs/setup/setup
@@ -3,4 +3,6 @@
 set -ex
 
 APT_DEPS="libmysqlclient-dev libevent-dev libffi-dev libssl-dev pkg-config"
-sudo apt install $APT_DEPS
+# We don't have tty-less sudo on docs.ceph.com; these deps must be installed
+# manually.
+#sudo apt install $APT_DEPS

--- a/teuthology-docs/setup/setup
+++ b/teuthology-docs/setup/setup
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+APT_DEPS="libmysqlclient-dev libevent-dev libffi-dev libssl-dev"
+sudo apt install $APT_DEPS

--- a/teuthology-docs/setup/setup
+++ b/teuthology-docs/setup/setup
@@ -2,7 +2,7 @@
 
 set -ex
 
-APT_DEPS="libmysqlclient-dev libevent-dev libffi-dev libssl-dev pkg-config"
+APT_DEPS="libmysqlclient-dev libevent-dev libffi-dev libssl-dev pkg-config libvirt-dev"
 # We don't have tty-less sudo on docs.ceph.com; these deps must be installed
 # manually.
 #sudo apt install $APT_DEPS

--- a/teuthology-docs/setup/setup
+++ b/teuthology-docs/setup/setup
@@ -2,5 +2,5 @@
 
 set -ex
 
-APT_DEPS="libmysqlclient-dev libevent-dev libffi-dev libssl-dev"
+APT_DEPS="libmysqlclient-dev libevent-dev libffi-dev libssl-dev pkg-config"
 sudo apt install $APT_DEPS


### PR DESCRIPTION
Even though we can't actually *install* them, since we don't have tty-less sudo on ``docs.dhc``, it's useful to put jobs' dependencies in the job definition.