### PR TITLE
ansible: install python2.7 on xenial nodes

### DIFF
--- a/ansible/examples/init.yml
+++ b/ansible/examples/init.yml
@@ -5,6 +5,17 @@
 # one. This should be run against newly brought up hosts when they are going to
 # be publicly accessible.
 
+# install python2.7 on xenial nodes
+- hosts: all
+  sudo: yes
+  user: admin 
+  gather_facts: false
+  tasks:
+    - name: install python-simplejson
+      raw: sudo apt-get -y install python-simplejson
+      # so that this is ignored on rpm nodes
+      failed_when: false
+
 - hosts: all
   user: admin
   sudo: true


### PR DESCRIPTION
We use this playbook on new chacra nodes to set the SSH port to 2222. All new chacra nodes are xenial, so we'll also need to install python2.7 on these nodes before ansible modules will work.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>