### PR TITLE
we need to set variables when reporting build failures

### DIFF
--- a/ceph-dev-build/build/failure
+++ b/ceph-dev-build/build/failure
@@ -3,6 +3,7 @@
 # note: the failed_build_status call relies on normalized variable names that
 # are infered by the builds themselves. If the build fails before these are
 # set, they will be posted with empty values
+BRANCH=`branch_slash_filter $BRANCH`
 
 # update shaman with the failed build status
 failed_build_status "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH

--- a/ceph-dev-setup/build/failure
+++ b/ceph-dev-setup/build/failure
@@ -3,4 +3,7 @@
 # update shaman with the failed build status. At this point there aren't any
 # architectures or distro information, so we just report this with the current
 # (ceph-dev-setup) build information that includes log and build urls
+BRANCH=`branch_slash_filter $BRANCH`
+SHA1=${GIT_COMMIT}
+
 failed_build_status "ceph"


### PR DESCRIPTION
The failure scripts are not run in the same context as the build scripts, so they do not get the modified versions for ``BRANCH`` or ``SHA1``. They will get the fresh versions from ``ceph-ev``  which causes trouble in shaman when a branch looks like ``origin/*``.