### PR TITLE
cmake: modified several scripts for cmake support

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -81,6 +81,7 @@
         - autoconf
         - redhat-lsb-core
         - automake
+        - cmake
         - binutils
         - bison
         - flex

--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -111,6 +111,7 @@
         - autoconf
         - redhat-lsb-core
         - automake
+        - cmake
         - binutils
         - bison
         - flex
@@ -151,6 +152,7 @@
         - libtool
         - autotools-dev
         - automake
+        - cmake
         - debian-archive-keyring
         # jenkins-job-builder job:
         - libyaml-dev

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -43,25 +43,43 @@ echo "Running submodule update ..."
 git submodule update --init
 
 # Flavor Builds support
-# TODO: enable CMAKE
-#export CEPH_EXTRA_CMAKE_ARGS
 
-FLAVOR_FLAGS="--without-cryptopp"
+#cryptopp is not default for CMake
+AUTOCONF_FLAVOR_FLAGS="--without-cryptopp"
 
 if [ "${FLAVOR}" == "notcmalloc" ]
 then
-    echo "Detected notcmalloc flavor: will use flag: --without-tcmalloc"
-    FLAVOR_FLAGS="$FLAVOR_FLAGS --without-tcmalloc"
-    #export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
+    echo "Detected notcmalloc flavor: will use flag: --without-tcmalloc or -DALLOCATOR=libc"
+    AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --without-tcmalloc"
+    export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
 else
-    FLAVOR_FLAGS="$FLAVOR_FLAGS --with-tcmalloc"
-    #export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
+    AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --with-tcmalloc"
+    export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
 fi
 
-if [ "${FLAVOR}" == "blkin" ]
-then
-    echo "Detected bklin flavor: will use flag: --with-blkin"
-    FLAVOR_FLAGS="$FLAVOR_FLAGS --with-blkin"
+
+# make-dist does not exist for autotools builds
+if [ ! -x make-dist ]
+    echo "Using autotools build system"
+    echo "Running autogen.sh ..."
+    ./autogen.sh
+    echo "Running configure ..."
+    ./configure \
+      --disable-option-checking \
+      '--prefix=/usr' \
+      '--sbindir=/sbin' \
+      '--localstatedir=/var' \
+      '--sysconfdir=/etc' \
+      '--with-debug' \
+      '--with-nss' \
+      '--with-radosgw' \
+      '--disable-static' \
+      '--without-lttng' \
+      $AUTOCONF_FLAVOR_FLAGS \
+      'CFLAGS= -Wno-unused-parameter' \
+      'CXXFLAGS=  -Wno-unused-parameter' \
+      --cache-file=/dev/null \
+      --srcdir=.
 fi
 
 mkdir -p release
@@ -104,38 +122,18 @@ else
 
     if [ -x make-dist ]
     then
-      ./make-dist $cephver
-      vers=`ls ceph-*.tar.bz2 | cut -c 6- | sed 's/.tar.bz2//'`
-      extension="tar.bz2"
-      extract_flags="jxf"
-      compress_flags="jcf"
+        ./make-dist $cephver
+        vers=`ls ceph-*.tar.bz2 | cut -c 6- | sed 's/.tar.bz2//'`
+        extension="tar.bz2"
+        extract_flags="jxf"
+        compress_flags="jcf"
     else
-      echo "Running autogen.sh ..."
-      ./autogen.sh
-      echo "Running configure ..."
-      ./configure \
-        --disable-option-checking \
-        '--prefix=/usr' \
-        '--sbindir=/sbin' \
-        '--localstatedir=/var' \
-        '--sysconfdir=/etc' \
-        '--with-debug' \
-        '--with-nss' \
-        '--with-radosgw' \
-        '--disable-static' \
-        '--without-lttng' \
-        $FLAVOR_FLAGS \
-        'CFLAGS= -Wno-unused-parameter' \
-        'CXXFLAGS=  -Wno-unused-parameter' \
-        --cache-file=/dev/null \
-        --srcdir=.
-
-      make dist
-      make dist-bzip2
-      vers=`ls ceph-*.tar.gz | cut -c 6- | sed 's/.tar.gz//'`
-      extension="tar.gz"
-      extract_flags="zxf"
-      compress_flags="zcf"
+        make dist
+        make dist-bzip2
+        vers=`ls ceph-*.tar.gz | cut -c 6- | sed 's/.tar.gz//'`
+        extension="tar.gz"
+        extract_flags="zxf"
+        compress_flags="zcf"
     fi
 
     echo tarball vers $vers

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -56,9 +56,8 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           choices:
             - default
             - notcmalloc
