### PR TITLE
ceph-dev: specify a laxed pinning for nodes

### DIFF
--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -1,5 +1,6 @@
 - job:
     name: ceph-dev-build
+    node: trusty || centos7 || xenial || master
     project-type: matrix
     defaults: global
     display-name: 'ceph-dev-build'

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -1,6 +1,7 @@
 - job:
     name: ceph-dev
     description: 'This is the main ceph build task which builds for testing purposes.'
+    node: trusty || centos7 || xenial || master
     project-type: multijob
     defaults: global
     concurrent: true


### PR DESCRIPTION
Should avoid this situation:

![screen shot 2016-08-30 at 2 08 29 pm](https://cloud.githubusercontent.com/assets/317847/18101046/487e7476-6ebb-11e6-8ccc-e45ecf1ae065.png)
