### PR TITLE
scripts: create the build_info properties file when updating shaman

### DIFF
--- a/ceph-dev-build/build/setup_deb
+++ b/ceph-dev-build/build/setup_deb
@@ -99,15 +99,6 @@ NORMAL_DISTRO=$distro
 NORMAL_DISTRO_VERSION=$DIST
 NORMAL_ARCH=$ARCH
 
-# Write these values to a file so the failure
-# script can consume them if the build fails
-cat > $WORKSPACE/build_info << EOF
-NORMAL_DISTRO=$distro
-NORMAL_DISTRO_VERSION=$DIST
-NORMAL_ARCH=$ARCH
-SHA1=$SHA1
-EOF
-
 # create build status in shaman
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -107,15 +107,6 @@ NORMAL_DISTRO=$DISTRO
 NORMAL_DISTRO_VERSION=$RELEASE
 NORMAL_ARCH=$ARCH
 
-# Write these values to a file so the failure
-# script can consume them if the build fails
-cat > $WORKSPACE/build_info << EOF
-NORMAL_DISTRO=$DISTRO
-NORMAL_DISTRO_VERSION=$RELEASE
-NORMAL_ARCH=$ARCH
-SHA1=$SHA1
-EOF
-
 # create build status in shaman
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -161,6 +161,16 @@ submit_build_status() {
 }
 EOF
 
+    # these variables are saved in this jenkins
+    # properties file so that other scripts
+    # in the same job can inject them
+    cat > $WORKSPACE/build_info << EOF
+NORMAL_DISTRO=$distro
+NORMAL_DISTRO_VERSION=$distro_version
+NORMAL_ARCH=$distro_arch
+SHA1=$SHA1
+EOF
+
     SHAMAN_URL="https://shaman.ceph.com/api/builds/$project/"
     # post the build information as JSON to shaman
     curl -X $http_method -H "Content-Type:application/json" --data "@$WORKSPACE/build_status.json" -u $SHAMAN_API_USER:$SHAMAN_API_KEY ${SHAMAN_URL}


### PR DESCRIPTION
Centralizes the creation of the build_info properties file in build_utils.sh so that other jobs don't need to create it.