### PR TITLE
ceph-dev: provide the ability to choose which distros are used

### DIFF
--- a/ceph-dev-build/build/setup
+++ b/ceph-dev-build/build/setup
@@ -70,6 +70,6 @@ pkgs=( "chacractl>=0.0.4" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use
-chacra_url=`curl -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
+chacra_url=`curl -f -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
 # create the .chacractl config file using global variables
 make_chacractl_config $chacra_url

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -9,7 +9,7 @@
       - github:
           url: https://github.com/ceph/ceph
     execution-strategy:
-      combination-filter: ARCH=="x86_64" || (ARCH == "arm64" && (DIST == "xenial" || DIST == "centos7"))
+       combination-filter: DIST==AVAILABLE_DIST && (ARCH=="x86_64" || (ARCH == "arm64" && (DIST == "xenial" || DIST == "centos7")))
     axes:
       - axis:
           type: label-expression
@@ -24,15 +24,19 @@
             - arm64
       - axis:
           type: label-expression
-          name: DIST
+          name: AVAILABLE_DIST
           values:
-            - jessie
-            #- wheezy
-            #- precise
             - trusty
             - xenial
-            #- centos6
             - centos7
+            - jessie
+      - axis:
+          type: dynamic
+          name: DIST
+          values:
+            - DISTROS
+
+
 
     builders:
       - shell: |

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -134,7 +134,7 @@ vers=`cat release/version`
 mkdir -p dist
 # Debian Source Files
 mv release/$vers/*.dsc dist/.
-mv release/$vers/*.diff.gz dist/.
+mv release/$vers/*.diff.gz dist/. || true
 mv release/$vers/*.orig.tar.gz dist/.
 # RPM Source Files
 mkdir -p dist/rpm/

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -38,9 +38,6 @@ Default: False. When True it will not POST binaries to chacra. Artifacts will no
 If this is unchecked, then then nothing is built or pushed if they already exist in chacra. This is the default.
 
 If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
-      - string:
-          name: VERSION
-          description: "The version for release, e.g. 0.94.4"
 
       - string:
           name: CEPH_BUILD_VIRTUALENV

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -21,6 +21,11 @@
           description: "The git branch (or tag) to build"
           default: master
 
+      - string:
+          name: DISTROS
+          description: "A list of distros to build for"
+          default: "xenial centos7"
+
       - bool:
           name: THROWAWAY
           description: "

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -23,7 +23,7 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for"
+          description: "A list of distros to build for. Available options are: xenial, centos7, trusty and jessie"
           default: "xenial centos7"
 
       - bool:

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -2,7 +2,8 @@
 
 set -ex
 
-VENV="/tmp/jenkins-venv/bin"
+TEMPVENV=$(mktemp -td venv.XXXXXXXXXX)
+VENV="$TEMPVENV/bin"
 
 install_python_packages () {
     # Use this function to create a virtualenv and install
@@ -14,8 +15,7 @@ install_python_packages () {
     #   install_python_packages "to_install[@]"
 
     # Create the virtualenv
-    rm -rf "/tmp/jenkins-venv"
-    virtualenv /tmp/jenkins-venv
+    virtualenv $TEMPVENV
 
     # Define and ensure the PIP cache
     PIP_SDIST_INDEX="$HOME/.cache/pip"

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-VENV="$WORKSPACE/venv/bin"
+VENV="/tmp/jenkins-venv/bin"
 
 install_python_packages () {
     # Use this function to create a virtualenv and install
@@ -14,8 +14,8 @@ install_python_packages () {
     #   install_python_packages "to_install[@]"
 
     # Create the virtualenv
-    rm -rf "$WORKSPACE/venv"
-    virtualenv $WORKSPACE/venv
+    rm -rf "/tmp/jenkins-venv"
+    virtualenv /tmp/jenkins-venv
 
     # Define and ensure the PIP cache
     PIP_SDIST_INDEX="$HOME/.cache/pip"


### PR DESCRIPTION
This PR allows for the user to select which distros ceph will be built for. It also fixes a few things that were found while testing.