### PR TITLE
ceph-dev-build: add scripts to validate distro type

### DIFF
--- a/ceph-dev-build/build/build_deb
+++ b/ceph-dev-build/build/build_deb
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -ex
 
-# Only do actual work when we are a DEB distro
-if test -f /etc/redhat-release ; then
-    exit 0
-fi
-
 cd $WORKSPACE
 
 get_bptag() {

--- a/ceph-dev-build/build/validate_deb
+++ b/ceph-dev-build/build/validate_deb
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+
+# Only do actual work when we are a DEB distro
+if test -f /etc/redhat-release ; then
+    exit 0
+fi

--- a/ceph-dev-build/build/validate_rpm
+++ b/ceph-dev-build/build/validate_rpm
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+
+# only do work if we are a RPM distro
+if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then
+    exit 0
+fi

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -53,6 +53,7 @@
       # debian build scripts
       - shell:
           !include-raw:
+            - ../../build/validate_deb
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/setup_pbuilder
@@ -60,6 +61,7 @@
       # rpm build scripts
       - shell:
           !include-raw:
+            - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_rpm


### PR DESCRIPTION
This will make sure a build script fails early if it will not work on
the distro being built for. Doing this early avoids duplicate calls to
the build_utils and setup scripts.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>