### PR TITLE
ansible: always add 'ceph-builders' to /etc/hosts

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -194,14 +194,14 @@
         backup: yes
         dest: /etc/hosts
         regexp: '^(127\.0\.1\.1(?!.*\b{{ ansible_hostname }}\b).*)$'
-        replace: '\1 {{ ansible_hostname }}'
+        replace: '\1 {{ ansible_hostname }} ceph-builders'
 
     - name: ensure that 127.0.1.1 is present with an actual hostname
       sudo: true
       lineinfile:
         dest: /etc/hosts
         regexp: '^(127\.0\.1\.1(?!.*\b{{ ansible_hostname }}\b).*)$'
-        line: '127.0.1.1 {{ ansible_hostname }}'
+        line: '127.0.1.1 {{ ansible_hostname }} ceph-builders'
 
     - name: install six, latest one
       sudo: true


### PR DESCRIPTION
The nodes we spin up in OVH are using an image that sets the hostname
to 'ceph-builders'. Also, the hostname we give it is too long to use and
ansible silenty fails to set it.

This change ensures that nodes can use sudo correctly and avoids errors
like: 'sudo: unable to resolve host ceph-builders'.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>