### PR TITLE
ceph-ansible: bump ansible version to 2.2

### DIFF
--- a/ceph-ansible-pull-requests/build/build
+++ b/ceph-ansible-pull-requests/build/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "ansible==2.1" )
+pkgs=( "ansible==2.2" )
 install_python_packages "pkgs[@]"
 
 # ceph-ansible does a check on the installed version of ansible and


### PR DESCRIPTION
ceph-ansible is now fully compliant with ansible 2.2 so bumping the
ansible version to make we test the right things.

Signed-off-by: Sébastien Han <seb@redhat.com>