### PR TITLE
updates to the kernel build job

### DIFF
--- a/kernel/build/build_deb
+++ b/kernel/build/build_deb
@@ -106,7 +106,7 @@ cd "$WORKSPACE"
 
 if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
-    find ../*.deb | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${DEB_ARCH}/
+    find ../*.deb | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/
 
     # start repo creation
     $VENV/chacractl repo update ${chacra_endpoint}

--- a/kernel/build/setup
+++ b/kernel/build/setup
@@ -56,10 +56,7 @@ esac
 pkgs=( "chacractl>=0.0.4" )
 install_python_packages "pkgs[@]"
 
-# ask shaman which chacra instance to use
-chacra_url=`curl -f -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
-# create the .chacractl config file using global variables
-make_chacractl_config $chacra_url
+make_chacractl_config
 
 # Make sure we execute at the top level directory
 cd "$WORKSPACE"

--- a/kernel/config/definitions/kernel.yml
+++ b/kernel/config/definitions/kernel.yml
@@ -14,7 +14,7 @@
       - string:
           name: DISTROS
           description: "A list of distros to build for. Available options are: xenial, centos7, centos6, trusty, precise, wheezy, and jessie"
-          default: "centos7 precise xenial"
+          default: "centos7 trusty xenial"
 
       - string:
           name: ARCHS


### PR DESCRIPTION
Includes:

- posting deb binaries to chacra as x86_64 instead of amd64

- building for trusty instead of precise by default

- uploading to chacra.ceph.com instead of a test chacra instance so binaries persist past 2 weeks