### PR TITLE
add ceph-installer-rpm job

### DIFF
--- a/ceph-installer-rpm/build/build
+++ b/ceph-installer-rpm/build/build
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -ex
+
+# Sanity-check:
+[ -z "$GIT_BRANCH" ] && echo Missing GIT_BRANCH variable && exit 1
+
+sudo yum -y install epel-release
+sudo yum -y install fedpkg
+
+# Add the Jenkins slave UID to the mock group.
+sudo usermod -a -G mock $(whoami)
+
+# Attempt the build. If it fails, print the mock logs to STDOUT.
+make rpm || ( tail -n +1 {root,build}.log && exit 1 )
+
+# Chacra time
+
+pkgs=( "chacractl>=0.0.4" )
+install_python_packages "pkgs[@]"
+
+# ask shaman which chacra instance to use
+chacra_url=`curl -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
+# create the .chacractl config file using global variables
+make_chacractl_config $chacra_url
+
+BRANCH=`branch_slash_filter $GIT_BRANCH`
+
+## Upload the created RPMs to chacra
+chacra_endpoint="ceph-installer/${BRANCH}/${GIT_COMMIT}/centos/7"
+
+[ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
+
+# push binaries to chacra
+ls *.rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/noarch/
+
+# start repo creation
+$VENV/chacractl repo update ${chacra_endpoint}
+
+echo Check the status of the repo at: https://shaman.ceph.com/api/repos/${chacra_endpoint}

--- a/ceph-installer-rpm/config/ceph-installer-rpm.yml
+++ b/ceph-installer-rpm/config/ceph-installer-rpm.yml
@@ -1,0 +1,44 @@
+- job:
+    name: ceph-installer-rpm
+    node: 'centos7 && x86_64 && small'
+    project-type: freestyle
+    defaults: global
+    disabled: false
+    display-name: 'ceph-installer: RPMs'
+    description: 'Build RPMs for every ceph-installer Git branch'
+    concurrent: true
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-installer
+    discard-old-builds: true
+    logrotate:
+      daysToKeep: 1
+      numToKeep: 10
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    triggers:
+      - github
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-installer
+          browser: auto
+          skip-tag: true
+          timeout: 20
+          wipe-workspace: true
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../scripts/build_utils.sh
+            - ../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true


### PR DESCRIPTION
This job builds RPMs for each ceph-installer GitHub branch.

NOTE: the current build script does not yet upload the builds to chacra. How should I implement that?
