### PR TITLE
ceph-dev-build: modify autosetup when setup is not defined in spec file

### DIFF
--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -113,7 +113,7 @@ PACKAGE_MANAGER_VERSION="$RPM_VERSION-$RPM_RELEASE"
 # Set up build area
 BUILDAREA=./rpm/$dist
 mkdir -p ${BUILDAREA}/{SOURCES,SRPMS,SPECS,RPMS,BUILD}
-cp -a ceph-$vers.tar.bz2 ${BUILDAREA}/SOURCES/ceph-$raw_version.tar.bz2
+cp -a ceph-*.tar.bz2 ${BUILDAREA}/SOURCES/.
 cp -a ceph.spec ${BUILDAREA}/SPECS/.
 cp -a rpm/*.patch ${BUILDAREA}/SOURCES/. || true
 

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -99,6 +99,8 @@ cd $releasedir/$cephver || exit 1
 
 # modify the spec file so that it understands we are dealing with a different directory
 sed -i "s/^%setup.*/%setup -q -n %{name}-$vers/" ceph.spec
+# it is entirely possible that `%setup` is not even used, but rather, autosetup
+sed -i "s/^%autosetup.*/%autosetup -p1 -n %{name}-$vers/" ceph.spec
 
 # This is needed because the 'version' this job gets from upstream contains chars
 # that are not legal for an RPM file. These are already converted in the spec file whic


### PR DESCRIPTION
Newer Ceph uses autosetup, not setup.