### PR TITLE
pin jobs to master that used to use huge_xenial_builder`

### DIFF
--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-dev-build
-    node: huge_xenial_builder
+    node: master
     project-type: matrix
     defaults: global
     display-name: 'ceph-dev-build'

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-dev-trigger
-    node: huge_xenial_builder
+    node: master
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-dev
     description: 'This is the main ceph build task which builds for testing purposes.'
-    node: huge_xenial_builder
+    node: master
     project-type: multijob
     defaults: global
     concurrent: true


### PR DESCRIPTION
We want these jobs to use master until we can enable mita to spin up nodes with many executors for these types of "coordinating" jobs.