### PR TITLE
set BUILD_HOME to the right path

### DIFF
--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -75,7 +75,7 @@ echo "$components" > ~/.pbuilderrc
 echo "$debootstrapopts" >> ~/.pbuilderrc
 # Newer pbuilder versions set $HOME to /nonexistent which breaks all kinds of
 # things that rely on a proper (writable) home directory
-echo "BUILD_HOME=/home/`whoami`/.pbuilderrc" >> ~/.pbuilderrc
+echo "BUILD_HOME=/home/`whoami`" >> ~/.pbuilderrc
 
 sudo pbuilder --clean
 

--- a/ceph-dev-build/build/setup_pbuilder
+++ b/ceph-dev-build/build/setup_pbuilder
@@ -75,7 +75,7 @@ echo "$components" > ~/.pbuilderrc
 echo "$debootstrapopts" >> ~/.pbuilderrc
 # Newer pbuilder versions set $HOME to /nonexistent which breaks all kinds of
 # things that rely on a proper (writable) home directory
-echo "BUILD_HOME=/home/`whoami`/.pbuilderrc" >> ~/.pbuilderrc
+echo "BUILD_HOME=/home/`whoami`" >> ~/.pbuilderrc
 
 sudo pbuilder --clean
 


### PR DESCRIPTION
It was making `.pbuilderrc` (the configuration **file**) a directory. This makes it right