### PR TITLE
include the sha1 when uploading binaries to chacra

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -72,7 +72,7 @@ gen_debian_version() {
 bpvers=`gen_debian_version $debian_version $DIST`
 
 # look for a specific package to tell if we can avoid the build
-chacra_endpoint="ceph/${chacra_ref}/${distro}/${DIST}/${ARCH}"
+chacra_endpoint="ceph/${chacra_ref}/${SHA1}/${distro}/${DIST}/${ARCH}"
 DEB_ARCH=`dpkg-architecture | grep DEB_BUILD_ARCH\= | cut -d '=' -f 2`
 chacra_check_url="${chacra_endpoint}/librados2_${bpvers}_${DEB_ARCH}.deb"
 

--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -62,7 +62,7 @@ vers=`cat ./dist/version`
 [ "$RC" = true ] && chacra_ref="$BRANCH-rc" || chacra_ref="$BRANCH"
 [ "$TEST" = true ] && chacra_ref="test"
 
-chacra_endpoint="ceph/${chacra_ref}/${DISTRO}/${RELEASE}"
+chacra_endpoint="ceph/${chacra_ref}/${SHA1}/${DISTRO}/${RELEASE}"
 chacra_check_url="${chacra_endpoint}/${ARCH}/librados2-${vers}-0.${DIST}.${ARCH}.rpm"
 
 

--- a/ceph-deploy-build/build/build
+++ b/ceph-deploy-build/build/build
@@ -13,6 +13,7 @@ echo "  BPTAG=${BPTAG}"
 echo "  WS=$WORKSPACE"
 echo "  PWD=$(pwd)"
 echo "  BRANCH=$BRANCH"
+echo "  SHA1=$SHA1"
 
 # FIXME A very naive way to just list the RPM $DIST that we currently support.
 # We should be a bit more lenient to allow any rhel/centos/sles/suse
@@ -43,7 +44,7 @@ then
         RPM_BUILD=$(lsb_release -s -c)
 
         [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
-        chacra_endpoint="ceph-deploy/${chacra_ref}/${DISTRO}/${DISTRO_VERSION}"
+        chacra_endpoint="ceph-deploy/${chacra_ref}/${SHA1}/${DISTRO}/${DISTRO_VERSION}"
 
         # this exists in scripts/build_utils.sh for ceph-deploy, binaries have
         # no architecture so we POST them to 'noarch' for rpms
@@ -89,7 +90,7 @@ then
     [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
     # ceph-deploy isn't architecture dependant, so we use 'all' as architecture and
     # uses 'universal' to signal this is not specific to any distro version
-    chacra_endpoint="ceph-deploy/${chacra_ref}/${DISTRO}/universal/all"
+    chacra_endpoint="ceph-deploy/${chacra_ref}/${SHA1}/${DISTRO}/universal/all"
 
     # this exists in scripts/build_utils.sh
     check_binary_existence $chacra_endpoint

--- a/ceph-deploy-build/build/build
+++ b/ceph-deploy-build/build/build
@@ -13,7 +13,7 @@ echo "  BPTAG=${BPTAG}"
 echo "  WS=$WORKSPACE"
 echo "  PWD=$(pwd)"
 echo "  BRANCH=$BRANCH"
-echo "  SHA1=$SHA1"
+echo "  SHA1=$GIT_COMMIT"
 
 # FIXME A very naive way to just list the RPM $DIST that we currently support.
 # We should be a bit more lenient to allow any rhel/centos/sles/suse
@@ -44,7 +44,7 @@ then
         RPM_BUILD=$(lsb_release -s -c)
 
         [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
-        chacra_endpoint="ceph-deploy/${chacra_ref}/${SHA1}/${DISTRO}/${DISTRO_VERSION}"
+        chacra_endpoint="ceph-deploy/${chacra_ref}/${GIT_COMMIT}/${DISTRO}/${DISTRO_VERSION}"
 
         # this exists in scripts/build_utils.sh for ceph-deploy, binaries have
         # no architecture so we POST them to 'noarch' for rpms
@@ -90,7 +90,7 @@ then
     [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
     # ceph-deploy isn't architecture dependant, so we use 'all' as architecture and
     # uses 'universal' to signal this is not specific to any distro version
-    chacra_endpoint="ceph-deploy/${chacra_ref}/${SHA1}/${DISTRO}/universal/all"
+    chacra_endpoint="ceph-deploy/${chacra_ref}/${GIT_COMMIT}/${DISTRO}/universal/all"
 
     # this exists in scripts/build_utils.sh
     check_binary_existence $chacra_endpoint

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -25,15 +25,15 @@ make_chacractl_config
 target=$DIST
 if [ "$target" = "centos6" ] ; then
     target=el6
-    chacra_baseurl="ceph-release/${chacra_ref}/centos/6"
+    chacra_baseurl="ceph-release/${chacra_ref}/HEAD/centos/6"
 fi
 if [ "$target" = "centos7" ] ; then
     target=el7
-    chacra_baseurl="ceph-release/${chacra_ref}/centos/7"
+    chacra_baseurl="ceph-release/${chacra_ref}/HEAD/centos/7"
 fi
 if [ "$target" = "sles11sp2" ] ; then
     target=sles11
-    chacra_baseurl="ceph-release/${chacra_ref}/sles/11"
+    chacra_baseurl="ceph-release/${chacra_ref}/HEAD/sles/11"
 fi
 echo "Target directory is: $target"
 

--- a/radosgw-agent/build/build
+++ b/radosgw-agent/build/build
@@ -9,7 +9,7 @@ echo "  BPTAG=${BPTAG}"
 echo "  WS=$WORKSPACE"
 echo "  PWD=$(pwd)"
 echo "  BRANCH=$BRANCH"
-echo "  SHA1=$SHA1"
+echo "  SHA1=$GIT_COMMIT"
 ls -l
 
 

--- a/radosgw-agent/build/build
+++ b/radosgw-agent/build/build
@@ -8,6 +8,8 @@ echo "  DIST=${DIST}"
 echo "  BPTAG=${BPTAG}"
 echo "  WS=$WORKSPACE"
 echo "  PWD=$(pwd)"
+echo "  BRANCH=$BRANCH"
+echo "  SHA1=$SHA1"
 ls -l
 
 
@@ -33,7 +35,7 @@ if [[ -f /etc/redhat-release || -f /usr/bin/zypper ]] ; then
         # get_rpm_dist is located in scripts/build_utils.sh
         get_rpm_dist
 
-        chacra_endpoint="radosgw-agent/${chacra_ref}/${DISTRO}/${DISTRO_VERSION}"
+        chacra_endpoint="radosgw-agent/${chacra_ref}/${GIT_COMMIT}/${DISTRO}/${DISTRO_VERSION}"
 
         check_binary_existence $chacra_endpoint/noarch
 
@@ -71,7 +73,7 @@ else
         DEB_BUILD=$(lsb_release -s -c)
         DISTRO=`python -c "exec 'import platform; print platform.linux_distribution()[0].lower()'"`
 
-        chacra_endpoint="radosgw-agent/${chacra_ref}/${DISTRO}/${DEB_BUILD}/noarch"
+        chacra_endpoint="radosgw-agent/${chacra_ref}/${GIT_COMMIT}/${DISTRO}/${DEB_BUILD}/noarch"
 
         check_binary_existence $chacra_endpoint
 


### PR DESCRIPTION
This can't be merged until https://github.com/ceph/chacra/pull/129 is merged and deployed.

The SHA1 variable comes from the ceph-setup job. See: https://github.com/ceph/ceph-build/pull/409