### PR TITLE
calamari-server-trusty: Install multitee before we use it

### DIFF
--- a/calamari-server-trusty/build/build
+++ b/calamari-server-trusty/build/build
@@ -8,7 +8,7 @@ sudo add-apt-repository -y ppa:saltstack/salt
 sudo apt-get update
 wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
 ssh-keyscan $(hostname -f)| sudo tee -a /root/.ssh/known_hosts
-sudo apt-get -y install salt-minion salt-common python-jinja2
+sudo apt-get -y install salt-minion salt-common python-jinja2 multitee
 
 sudo salt-call --local --file-root=$(pwd)/vagrant/trusty-build/salt/roots state.highstate | multitee 0-1,4 4>/tmp/${BUILD_TAG}.out
 


### PR DESCRIPTION
The calamari-server-trusty build fails because there is no multitee available. Fix this by installing it before running the multitee'd salt command.