### PR TITLE
ceph-ansible-pull-requests: force ansible version

### DIFF
--- a/ceph-ansible-pull-requests/build/build
+++ b/ceph-ansible-pull-requests/build/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "ansible" )
+pkgs=( "ansible==2.1" )
 install_python_packages "pkgs[@]"
 
 # ceph-ansible does a check on the installed version of ansible and


### PR DESCRIPTION
Ansible 2.2 seems to be breaking things, let's stick with 2.1 for now.

Signed-off-by: Sébastien Han <seb@redhat.com>