### PR TITLE
ansible: set hostname on slaves

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -182,6 +182,11 @@
         path: "/home/{{ jenkins_user }}/.gitconfig"
         owner: "{{ jenkins_user }}"
 
+    - name: Set Hostname with hostname command
+      sudo: yes
+      hostname:
+        name: "{{ ansible_hostname }}"
+
     - name: ensure that the current host is in /etc/hosts. Yes this is a thing.
       sudo: true
       replace:

--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -213,6 +213,11 @@
         path: "/home/{{ jenkins_user }}/.gitconfig"
         owner: "{{ jenkins_user }}"
 
+    - name: Set Hostname with hostname command
+      sudo: yes
+      hostname:
+        name: "{{ ansible_hostname }}"
+
     - name: ensure that the current host is in /etc/hosts. Yes this is a thing.
       sudo: true
       replace:


### PR DESCRIPTION
We are seeing OVH slaves fail builds because they can not use sudo. When inspecting the nodes we see the hostname is set to ``(none)``. This should fix that.