### PR TITLE
ceph-dev-build: write the correct vars to build_info in setup_rpm

### DIFF
--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -110,8 +110,8 @@ NORMAL_ARCH=$ARCH
 # Write these values to a file so the failure
 # script can consume them if the build fails
 cat > $WORKSPACE/build_info << EOF
-NORMAL_DISTRO=$distro
-NORMAL_DISTRO_VERSION=$DIST
+NORMAL_DISTRO=$DISTRO
+NORMAL_DISTRO_VERSION=$RELEASE
 NORMAL_ARCH=$ARCH
 SHA1=$SHA1
 EOF


### PR DESCRIPTION
I was using the incorrect values for the NORMAL_* values in setup_rpm
which was posting incorrect information to shaman.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>