### PR TITLE
further fixing for spliting branches on forward slashes

### DIFF
--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
-BRANCH=`echo $GIT_BRANCH | cut -d '/' -f 2-`
+# split on '/' to get just 'wip-mybranch' when input is like: origin/wip-mybranch
+BRANCH=`echo ${GIT_BRANCH} | rev | cut -d '/' -f 1 | rev`
 
 HOST=$(hostname --short)
 echo "Building on ${HOST}"

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -1,7 +1,16 @@
 #!/bin/bash -ex
 
-# split on '/' to get just 'wip-mybranch' when input is like: origin/wip-mybranch
+branch_slashes=$(grep -o "/" <<< ${GIT_BRANCH} | wc -l)
 BRANCH=`echo ${GIT_BRANCH} | rev | cut -d '/' -f 1 | rev`
+
+# Prevent building branches that have slashes in their name
+if [ "$((branch_slashes))" -gt 1 ] ; then
+    echo "Will refuse to build branch: ${GIT_BRANCH}"
+    echo "Invalid branch name (contains slashes): ${BRANCH}"
+    exit 1
+fi
+
+# split on '/' to get just 'wip-mybranch' when input is like: origin/wip-mybranch
 
 HOST=$(hostname --short)
 echo "Building on ${HOST}"


### PR DESCRIPTION
And prevent them from building if the actual branch name contains a slash.

E.g. This would not build:

    origin/historic/async_mds