### PR TITLE
ceph-dev-trigger: force push even when remote package exists

### DIFF
--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -36,3 +36,4 @@
         - project: 'ceph-dev'
           predefined-parameters:
             BRANCH=${GIT_BRANCH}
+            FORCE=True


### PR DESCRIPTION
dev builds should not really hit this, but as we start getting into dev workflow we see that it is entirely possible to get in a situation where the binary existed, and the whole build will fail because the binary was there.

This check was useful mostly for releases, for dev workflows it should just accept a forceful update