### PR TITLE
allow network access in pbuilder builds

### DIFF
--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -74,8 +74,15 @@ fi
 echo "$components" > ~/.pbuilderrc
 echo "$debootstrapopts" >> ~/.pbuilderrc
 # Newer pbuilder versions set $HOME to /nonexistent which breaks all kinds of
-# things that rely on a proper (writable) home directory
-echo "BUILD_HOME=/home/`whoami`" >> ~/.pbuilderrc
+# things that rely on a proper (writable) path. Setting this to the system user's $HOME is not enough
+# because of how pbuilder uses a chroot environment for builds, using a temporary directory here ensures
+# that writes will be successful.
+echo "BUILD_HOME=`mktemp -d`" >> ~/.pbuilderrc
+# Some Ceph components will want to use cached wheels that may have older versions of buggy executables
+# like: /usr/share/python-wheels/pip-8.1.1-py2.py3-none-any.whl which causes errors that are already fixed
+# in newer versions. This ticket solves the specific issue in 8.1.1 (which vendors urllib3):
+# https://github.com/shazow/urllib3/issues/567
+echo "USENETWORK=yes" >> ~/.pbuilderrc
 
 sudo pbuilder --clean
 

--- a/ceph-dev-build/build/setup_pbuilder
+++ b/ceph-dev-build/build/setup_pbuilder
@@ -74,8 +74,15 @@ fi
 echo "$components" > ~/.pbuilderrc
 echo "$debootstrapopts" >> ~/.pbuilderrc
 # Newer pbuilder versions set $HOME to /nonexistent which breaks all kinds of
-# things that rely on a proper (writable) home directory
-echo "BUILD_HOME=/home/`whoami`" >> ~/.pbuilderrc
+# things that rely on a proper (writable) path. Setting this to the system user's $HOME is not enough
+# because of how pbuilder uses a chroot environment for builds, using a temporary directory here ensures
+# that writes will be successful.
+echo "BUILD_HOME=`mktemp -d`" >> ~/.pbuilderrc
+# Some Ceph components will want to use cached wheels that may have older versions of buggy executables
+# like: /usr/share/python-wheels/pip-8.1.1-py2.py3-none-any.whl which causes errors that are already fixed
+# in newer versions. This ticket solves the specific issue in 8.1.1 (which vendors urllib3):
+# https://github.com/shazow/urllib3/issues/567
+echo "USENETWORK=yes" >> ~/.pbuilderrc
 
 sudo pbuilder --clean
 


### PR DESCRIPTION
Because ceph components may want to install things that are cached and buggy in certain environments. Hi Xenial. Hello there pip 8.1.1. How are you urllib3