### PR TITLE
cd to $WORKSPACE before building

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -6,6 +6,8 @@ if test -f /etc/redhat-release ; then
     exit 0
 fi
 
+cd $WORKSPACE
+
 get_bptag() {
     dist=$1
 

--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -5,6 +5,8 @@ if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then
     exit 0
 fi
 
+cd "$WORKSPACE"
+
 get_rpm_dist() {
     LSB_RELEASE=/usr/bin/lsb_release
     [ ! -x $LSB_RELEASE ] && echo unknown && exit


### PR DESCRIPTION
To avoid:

    ++ cat ./dist/version
    cat: ./dist/version: No such file or directory