### PR TITLE
post build info status to shaman on failure

### DIFF
--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -81,6 +81,7 @@
     publishers:
       - postbuildscript:
           script-only-if-failed: True
+          script-only-if-succeeded: False 
           builders:
             - shell:
                 !include-raw:

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -46,6 +46,7 @@
 
       - postbuildscript:
           script-only-if-failed: True
+          script-only-if-succeeded: False 
           builders:
             - shell:
                 !include-raw:


### PR DESCRIPTION
You have to explicitly set ``script-only-if-succeeded`` to ``False`` because the default is ``True`` and even if you set ``script-only-if-failed`` to ``True`` jenkins checks the other value first and fails the build without running the postbuildscript.