### PR TITLE
ansible: set use_jnlp: false in slave.yml

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -11,7 +11,7 @@
    - api_uri: 'https://jenkins.ceph.com'
    - nodename: '{{ nodename }}'
    - labels: '{{ labels }}'
-   - use_jnlp: '{{ use_jnlp|default(false) }}'
+   - use_jnlp: false
 
   tasks:
     - name: create a {{ jenkins_user }} user


### PR DESCRIPTION
We will never use prado to setup slaves using jnlp and
the way this was before was causing a recursion error when
ansible was trying to render the playbook.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>