### PR TITLE
ceph-dev-setup: ensure that the debian dir exists before copying

### DIFF
--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -169,6 +169,7 @@ vers=`cat release/version`
 
 (
     cd release/$vers
+    mkdir -p ceph-$vers/debian
     cp -r debian/* ceph-$vers/debian/
     dpkg-source -b ceph-$vers
 )


### PR DESCRIPTION
Prevents this from failing:

    cp: target ‘ceph-10.2.2-427-g089bb43/debian/’ is not a directory
    Build step 'Execute shell' marked build as failure