### PR TITLE
ansible: use letsencrypt renew vs. asking for a new cert every 12 hours

### DIFF
--- a/ansible/roles/nginx/tasks/letsencrypt.yml
+++ b/ansible/roles/nginx/tasks/letsencrypt.yml
@@ -44,7 +44,7 @@
     name: "renew letsencrypt cert for {{ item.app_name }}"
     minute: "21"
     hour: "6,18"
-    job: "letsencrypt renew"
+    job: "letsencrypt renew --agree-tos  --email {{ ssl_support_email }}"
   sudo: yes
   with_items: nginx_hosts
 

--- a/ansible/roles/nginx/tasks/letsencrypt.yml
+++ b/ansible/roles/nginx/tasks/letsencrypt.yml
@@ -42,9 +42,9 @@
 - name: setup a cron to renew the SSL cert every day
   cron:
     name: "renew letsencrypt cert for {{ item.app_name }}"
-    minute: "0"
+    minute: "21"
     hour: "6,18"
-    job: "letsencrypt certonly --webroot -w {{ ssl_webroot_base_path }}/{{ item.fqdn }} -d {{ item.fqdn }} --email {{ ssl_support_email }} --agree-tos --renew-by-default"
+    job: "letsencrypt renew"
   sudo: yes
   with_items: nginx_hosts
 


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>