### PR TITLE
ceph-dev: fix debian binary names

### DIFF
--- a/ceph-dev-build/build/build_deb
+++ b/ceph-dev-build/build/build_deb
@@ -167,7 +167,7 @@ if [ `dpkg-architecture -qDEB_BUILD_ARCH` = "i386" ] ; then
         --basetgz $pbuilddir/$DIST.tgz \
         --buildresult $releasedir/$cephver \
         --debbuildopts "-j`grep -c processor /proc/cpuinfo`" \
-        $releasedir/$cephver/ceph_$vers-1.dsc
+        $releasedir/$cephver/ceph_$bpvers.dsc
 else
     #  Binary only architecture dependent
     sudo pbuilder build \
@@ -176,7 +176,7 @@ else
         --basetgz $pbuilddir/$DIST.tgz \
         --buildresult $releasedir/$cephver \
         --debbuildopts "-j`grep -c processor /proc/cpuinfo`" \
-        $releasedir/$cephver/ceph_$vers-1.dsc
+        $releasedir/$cephver/ceph_$bpvers.dsc
 fi
 
 # do lintian checks

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -96,8 +96,6 @@ srcdir=`pwd`
 if [ -d "$releasedir/$cephver" ]; then
     echo "$releasedir/$cephver already exists; reuse that release tarball"
 else
-    dch -v $cephver-1 'autobuilder'
-
     echo building tarball
     rm ceph-*.tar.gz || true
     rm ceph-*.tar.bz2 || true


### PR DESCRIPTION
Before this the binaries produced did not include the distro codename in the filename.

This fixes the issues described here: https://github.com/ceph/shaman/issues/57#issuecomment-246037415