### PR TITLE
Ceph build updates

### DIFF
--- a/ceph-build/build/validate_deb
+++ b/ceph-build/build/validate_deb
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+
+# Only do actual work when we are a DEB distro
+if test -f /etc/redhat-release ; then
+    exit 0
+fi

--- a/ceph-build/build/validate_rpm
+++ b/ceph-build/build/validate_rpm
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+
+# only do work if we are a RPM distro
+if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then
+    exit 0
+fi

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -9,7 +9,7 @@
       - github:
           url: https://github.com/ceph/ceph
     execution-strategy:
-      combination-filter: ARCH=="x86_64" || (ARCH == "arm64" && (DIST == "xenial" || DIST == "centos7"))
+       combination-filter: DIST==AVAILABLE_DIST && ARCH==AVAILABLE_ARCH && (ARCH=="x86_64" || (ARCH == "arm64" && (DIST == "xenial" || DIST == "centos7")))
     axes:
       - axis:
           type: label-expression
@@ -18,21 +18,31 @@
             - huge
       - axis:
           type: label-expression
-          name: ARCH
+          name: AVAILABLE_ARCH
           values:
             - x86_64
             - arm64
       - axis:
           type: label-expression
-          name: DIST
+          name: AVAILABLE_DIST
           values:
-            - jessie
-            #- wheezy
-            #- precise
             - trusty
             - xenial
-            #- centos6
             - centos7
+            - jessie
+            - precise
+            - centos6
+            - wheezy
+      - axis:
+          type: dynamic
+          name: DIST
+          values:
+            - DISTROS
+      - axis:
+          type: dynamic
+          name: ARCH
+          values:
+            - ARCHS
 
     builders:
       - shell: |

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -59,6 +59,7 @@
       # debian build scripts
       - shell:
           !include-raw:
+            - ../../build/validate_deb
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/setup_pbuilder
@@ -66,6 +67,7 @@
       # rpm build scripts
       - shell:
           !include-raw:
+            - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_rpm

--- a/ceph/config/definitions/ceph.yml
+++ b/ceph/config/definitions/ceph.yml
@@ -69,6 +69,16 @@ Defaults to un-checked"
           description: "Base parent path for virtualenv locations, set to avoid issues with extremely long paths that are incompatible with tools like pip. Defaults to '/tmp/' (note the trailing slash, which is required)."
           default: "/tmp/"
 
+      - string:
+          name: DISTROS
+          description: "A list of distros to build for. Available options are: xenial, centos7, centos6, trusty, precise, wheezy, and jessie"
+          default: "xenial centos7"
+
+      - string:
+          name: ARCHS
+          description: "A list of architectures to build for. Available options are: x86_64, and arm64"
+          default: "x86_64"
+
     builders:
       - multijob:
           name: 'ceph tag phase'


### PR DESCRIPTION
This gets ceph-build caught up with the features we added to ceph-dev-build.

You can now pick with distros and archs you wish to build for. This also adds validation scripts that will very early avoid build scripts that do not pertain to the distro being built for by the current job.