### PR TITLE
Make the sha1 from the current build available in the build scripts

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -44,6 +44,8 @@
           project: ceph-setup
           filter: 'dist/**'
           which-build: last-successful
+      - inject:
+          properties-file: ${WORKSPACE}/dist/sha1
       # general setup
       - shell:
           !include-raw:

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -143,3 +143,7 @@ mv release/$vers/ceph.spec dist/.
 mv release/$vers/*.tar.* dist/.
 # Parameters
 mv release/version dist/.
+
+cat > dist/sha1 << EOF
+SHA1=${GIT_COMMIT}
+EOF

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -7,6 +7,7 @@ echo "  BPTAG=${BPTAG}"
 echo "  WS=$WORKSPACE"
 echo "  PWD=$(pwd)"
 echo "  BRANCH=$BRANCH"
+echo "  SHA1=$GIT_COMMIT"
 
 if [ -x "$BRANCH" ] ; then
     echo "No git branch was supplied"


### PR DESCRIPTION
The ceph-setup job is the only one with the access to the current sha1 being built because it performs the clone of ceph. We need to write that value to a properties file that is archived and then injected into the ceph-build job.