### PR TITLE
creates a ceph-dev job for testing builds

### DIFF
--- a/ceph-dev-build/build/build_deb
+++ b/ceph-dev-build/build/build_deb
@@ -1,0 +1,192 @@
+#!/bin/bash
+set -ex
+
+# Only do actual work when we are a DEB distro
+if test -f /etc/redhat-release ; then
+    exit 0
+fi
+
+VENV="$WORKSPACE/venv/bin"
+
+get_bptag() {
+    dist=$1
+
+    [ "$dist" = "sid" ] && dver=""
+    [ "$dist" = "jessie" ] && dver="~bpo80+1"
+    [ "$dist" = "wheezy" ] && dver="~bpo70+1"
+    [ "$dist" = "squeeze" ] && dver="~bpo60+1"
+    [ "$dist" = "lenny" ] && dver="~bpo50+1"
+    [ "$dist" = "xenial" ] && dver="$dist"
+    [ "$dist" = "trusty" ] && dver="$dist"
+    [ "$dist" = "saucy" ] && dver="$dist"
+    [ "$dist" = "precise" ] && dver="$dist"
+    [ "$dist" = "oneiric" ] && dver="$dist"
+    [ "$dist" = "natty" ] && dver="$dist"
+    [ "$dist" = "maverick" ] && dver="$dist"
+    [ "$dist" = "lucid" ] && dver="$dist"
+    [ "$dist" = "karmic" ] && dver="$dist"
+
+    echo $dver
+}
+
+BPTAG=`get_bptag $DIST`
+
+chacra_ref="$BRANCH"
+vers=`cat ./dist/version`
+
+# We used to detect the $distro variable by inspecting at the host, but this is
+# not accurate because we are using pbuilder and just ubuntu to build
+# everything. That would cause POSTing binaries to incorrect chacra endpoints
+# like project/ref/ubuntu/jessie/.
+distro=""
+case $DIST in
+    jessie|wheezy)
+        distro="debian"
+        ;;
+    *)
+        distro="ubuntu"
+        ;;
+esac
+
+debian_version=${vers}-1
+
+gen_debian_version() {
+    raw=$1
+    dist=$2
+
+    [ "$dist" = "sid" ] && dver="$raw"
+    [ "$dist" = "jessie" ] && dver="$raw~bpo80+1"
+    [ "$dist" = "wheezy" ] && dver="$raw~bpo70+1"
+    [ "$dist" = "squeeze" ] && dver="$raw~bpo60+1"
+    [ "$dist" = "lenny" ] && dver="$raw~bpo50+1"
+    [ "$dist" = "precise" ] && dver="$raw$dist"
+    [ "$dist" = "saucy" ] && dver="$raw$dist"
+    [ "$dist" = "trusty" ] && dver="$raw$dist"
+    [ "$dist" = "xenial" ] && dver="$raw$dist"
+
+    echo $dver
+}
+
+bpvers=`gen_debian_version $debian_version $DIST`
+
+# look for a specific package to tell if we can avoid the build
+chacra_endpoint="ceph/${chacra_ref}/${SHA1}/${distro}/${DIST}/${ARCH}"
+DEB_ARCH=`dpkg-architecture | grep DEB_BUILD_ARCH\= | cut -d '=' -f 2`
+chacra_check_url="${chacra_endpoint}/librados2_${bpvers}_${DEB_ARCH}.deb"
+
+if [ "$THROWAWAY" = false ] ; then
+    # this exists in scripts/build_utils.sh
+    check_binary_existence $chacra_check_url
+fi
+
+HOST=$(hostname --short)
+echo "Building on $(hostname)"
+echo "  DIST=${DIST}"
+echo "  BPTAG=${BPTAG}"
+echo "  WS=$WORKSPACE"
+echo "  PWD=$(pwd)"
+echo "  BUILD SOURCE=$COPYARTIFACT_BUILD_NUMBER_CEPH_SETUP"
+echo "*****"
+env
+echo "*****"
+
+# create a release directory for ceph-build tools
+mkdir -p release
+cp -a dist release/${vers}
+echo $DIST > release/${vers}/debian_dists
+echo "${debian_version}" > release/${vers}/debian_version
+
+cd release/$vers
+
+
+# HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK
+# FIXME: I don't think we need this 'hack' anymore
+# Dirty Hack:
+baddist=$(echo $DIST | grep -ic -e squeeze -e wheezy || true)
+if [ $baddist -eq 1 ]
+then
+    sed -i 's/ libbabeltrace-ctf-dev, libbabeltrace-dev,//g' ceph_${vers}-1.dsc || true
+    sed -i 's/ liblttng-ust-dev//g' ceph_${vers}-1.dsc || true
+
+fi
+# HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK
+
+
+# unpack sources
+dpkg-source -x ceph_${vers}-1.dsc
+
+
+# HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK
+if [ $baddist -eq 1 ]
+then
+    rm -vf *.orig.tar.gz || true
+    grep -v babeltrace ceph-${vers}/debian/control  | grep -v liblttng > ceph-${vers}/debian/control.new
+    mv -v ceph-${vers}/debian/control.new ceph-${vers}/debian/control
+fi
+# HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK HACK
+
+
+(  cd ceph-${vers}
+   DEB_VERSION=$(dpkg-parsechangelog | sed -rne 's,^Version: (.*),\1, p')
+   BP_VERSION=${DEB_VERSION}${BPTAG}
+   dch -D $DIST --force-distribution -b -v "$BP_VERSION" "$comment"
+)
+dpkg-source -b ceph-${vers}
+
+echo "Building Debian"
+cd "$WORKSPACE"
+# Before, at this point, this script called the below contents that
+# was part of /srv/ceph-buid/build_debs.sh. Now everything is in here, in one
+# place, no need to checkout/clone anything. WYSIWYG::
+#
+#    sudo $bindir/build_debs.sh ./release /srv/debian-base $vers
+
+
+releasedir="./release"
+pbuilddir="/srv/debian-base"
+cephver=$vers
+
+echo version $cephver
+
+# This used to live in a *file* on /src/ceph-build. Now it lives here because
+# it doesn't make sense to have a file that lives in /srv/ that we then
+# concatenate to get its contents.
+
+
+# FIXME this looks exactly like `setup_pbuilder`, we probably don't need this
+# or we need to refactor.
+sudo pbuilder --clean
+
+echo deb vers $bpvers
+
+
+echo building debs for $DIST
+if [ `dpkg-architecture -qDEB_BUILD_ARCH` = "i386" ] ; then
+    #  Architecture dependent, independent and source
+    sudo pbuilder build \
+        --distribution $DIST \
+        --basetgz $pbuilddir/$DIST.tgz \
+        --buildresult $releasedir/$cephver \
+        --debbuildopts "-j`grep -c processor /proc/cpuinfo`" \
+        $releasedir/$cephver/ceph_$bpvers.dsc
+else
+    #  Binary only architecture dependent
+    sudo pbuilder build \
+        --binary-arch \
+        --distribution $DIST \
+        --basetgz $pbuilddir/$DIST.tgz \
+        --buildresult $releasedir/$cephver \
+        --debbuildopts "-j`grep -c processor /proc/cpuinfo`" \
+        $releasedir/$cephver/ceph_$bpvers.dsc
+fi
+
+# do lintian checks
+echo lintian checks for $bpvers
+echo lintian --allow-root $releasedir/$cephver/*$bpvers*.deb
+
+[ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
+
+if [ "$THROWAWAY" = false ] ; then
+    # push binaries to chacra
+    find release/$vers/ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+fi

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -1,0 +1,122 @@
+#!/bin/bash
+set -ex
+
+if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then
+    exit 0
+fi
+
+VENV="$WORKSPACE/venv/bin"
+
+get_rpm_dist() {
+    LSB_RELEASE=/usr/bin/lsb_release
+    [ ! -x $LSB_RELEASE ] && echo unknown && exit
+
+    ID=`$LSB_RELEASE --short --id`
+
+    case $ID in
+    RedHatEnterpriseServer)
+        RELEASE=`$LSB_RELEASE --short --release | cut -d. -f1`
+        DIST=rhel$RELEASE
+        DISTRO=rhel
+        ;;
+    CentOS)
+        RELEASE=`$LSB_RELEASE --short --release | cut -d. -f1`
+        DIST=el$RELEASE
+        DISTRO=centos
+        ;;
+    Fedora)
+        RELEASE=`$LSB_RELEASE --short --release`
+        DIST=fc$RELEASE
+        DISTRO=fedora
+        ;;
+    SUSE\ LINUX)
+        DESC=`$LSB_RELEASE --short --description`
+        RELEASE=`$LSB_RELEASE --short --release`
+        case $DESC in
+        *openSUSE*)
+                DIST=opensuse$RELEASE
+                DISTRO=opensuse
+            ;;
+        *Enterprise*)
+                DIST=sles$RELEASE
+                DISTRO=sles
+                ;;
+            esac
+        ;;
+    *)
+        DIST=unknown
+        DISTRO=unknown
+        ;;
+    esac
+
+    echo $DIST
+}
+
+get_rpm_dist
+dist=$DIST
+[ -z "$dist" ] && echo no dist && exit 1
+echo dist $dist
+
+vers=`cat ./dist/version`
+chacra_ref="$BRANCH"
+
+chacra_endpoint="ceph/${chacra_ref}/${SHA1}/${DISTRO}/${RELEASE}"
+chacra_check_url="${chacra_endpoint}/${ARCH}/librados2-${vers}-0.${DIST}.${ARCH}.rpm"
+
+
+if [ "$THROWAWAY" = false ] ; then
+    # this exists in scripts/build_utils.sh
+    check_binary_existence $chacra_check_url
+fi
+
+HOST=$(hostname --short)
+echo "Building on $(hostname)"
+echo "  DIST=${DIST}"
+echo "  ARCH=${ARCH}"
+echo "  WS=$WORKSPACE"
+echo "  PWD=$(pwd)"
+echo "  BUILD SOURCE=$COPYARTIFACT_BUILD_NUMBER_CEPH_SETUP"
+echo "*****"
+env
+echo "*****"
+
+
+# create a release directory for ceph-build tools
+mkdir -p release
+cp -a dist release/${vers}
+
+echo "Building RPMs"
+
+# The below contents ported from /srv/ceph-build/build_rpms.sh ::
+#     $bindir/build_rpms.sh ./release $vers
+#
+
+releasedir="./release"
+cephver=$vers
+
+cd $releasedir/$cephver || exit 1
+
+# Set up build area
+BUILDAREA=./rpm/$dist
+mkdir -p ${BUILDAREA}/{SOURCES,SRPMS,SPECS,RPMS,BUILD}
+cp -a ceph-*.tar.bz2 ${BUILDAREA}/SOURCES/.
+cp -a ceph.spec ${BUILDAREA}/SPECS/.
+cp -a rpm/*.patch ${BUILDAREA}/SOURCES/. || true
+
+# Build RPMs
+BUILDAREA=`readlink -fn ${BUILDAREA}`   ### rpm wants absolute path
+cd ${BUILDAREA}/SPECS
+rpmbuild -ba --define "_topdir ${BUILDAREA}" ceph.spec
+
+echo done
+
+# Make sure we execute at the top level directory
+cd "$WORKSPACE"
+
+[ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
+
+if [ "$THROWAWAY" = false ] ; then
+    # push binaries to chacra
+    find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
+    find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
+fi

--- a/ceph-dev-build/build/setup
+++ b/ceph-dev-build/build/setup
@@ -69,5 +69,7 @@ esac
 pkgs=( "chacractl>=0.0.4" )
 install_python_packages "pkgs[@]"
 
+# ask shaman which chacra instance to use
+chacra_url=`curl -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
 # create the .chacractl config file using global variables
-make_chacractl_config
+make_chacractl_config $chacra_url

--- a/ceph-dev-build/build/setup
+++ b/ceph-dev-build/build/setup
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Ceph distributed storage system
+#
+# Copyright (C) 2014 Red Hat <contact@redhat.com>
+#
+# Author: Loic Dachary <loic@dachary.org>
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+set -ex
+HOST=$(hostname --short)
+echo "Building on $(hostname)"
+echo "  DIST=${DIST}"
+echo "  BPTAG=${BPTAG}"
+echo "  KEYID=${KEYID}"
+echo "  WS=$WORKSPACE"
+echo "  PWD=$(pwd)"
+echo "  BUILD SOURCE=$COPYARTIFACT_BUILD_NUMBER_CEPH_SETUP"
+echo "*****"
+env
+echo "*****"
+
+DIR=/tmp/install-deps.$$
+trap "rm -fr $DIR" EXIT
+mkdir -p $DIR
+if test $(id -u) != 0 ; then
+    SUDO=sudo
+fi
+export LC_ALL=C # the following is vulnerable to i18n
+
+if test -f /etc/redhat-release ; then
+    $SUDO yum install -y redhat-lsb-core
+fi
+
+if which apt-get > /dev/null ; then
+    $SUDO apt-get install -y lsb-release
+fi
+
+# unpack the tar.gz that contains the debian dir
+cd dist
+tar xzf *.orig.tar.gz
+cd ceph-*
+pwd
+
+
+
+case $(lsb_release -si) in
+CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
+        case $(lsb_release -si) in
+            SUSE*)
+                $SUDO zypper -y yum-utils
+                ;;
+            *)
+                $SUDO yum install -y yum-utils
+                ;;
+        esac
+        sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
+        $SUDO yum-builddep -y $DIR/ceph.spec
+        ;;
+*)
+        echo "$(lsb_release -si) is unknown, dependencies will have to be installed manually."
+        ;;
+esac
+
+pkgs=( "chacractl>=0.0.4" )
+install_python_packages "pkgs[@]"
+
+# create the .chacractl config file using global variables
+make_chacractl_config

--- a/ceph-dev-build/build/setup_pbuilder
+++ b/ceph-dev-build/build/setup_pbuilder
@@ -1,0 +1,91 @@
+#!/bin/sh -x
+# This file will set the tgz images needed for pbuilder on a given host. It has
+# some hard-coded values like `/srv/debian-base` because it gets built every
+# time this file is executed - completely ephemeral.  If a Debian host will use
+# pbuilder, then it will need this. Since it is not idempotent it makes
+# everything a bit slower. ## FIXME ##
+
+set -e
+
+# Only run when we are a Debian or Debian-based distro
+if test -f /etc/redhat-release ; then
+    exit 0
+fi
+
+basedir="/srv/debian-base"
+
+# Ensure that the basedir directory exists
+sudo mkdir -p "$basedir"
+
+# This used to live in a *file* on /srv/ceph-build as
+# /srv/ceph-build/update_pbuilder.sh Now it lives here because it doesn't make
+# sense to have a file that lives in /srv/ that we then concatenate to get its
+# contents.  what.
+# By using $DIST we are narrowing down to updating only the distro image we
+# need, unlike before where we updated everything on every server on every
+# build.
+
+os="debian"
+[ "$DIST" = "precise" ] && os="ubuntu"
+[ "$DIST" = "saucy" ] && os="ubuntu"
+[ "$DIST" = "trusty" ] && os="ubuntu"
+[ "$DIST" = "xenial" ] && os="ubuntu"
+
+if [ $os = "debian" ]; then
+    mirror="http://www.gtlib.gatech.edu/pub/debian"
+    # this assumes that newer Debian releases are being added to
+    # /etc/apt/trusted.gpg that is also the default location for Ubuntu trusted
+    # keys. The slave should ensure that the needed keys are added accordingly
+    # to this location.
+    debootstrapopts='DEBOOTSTRAPOPTS=( "--keyring" "/etc/apt/trusted.gpg" )'
+    components='COMPONENTS="main contrib"'
+elif [ "$ARCH" = "arm64" ]; then
+    mirror="http://ports.ubuntu.com/ubuntu-ports"
+    debootstrapopts=""
+    components='COMPONENTS="main universe"'
+else
+    mirror="http://us.archive.ubuntu.com/ubuntu"
+    debootstrapopts=""
+    components='COMPONENTS="main universe"'
+fi
+
+# ensure that the tgz is valid, otherwise remove it so that it can be recreated
+# again
+pbuild_tar="$basedir/$DIST.tgz"
+is_not_tar=`python -c "exec 'try: import tarfile;print int(not int(tarfile.is_tarfile(\"$pbuild_tar\")))\nexcept IOError: print 1'"`
+file_size_kb=`du -k "$pbuild_tar" | cut -f1`
+
+if $is_not_tar; then
+    sudo rm -f "$pbuild_tar"
+fi
+
+if [ $file_size_kb -lt 1 ]; then
+    sudo rm -f "$pbuild_tar"
+fi
+
+# Ordinarily pbuilder only pulls packages from "main".  ceph depends on
+# packages like python-virtualenv which are in "universe". We have to configure
+# pbuilder to look in "universe". Otherwise the build would fail with a message similar
+# to:
+#    The following packages have unmet dependencies:
+#      pbuilder-satisfydepends-dummy : Depends: python-virtualenv which is a virtual package.
+#                                      Depends: xmlstarlet which is a virtual package.
+#     Unable to resolve dependencies!  Giving up...
+echo "$components" > ~/.pbuilderrc
+echo "$debootstrapopts" >> ~/.pbuilderrc
+
+sudo pbuilder --clean
+
+if [ -e $basedir/$DIST.tgz ]; then
+    echo updating $DIST base.tgz
+    sudo pbuilder update \
+    --basetgz $basedir/$DIST.tgz \
+    --distribution $DIST \
+    --mirror "$mirror"
+else
+    echo building $DIST base.tgz
+    sudo pbuilder create \
+    --basetgz $basedir/$DIST.tgz \
+    --distribution $DIST \
+    --mirror "$mirror"
+fi

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -1,0 +1,69 @@
+- job:
+    name: ceph-dev-build
+    project-type: matrix
+    defaults: global
+    display-name: 'ceph-dev-build'
+    block-downstream: false
+    block-upstream: false
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph
+    execution-strategy:
+      combination-filter: ARCH=="x86_64" || (ARCH == "arm64" && (DIST == "xenial" || DIST == "centos7"))
+    axes:
+      - axis:
+          type: label-expression
+          name: MACHINE_SIZE
+          values:
+            - huge
+      - axis:
+          type: label-expression
+          name: ARCH
+          values:
+            - x86_64
+            - arm64
+      - axis:
+          type: label-expression
+          name: DIST
+          values:
+            - jessie
+            #- wheezy
+            #- precise
+            - trusty
+            - xenial
+            #- centos6
+            - centos7
+
+    builders:
+      - shell: |
+          echo "Cleaning up top-level workarea (shared among workspaces)"
+          rm -rf dist
+          rm -rf venv
+          rm -rf release
+      - copyartifact:
+          project: ceph-dev-setup
+          filter: 'dist/**'
+          which-build: last-successful
+      - inject:
+          properties-file: ${WORKSPACE}/dist/sha1
+      # general setup
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/setup
+      # debian build scripts
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/setup_pbuilder
+            - ../../build/build_deb
+      # rpm build scripts
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build_rpm
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -1,0 +1,149 @@
+#!/bin/bash -ex
+
+HOST=$(hostname --short)
+echo "Building on ${HOST}"
+echo "  DIST=${DIST}"
+echo "  BPTAG=${BPTAG}"
+echo "  WS=$WORKSPACE"
+echo "  PWD=$(pwd)"
+echo "  BRANCH=$BRANCH"
+echo "  SHA1=$GIT_COMMIT"
+
+if [ -x "$BRANCH" ] ; then
+    echo "No git branch was supplied"
+    exit 1
+fi
+
+echo "Building version $(git describe) Branch $BRANCH"
+
+rm -rf dist
+rm -rf release
+
+# fix version/release.  Hack needed only for the spec
+# file for rc candidates.
+#export force=force
+#sed -i 's/^Version:.*/Version:        0.80/' ceph.spec.in
+#sed -i 's/^Release:.*/Release:        rc1%{?dist}/' ceph.spec.in
+#sed -i 's/^Source0:.*/Source0:        http:\/\/ceph.com\/download\/%{name}-%{version}-rc1.tar.bz2/' ceph.spec.in
+#sed -i 's/^%setup.*/%setup -q -n %{name}-%{version}-rc1/' ceph.spec.in
+
+# because autogen+configure will check for dependencies, we are forced to install them
+# and ensure they are present in the current host
+if [ -x install-deps.sh ]; then
+  echo "Ensuring dependencies are installed"
+  ./install-deps.sh
+fi
+
+# run submodule updates regardless
+echo "Running submodule update ..."
+git submodule update --init
+
+echo "Running autogen.sh ..."
+./autogen.sh
+echo "Running configure ..."
+./configure \
+  --disable-option-checking \
+  '--prefix=/usr' \
+  '--sbindir=/sbin' \
+  '--localstatedir=/var' \
+  '--sysconfdir=/etc' \
+  '--with-debug' \
+  '--with-nss' \
+  '--with-radosgw' \
+  '--disable-static' \
+  '--without-lttng' \
+  'CFLAGS= -Wno-unused-parameter' \
+  'CXXFLAGS=  -Wno-unused-parameter' \
+  --cache-file=/dev/null \
+  --srcdir=.
+
+mkdir -p release
+
+# Contents below used to come from /srv/release_tarball.sh and
+# was called like::
+#
+#    $bindir/release_tarball.sh release release/version
+
+releasedir='release'
+versionfile='release/version'
+
+if git diff --quiet ; then
+    echo repository is clean
+else
+    echo
+    echo "**** REPOSITORY IS DIRTY ****"
+    echo
+    if [ "$force" != "force" ]; then
+	echo "add 'force' argument if you really want to continue."
+	exit 1
+    fi
+    echo "forcing."
+fi
+
+cephver=`git describe --match "v*" | sed s/^v//`
+echo current version $cephver
+
+srcdir=`pwd`
+
+if [ -d "$releasedir/$cephver" ]; then
+    echo "$releasedir/$cephver already exists; reuse that release tarball"
+else
+    echo building tarball
+    rm ceph-*.tar.gz || true
+    rm ceph-*.tar.bz2 || true
+    make dist
+    make dist-bzip2
+
+    vers=`ls ceph-*.tar.gz | cut -c 6- | sed 's/.tar.gz//'`
+    echo tarball vers $vers
+
+    echo extracting
+    mkdir -p $releasedir/$cephver/rpm
+    cp rpm/*.patch $releasedir/$cephver/rpm || true
+    cd $releasedir/$cephver
+
+    tar zxf $srcdir/ceph-$vers.tar.gz
+    [ "$vers" != "$cephver" ] && mv ceph-$vers ceph-$cephver
+
+    tar zcf ceph_$cephver.orig.tar.gz ceph-$cephver
+    cp -a ceph_$cephver.orig.tar.gz ceph-$cephver.tar.gz
+
+    tar jcf ceph-$cephver.tar.bz2 ceph-$cephver
+
+    # copy debian dir, too
+    cp -a $srcdir/debian debian
+    cd $srcdir
+
+    # copy in spec file, too
+    cp ceph.spec $releasedir/$cephver
+fi
+
+if [ -n "$versionfile" ]; then
+    echo $cephver > $versionfile
+    echo "wrote $cephver to $versionfile"
+fi
+
+vers=`cat release/version`
+
+(
+    cd release/$vers
+    mv debian ceph-$vers/.
+    dpkg-source -b ceph-$vers
+)
+
+mkdir -p dist
+# Debian Source Files
+mv release/$vers/*.dsc dist/.
+mv release/$vers/*.diff.gz dist/.
+mv release/$vers/*.orig.tar.gz dist/.
+# RPM Source Files
+mkdir -p dist/rpm/
+mv release/$vers/rpm/*.patch dist/rpm/ || true
+mv release/$vers/ceph.spec dist/.
+mv release/$vers/*.tar.* dist/.
+# Parameters
+mv release/version dist/.
+
+cat > dist/sha1 << EOF
+SHA1=${GIT_COMMIT}
+EOF

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -1,0 +1,47 @@
+- job:
+    name: ceph-dev-setup
+    description: "This job step checks out the branch and builds the tarballs, diffs, and dsc that are passed to the ceph-dev-build step.\r\n\r\nNotes:\r\nJob needs to run on a releatively recent debian system.  The Restrict where run feature is used to specifiy an appropriate label.\r\nThe clear workspace before checkout box for the git plugin is used."
+    # we do not need to pin this to trusty anymore for the new jenkins instance
+    # FIXME: unpin when this gets ported over
+    node: huge && trusty
+    display-name: 'ceph-dev-setup'
+    logrotate:
+      daysToKeep: -1
+      numToKeep: 25
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+    block-downstream: false
+    block-upstream: false
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph
+
+    parameters:
+      - string:
+          name: BRANCH
+          description: "The git branch (or tag) to build"
+
+    scm:
+      - git:
+          url: git@github.com:ceph/ceph.git
+          # Use the SSH key attached to the ceph-jenkins GitHub account.
+          credentials-id: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
+          branches:
+            - $BRANCH
+          skip-tag: true
+          wipe-workspace: true
+
+    builders:
+      - shell:
+          !include-raw ../../build/build
+
+    publishers:
+      - archive:
+          artifacts: 'dist/**'
+          allow-empty: false
+          latest-only: false
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -22,13 +22,6 @@
           default: master
 
       - bool:
-          name: TEST
-          description: "
-If this is unchecked, then the builds will be pushed to chacra with the correct ref. This is the default.
-
-If this is checked, then the builds will be pushed to chacra under the 'test' ref."
-
-      - bool:
           name: THROWAWAY
           description: "
 Default: False. When True it will not POST binaries to chacra. Artifacts will not be around for long. Useful to test builds."

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -1,0 +1,71 @@
+- job:
+    name: ceph-dev
+    description: 'This is the main ceph build task which builds for testing purposes.'
+    project-type: multijob
+    defaults: global
+    display-name: 'ceph-dev'
+    logrotate:
+      daysToKeep: -1
+      numToKeep: 25
+      artifactDaysToKeep: 25
+      artifactNumToKeep: 25
+    block-downstream: false
+    block-upstream: false
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph
+
+    parameters:
+      - string:
+          name: BRANCH
+          description: "The git branch (or tag) to build"
+          default: master
+
+      - bool:
+          name: TEST
+          description: "
+If this is unchecked, then the builds will be pushed to chacra with the correct ref. This is the default.
+
+If this is checked, then the builds will be pushed to chacra under the 'test' ref."
+
+      - bool:
+          name: THROWAWAY
+          description: "
+Default: False. When True it will not POST binaries to chacra. Artifacts will not be around for long. Useful to test builds."
+          default: false
+
+      - bool:
+          name: FORCE
+          description: "
+If this is unchecked, then then nothing is built or pushed if they already exist in chacra. This is the default.
+
+If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
+      - string:
+          name: VERSION
+          description: "The version for release, e.g. 0.94.4"
+
+      - string:
+          name: CEPH_BUILD_VIRTUALENV
+          description: "Base parent path for virtualenv locations, set to avoid issues with extremely long paths that are incompatible with tools like pip. Defaults to '/tmp/' (note the trailing slash, which is required)."
+          default: "/tmp/"
+
+    builders:
+      - multijob:
+          name: 'ceph dev setup phase'
+          condition: SUCCESSFUL
+          projects:
+            - name: ceph-dev-setup
+              current-parameters: true
+              exposed-scm: false
+      - multijob:
+          name: 'ceph dev build phase'
+          condition: SUCCESSFUL
+          projects:
+            - name: ceph-dev-build
+              current-parameters: true
+              exposed-scm: false
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -40,8 +40,14 @@ install_python_packages () {
 
 make_chacractl_config () {
     # create the .chacractl config file
+    if [ -z "$1" ]                           # Is parameter #1 zero length?
+    then
+      url=$CHACRACTL_URL
+    else
+      url=$1
+    fi
     cat > $HOME/.chacractl << EOF
-url = "$CHACRACTL_URL"
+url = "$url"
 user = "$CHACRACTL_USER"
 key = "$CHACRACTL_KEY"
 EOF


### PR DESCRIPTION
A first pass as creating the job that will build ceph for testing purposes. This most likely will need polishing before it works correctly.

A few things:

1) SHAMAN_API_KEY and SHAMAN_API_USER need created in the Jenkins UI
2) shaman.ceph.com will need chacra nodes registered with it before it can give out chacra nodes at /api/nodes/next/
3) currently builds on a static list of distros, eventually we'll want that to dynamic and user driven
4) This currently only builds a branch, I'm unsure if passing a sha1 for that config option will work. I know a tag will.