### PR TITLE
Docker fixes

### DIFF
--- a/ceph-docker-pull-requests/build/build
+++ b/ceph-docker-pull-requests/build/build
@@ -36,5 +36,4 @@ sudo docker run -d --name ceph-demo --net=host -v /etc/ceph:/etc/ceph -v /var/li
 sudo "$WORKSPACE"/ceph-docker/travis-builds/validate_demo_cluster.sh
 
 # on success
-sudo docker exec ceph-mon ceph -s
 sudo docker exec ceph-demo ceph -s

--- a/ceph-docker-pull-requests/build/failure
+++ b/ceph-docker-pull-requests/build/failure
@@ -2,6 +2,12 @@
 
 set -ex
 
+# The below calls can be so verbose that using a header will make it
+# easier to track the actual failure point
+printf '=%.0s' {1..100}
+echo "ON FAILURE BUILD STEP"
+printf '=%.0s' {1..100}
+
 # on failure:
 sudo docker images
 sudo docker ps


### PR DESCRIPTION
Remove the ceph-mon call since it isn't really available and add a header before `on failure` scripts are called because they tend to be super verbose, making it hard to tell where the actual failure ocurred