### PR TITLE
Add xenial

### DIFF
--- a/deb_dists
+++ b/deb_dists
@@ -6,3 +6,4 @@ raring
 precise
 saucy
 trusty
+xenial

--- a/gen_debian_version.sh
+++ b/gen_debian_version.sh
@@ -8,6 +8,7 @@ dist=$2
 [ "$dist" = "wheezy" ] && dver="$raw~bpo70+1"
 [ "$dist" = "squeeze" ] && dver="$raw~bpo60+1"
 [ "$dist" = "lenny" ] && dver="$raw~bpo50+1"
+[ "$dist" = "xenial" ] && dver="$raw$dist"
 [ "$dist" = "trusty" ] && dver="$raw$dist"
 [ "$dist" = "saucy" ] && dver="$raw$dist"
 [ "$dist" = "raring" ] && dver="$raw$dist"

--- a/update_pbuilder.sh
+++ b/update_pbuilder.sh
@@ -21,6 +21,7 @@ do
     os="debian"
     [ "$dist" = "raring" ] && os="ubuntu"
     [ "$dist" = "saucy" ] && os="ubuntu"
+    [ "$dist" = "xenial" ] && os="ubuntu"
     [ "$dist" = "trusty" ] && os="ubuntu"
     [ "$dist" = "precise" ] && os="ubuntu"
     [ "$dist" = "oneiric" ] && os="ubuntu"


### PR DESCRIPTION
Gitbuilder builds on Xenial are failing due to

    + GNUPGHOME=/srv/gnupg reprepro --ask-passphrase -b ../out/output/sha1/35ecf84c44dc9cd23331d8244927923034d661e2.tmp -C main --ignore=undefinedtarget --ignore=wrongdistribution include xenial out~/ceph_10.2.0-2147-g35ecf84-1xenial_amd64.changes
    Cannot find definition of distribution 'xenial'!
    There have been errors!

Adding 'xenial' in the proper places using https://github.com/ceph/ceph-build/pull/102 as reference.

Signed-off-by: David Galloway <dgallowa@redhat.com>