### PR TITLE
ceph-dev-build: adds a new package_manager_version field to repo extra

### DIFF
--- a/ceph-dev-build/build/build_deb
+++ b/ceph-dev-build/build/build_deb
@@ -189,6 +189,7 @@ if [ "$THROWAWAY" = false ] ; then
     cat > $WORKSPACE/repo-extra.json << EOF
 {
     "version":"$vers",
+    "package_manager_version":"$dver",
     "build_url":"$BUILD_URL",
     "root_build_cause":"$ROOT_BUILD_CAUSE",
     "node_name":"$NODE_NAME",

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -229,6 +229,7 @@ if [ "$THROWAWAY" = false ] ; then
     cat > $WORKSPACE/repo-extra.json << EOF
 {
     "version":"$vers",
+    "package_manager_version":"$vers",
     "build_url":"$BUILD_URL",
     "root_build_cause":"$ROOT_BUILD_CAUSE",
     "node_name":"$NODE_NAME",


### PR DESCRIPTION
For DEB repos there is a different version that apt uses, this
allows the API to provide that information as well as the project
version.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>