### PR TITLE
ceph-dev-build: add centos6, precise, and wheezy to available distros

### DIFF
--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -30,6 +30,9 @@
             - xenial
             - centos7
             - jessie
+            - precise
+            - centos6
+            - wheezy
       - axis:
           type: dynamic
           name: DIST

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -24,7 +24,7 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: xenial, centos7, trusty, and jessie"
+          description: "A list of distros to build for. Available options are: xenial, centos7, centos6, trusty, precise, wheezy, and jessie"
           default: "xenial centos7"
 
       - string:


### PR DESCRIPTION
Signed-off-by: Andrew Schoen <aschoen@redhat.com>