### PR TITLE
ceph-pull-requests: remove ccache

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -120,6 +120,8 @@
         - python-pip
         - python-virtualenv
         - libtool
+        - libssl-dev
+        - libffi-dev
         - autotools-dev
         - automake
         - debian-archive-keyring

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -46,7 +46,7 @@
           wipe-workspace: true
 
     builders:
-      - shell: "ccache -M 5G; ccache -z; export NPROC=$(nproc); timeout 7200 ./run-make-check.sh; ccache -s"
+      - shell: "export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
 
     publishers:
       - postbuildscript:


### PR DESCRIPTION
We aren't installing the dependency in the new tenant and these machines are
short lived anyway.

Signed-off-by: Alfredo Deza <adeza@redhat.com>