### PR TITLE
jenkins-job-builder: should not use the master node

### DIFF
--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -1,6 +1,6 @@
 - job:
     name: jenkins-job-builder
-    node: (small && trusty) || master
+    node: small
     project-type: freestyle
     defaults: global
     display-name: 'Jenkins Job Builder'


### PR DESCRIPTION
master is not setup for building anything and does not have virtualenv
installed which this job needs. In general, we don't want jobs that do
any "building' to use master.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>