### PR TITLE
set BUILD_HOME in pbuilderrc

### DIFF
--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -73,6 +73,9 @@ fi
 #     Unable to resolve dependencies!  Giving up...
 echo "$components" > ~/.pbuilderrc
 echo "$debootstrapopts" >> ~/.pbuilderrc
+# Newer pbuilder versions set $HOME to /nonexistent which breaks all kinds of
+# things that rely on a proper (writable) home directory
+echo "BUILD_HOME=/home/`whoami`/.pbuilderrc" >> ~/.pbuilderrc
 
 sudo pbuilder --clean
 

--- a/ceph-dev-build/build/setup_pbuilder
+++ b/ceph-dev-build/build/setup_pbuilder
@@ -73,6 +73,9 @@ fi
 #     Unable to resolve dependencies!  Giving up...
 echo "$components" > ~/.pbuilderrc
 echo "$debootstrapopts" >> ~/.pbuilderrc
+# Newer pbuilder versions set $HOME to /nonexistent which breaks all kinds of
+# things that rely on a proper (writable) home directory
+echo "BUILD_HOME=/home/`whoami`/.pbuilderrc" >> ~/.pbuilderrc
 
 sudo pbuilder --clean
 


### PR DESCRIPTION
Newer versions of pbuilder maps `$HOME` to `/nonexistent`. This breaks everything that relies on writing files to `$HOME`. This PR reverts this back to what it was before `0.220`

From the changelog entry:

    * configuration:
      + new config: BUILD_HOME: set the value of HOME while building.
        Default it to /nonexistent to prevent builds from writing to /home.
        This reverts what was done for #170762.  Closes: #441052

The actual failure in a Jenkins node (xenial) failed like:

    Complete output from command /tmp/ceph-disk-virtualenv/bin/python2.7 - setuptools pkg_resources pip wheel:
      The directory '/nonexistent/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
    The directory '/nonexistent/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
    Collecting setuptools
