### PR TITLE
ceph-tag: always use the master branch of ceph-build

### DIFF
--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -8,6 +8,8 @@
           skip-tag: true
           wipe-workspace: true
           basedir: "ceph-build"
+          branches:
+            - origin/master
 
 - job:
     name: ceph-tag


### PR DESCRIPTION
Signed-off-by: Andrew Schoen <aschoen@redhat.com>