### PR TITLE
Ceph ansible tox

### DIFF
--- a/ceph-ansible-pull-requests/build/build
+++ b/ceph-ansible-pull-requests/build/build
@@ -1,40 +1,10 @@
 #!/bin/bash
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "ansible==2.1" )
+pkgs=( "tox" )
 install_python_packages "pkgs[@]"
 
-# ceph-ansible does a check on the installed version of ansible and
-# without our virtualenv activated it can not find it and fails
+# XXX this might not be needed
 source $VENV/activate
 
-devices='["/dev/vdb"]'
-ceph_stable="true"
-journal_collocation="true"
-journal_size=1024
-# both our trusty and centos nodes created in OVH use eth0
-monitor_interface="eth0"
-if [[ "$DIST" == "ceph_ansible_pr_xenial" ]]; then
-    monitor_interface="ens3"
-fi
-cluster_network="127.0.0.1/0"
-public_network="127.0.0.1/0"
-fsid="4a158d27-f750-41d5-9e7f-26ce4c9d2d45"
-monitor_secret="AQAWqilTCDh7CBAAawXt6kyTgLFCxSvJhTEmuw=="
-
-cat > $HOME/test-vars.json << EOF
-{
-    "devices":$devices,
-    "ceph_stable":$ceph_stable,
-    "journal_collocation":$journal_collocation,
-    "journal_size":$journal_size,
-    "monitor_interface":"$monitor_interface",
-    "cluster_network":"$cluster_network",
-    "public_network":"$cluster_network",
-    "fsid":"$fsid",
-    "monitor_secret":"$monitor_secret"
-}
-EOF
-
-cd "$WORKSPACE"/ceph-ansible
-$VENV/ansible-playbook -vvv -i tests/inventories/single-machine.yml -c local test.yml --extra-vars "@$HOME/test-vars.json"
+$VENV/tox -rv -- --provider=libvirt

--- a/ceph-ansible-pull-requests/build/teardown
+++ b/ceph-ansible-pull-requests/build/teardown
@@ -1,7 +1,13 @@
 #!/bin/bash
+# There has to be a better way to do this than this script which just looks
+# for every Vagrantfile in scenarios and then just destroys whatever is left.
 
-NODE=$(echo $NODE_NAME | awk -F'__' '{print $2}')
-# The "delay" means that mita will wait these many seconds before proceeding
-# with the deletion of the node
-echo "curl -k  -d '{"delay": 5}' -X POST https://mita.ceph.com/api/nodes/${NODE}/delete/"
-curl -k  -d '{"delay": 5}' -X POST https://mita.ceph.com/api/nodes/${NODE}/delete/
+cd $WORKSPACE
+
+scenarios=$(find . | grep Vagrantfile | xargs dirname)
+
+for scenario in $scenarios; do
+    cd $scenario
+    vagrant destroy -f
+    cd -
+done

--- a/ceph-ansible-pull-requests/build/teardown
+++ b/ceph-ansible-pull-requests/build/teardown
@@ -2,7 +2,7 @@
 # There has to be a better way to do this than this script which just looks
 # for every Vagrantfile in scenarios and then just destroys whatever is left.
 
-cd $WORKSPACE
+cd $WORKSPACE/tests
 
 scenarios=$(find . | grep Vagrantfile | xargs dirname)
 

--- a/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
+++ b/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
@@ -1,21 +1,7 @@
-- scm:
-    name: ceph-ansible
-    scm:
-      - git:
-          url: https://github.com/ceph/ceph-ansible.git
-          branches:
-            - ${sha1}
-          refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: auto
-          timeout: 20
-          skip-tag: true
-          wipe-workspace: false
-          basedir: "ceph-ansible"
-
 - job:
     name: ceph-ansible-pull-requests
     # disabling for now, until libvirt/vagrant tests are in place
-    disabled: true
+    disabled: false
     project-type: matrix
     defaults: global
     display-name: 'ceph-ansible: Pull Requests'
@@ -55,13 +41,21 @@
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false
-          status-context: "Testing Playbooks"
-          started-status: "Running ansible playbook"
+          status-context: "Testing cluster scenarios"
+          started-status: "Running ansible playbooks"
           success-status: "OK - Run completed"
           failure-status: "Playbook run failed with errors"
 
     scm:
-      - ceph-ansible
+      - git:
+          url: https://github.com/ceph/ceph-ansible.git
+          branches:
+            - ${sha1}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: false
 
     builders:
       - shell:

--- a/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
+++ b/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
@@ -2,7 +2,8 @@
     name: ceph-ansible-pull-requests
     # disabling for now, until libvirt/vagrant tests are in place
     disabled: false
-    project-type: matrix
+    # ties it to the one node that has this labels
+    node: vagrant&&ceph-ansible
     defaults: global
     display-name: 'ceph-ansible: Pull Requests'
     quiet-period: 5
@@ -12,14 +13,6 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph-ansible
-    axes:
-      - axis:
-          type: label-expression
-          name: DIST
-          values:
-            - ceph_ansible_pr_trusty
-            - ceph_ansible_pr_xenial
-            - ceph_ansible_pr_centos7
     logrotate:
       daysToKeep: 15
       numToKeep: 30


### PR DESCRIPTION
Enables the new tox-based testing for ceph-ansible pull requests.

This will require some extra work on the node assign to it to ensure that it runs properly. 