### PR TITLE
ceph-build: setup must be performed for both deb and rpm

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -46,21 +46,18 @@
           which-build: last-successful
       - inject:
           properties-file: ${WORKSPACE}/dist/sha1
-      # general setup
-      - shell:
-          !include-raw:
-            - ../../../scripts/build_utils.sh
-            - ../../build/setup
       # debian build scripts
       - shell:
           !include-raw:
             - ../../../scripts/build_utils.sh
+            - ../../build/setup
             - ../../build/setup_pbuilder
             - ../../build/build_deb
       # rpm build scripts
       - shell:
           !include-raw:
             - ../../../scripts/build_utils.sh
+            - ../../build/setup
             - ../../build/build_rpm
 
     wrappers:


### PR DESCRIPTION
If we do setup in it's own -shell then the virtualenv created there will
not be used in the other two -shell sections. This is because we
switched from using a standard venv to using one created in a temp
directory.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>