### PR TITLE
use the value of VENV from build_utils.sh everywhere

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -71,6 +71,7 @@ bpvers=`gen_debian_version $debian_version $DIST`
 
 # look for a specific package to tell if we can avoid the build
 chacra_endpoint="ceph/${chacra_ref}/${SHA1}/${distro}/${DIST}/${ARCH}"
+chacra_repo_endpoint="ceph/${chacra_ref}/${SHA1}/${distro}/${DIST}"
 DEB_ARCH=`dpkg-architecture | grep DEB_BUILD_ARCH\= | cut -d '=' -f 2`
 chacra_check_url="${chacra_endpoint}/librados2_${bpvers}_${DEB_ARCH}.deb"
 
@@ -189,4 +190,6 @@ echo lintian --allow-root $releasedir/$cephver/*$bpvers*.deb
 if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
     find release/$vers/ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+    # start repo creation
+    $VENV/chacractl repo update ${chacra_repo_endpoint}
 fi

--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -6,8 +6,6 @@ if test -f /etc/redhat-release ; then
     exit 0
 fi
 
-VENV="$WORKSPACE/venv/bin"
-
 get_bptag() {
     dist=$1
 

--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -5,8 +5,6 @@ if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then
     exit 0
 fi
 
-VENV="$WORKSPACE/venv/bin"
-
 get_rpm_dist() {
     LSB_RELEASE=/usr/bin/lsb_release
     [ ! -x $LSB_RELEASE ] && echo unknown && exit

--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -119,4 +119,6 @@ if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
+    # start repo creation
+    $VENV/chacractl repo update ${chacra_endpoint}
 fi

--- a/ceph-deploy-build/build/build
+++ b/ceph-deploy-build/build/build
@@ -20,8 +20,6 @@ echo "  SHA1=$GIT_COMMIT"
 rpm_dists="rhel centos6 centos7 centos"
 deb_dists="precise wheezy squeeze trusty jessie"
 
-VENV="$WORKSPACE/venv/bin"
-
 # A helper to match an item in a list of items, like python's `if item in list`
 listcontains() {
   for word in $2; do

--- a/ceph-deploy-pull-requests/build/build
+++ b/ceph-deploy-pull-requests/build/build
@@ -1,0 +1,1 @@
+cd $WORKSPACE/ceph-deploy && $VENV/tox -rv

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -80,4 +80,4 @@
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
-      - shell: "cd $WORKSPACE/ceph-deploy && $WORKSPACE/venv/bin/tox -rv"
+            - ../../build/build

--- a/ceph-dev-build/build/build_deb
+++ b/ceph-dev-build/build/build_deb
@@ -69,6 +69,7 @@ bpvers=`gen_debian_version $debian_version $DIST`
 
 # look for a specific package to tell if we can avoid the build
 chacra_endpoint="ceph/${chacra_ref}/${SHA1}/${distro}/${DIST}/${ARCH}"
+chacra_repo_endpoint="ceph/${chacra_ref}/${SHA1}/${distro}/${DIST}"
 DEB_ARCH=`dpkg-architecture | grep DEB_BUILD_ARCH\= | cut -d '=' -f 2`
 chacra_check_url="${chacra_endpoint}/librados2_${bpvers}_${DEB_ARCH}.deb"
 
@@ -187,4 +188,6 @@ echo lintian --allow-root $releasedir/$cephver/*$bpvers*.deb
 if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
     find release/$vers/ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+    # start repo creation
+    $VENV/chacractl repo update ${chacra_repo_endpoint}
 fi

--- a/ceph-dev-build/build/build_deb
+++ b/ceph-dev-build/build/build_deb
@@ -6,8 +6,6 @@ if test -f /etc/redhat-release ; then
     exit 0
 fi
 
-VENV="$WORKSPACE/venv/bin"
-
 get_bptag() {
     dist=$1
 

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -5,8 +5,6 @@ if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then
     exit 0
 fi
 
-VENV="$WORKSPACE/venv/bin"
-
 get_rpm_dist() {
     LSB_RELEASE=/usr/bin/lsb_release
     [ ! -x $LSB_RELEASE ] && echo unknown && exit

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -117,4 +117,6 @@ if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
+    # start repo creation
+    $VENV/chacractl repo update ${chacra_endpoint}
 fi


### PR DESCRIPTION
We need to do this now as the virtualenv is being created in a temp directory and not a standard path.