### PR TITLE
ceph-dev: also build trusty by default

### DIFF
--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -26,7 +26,7 @@
       - string:
           name: DISTROS
           description: "A list of distros to build for. Available options are: xenial, centos7, centos6, trusty, precise, wheezy, and jessie"
-          default: "xenial centos7"
+          default: "xenial trusty centos7"
 
       - string:
           name: ARCHS


### PR DESCRIPTION
The sepia lab is mostly testing on trusty, so we want to build trusty by
default as well.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>