### PR TITLE
ceph{-dev}-{setup,build}: pass CMAKE_EXTRA_CONFIG_ARGS

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -57,6 +57,8 @@
           which-build: multijob-build
       - inject:
           properties-file: ${WORKSPACE}/dist/sha1
+      - inject:
+          properties-file: ${WORKSPACE}/dist/other_envvars
       # debian build scripts
       - shell:
           !include-raw:

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -62,6 +62,8 @@
           properties-file: ${WORKSPACE}/dist/sha1
       - inject:
           properties-file: ${WORKSPACE}/dist/branch
+      - inject:
+          properties-file: ${WORKSPACE}/dist/other_envvars
       # debian build scripts
       - shell:
           !include-raw:

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -198,3 +198,7 @@ EOF
 cat > dist/branch << EOF
 BRANCH=${BRANCH}
 EOF
+
+cat > dist/other_envvars << EOF
+CEPH_EXTRA_CMAKE_ARGS="${CEPH_EXTRA_CMAKE_ARGS}"
+EOF

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -183,3 +183,7 @@ mv release/version dist/.
 cat > dist/sha1 << EOF
 SHA1=${GIT_COMMIT}
 EOF
+
+cat > dist/other_envvars << EOF
+CEPH_EXTRA_CMAKE_ARGS="${CEPH_EXTRA_CMAKE_ARGS}"
+EOF


### PR DESCRIPTION
Inject another file, this one a 'catchall' of other environment variables
that -setup may need to pass to -build.  At the moment, that contains
CEPH_EXTRA_CMAKE_ARGS, but there doesn't seem to be much point in creating
one file per variable.

Signed-off-by: Dan Mick <dan.mick@redhat.com>