-            - blkin
           default: "default"
-          description: "Type of Ceph build, choices are: notcmalloc, and blkin. Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: notcmalloc, default (i.e. with tcmalloc). Defaults to: 'default'"
 
     builders:
       - multijob:

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -38,24 +38,44 @@ fi
 echo "Running submodule update ..."
 git submodule update --init
 
-echo "Running autogen.sh ..."
-./autogen.sh
-echo "Running configure ..."
-./configure \
-  --disable-option-checking \
-  '--prefix=/usr' \
-  '--sbindir=/sbin' \
-  '--localstatedir=/var' \
-  '--sysconfdir=/etc' \
-  '--with-debug' \
-  '--with-nss' \
-  '--with-radosgw' \
-  '--disable-static' \
-  '--without-lttng' \
-  'CFLAGS= -Wno-unused-parameter' \
-  'CXXFLAGS=  -Wno-unused-parameter' \
-  --cache-file=/dev/null \
-  --srcdir=.
+# Flavor Builds support
+
+#cryptopp is not default for CMake
+AUTOCONF_FLAVOR_FLAGS="--without-cryptopp"
+
+if [ "${FLAVOR}" == "notcmalloc" ]
+then
+    echo "Detected notcmalloc flavor: will use flag: --without-tcmalloc or -DALLOCATOR=libc"
+    AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --without-tcmalloc"
+    export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
+else
+    AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --with-tcmalloc"
+    export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
+fi
+
+# make-dist does not exist for autotools builds
+if [ ! -x make-dist ]
+    echo "Using autotools build system"
+    echo "Running autogen.sh ..."
+    ./autogen.sh
+    echo "Running configure ..."
+    ./configure \
+      --disable-option-checking \
+      '--prefix=/usr' \
+      '--sbindir=/sbin' \
+      '--localstatedir=/var' \
+      '--sysconfdir=/etc' \
+      '--with-debug' \
+      '--with-nss' \
+      '--with-radosgw' \
+      '--disable-static' \
+      '--without-lttng' \
+      $AUTOCONF_FLAVOR_FLAGS \
+      'CFLAGS= -Wno-unused-parameter' \
+      'CXXFLAGS=  -Wno-unused-parameter' \
+      --cache-file=/dev/null \
+      --srcdir=.
+fi
 
 mkdir -p release
 
@@ -92,10 +112,22 @@ else
     echo building tarball
     rm ceph-*.tar.gz || true
     rm ceph-*.tar.bz2 || true
-    make dist
-    make dist-bzip2
+    if [ -x make-dist ]
+    then
+        ./make-dist $cephver
+        vers=`ls ceph-*.tar.bz2 | cut -c 6- | sed 's/.tar.bz2//'`
+        extension="tar.bz2"
+        extract_flags="jxf"
+        compress_flags="jcf"
+    else
+        make dist
+        make dist-bzip2
+        vers=`ls ceph-*.tar.gz | cut -c 6- | sed 's/.tar.gz//'`
+        extension="tar.gz"
+        extract_flags="zxf"
+        compress_flags="zcf"
+    fi
 
-    vers=`ls ceph-*.tar.gz | cut -c 6- | sed 's/.tar.gz//'`
     echo tarball vers $vers
 
     echo extracting


### PR DESCRIPTION
This is a first crack at release builds supporting cmake and autotools.

To Do: modify ceph/ceph.spec.in to support CEPH_EXTRA_CMAKE_ARGS

Signed-off-by: Ali Maredia <amaredia@redhat.com>