### PR TITLE
Fix CI errors caused by container status commands

### DIFF
--- a/ceph-docker-pull-requests/build/build
+++ b/ceph-docker-pull-requests/build/build
@@ -17,7 +17,12 @@ sudo apt-get install -y --force-yes xfsprogs
 sudo "$WORKSPACE"/ceph-docker/travis-builds/purge_cluster.sh
 # XXX purge_cluster only stops containers, it doesn't really remove them so try to
 # remove them for real
-sudo docker rm -f $@ $(sudo docker ps -a -q)
+containers_to_remove=$(sudo docker ps -a -q)
+
+if [ "${containers_to_remove}" ]; then
+    sudo docker rm -f $@ ${containers_to_remove} || echo failed to remove containers
+fi
+
 
 sudo "$WORKSPACE"/ceph-docker/travis-builds/build_imgs.sh
 


### PR DESCRIPTION
The docker ps command was returning no containers that caused the docker
rm command to fail. That, combined with the set -e flag was causing the
build script to exit prematurely.

Signed-off-by: Ivan Font <ifont@redhat.com>