### PR TITLE
ceph-dev-setup: add back the dch -v command

### DIFF
--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -96,6 +96,8 @@ srcdir=`pwd`
 if [ -d "$releasedir/$cephver" ]; then
     echo "$releasedir/$cephver already exists; reuse that release tarball"
 else
+    dch -v $cephver-1 'autobuilder'
+
     echo building tarball
     rm ceph-*.tar.gz || true
     rm ceph-*.tar.bz2 || true


### PR DESCRIPTION
Without this command the dsc artifacts are not created correctly and
ceph-dev-build fails to find them, resulting in errors like:

"dpkg-source: error: cannot read ceph_10.2.2-508-g9bfc0cf-1.dsc: No such
file or directory"

From:
https://jenkins.ceph.com/job/ceph-dev-build/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=xenial,DIST=xenial,MACHINE_SIZE=huge/492/console

Signed-off-by: Andrew Schoen <aschoen@redhat.com>