### PR TITLE
ansible: add missing ssl deps to static deb builders

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -131,6 +131,7 @@
         - doxygen
         - ditaa
         - ant
+        - curl
       when: ansible_pkg_mgr  == "apt"
 
     - name: Add the Debian Jessie Key

--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -150,6 +150,8 @@
         - python-pip
         - python-virtualenv
         - libtool
+        - libssl-dev
+        - libffi-dev
         - autotools-dev
         - automake
         - cmake


### PR DESCRIPTION
Also, install curl on all slaves

Signed-off-by: David Galloway <dgallowa@redhat.com>