### PR TITLE
ceph-ansible-pull-requests: only run teardown on failure

### DIFF
--- a/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
+++ b/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
@@ -59,6 +59,6 @@
     publishers:
       - postbuildscript:
           script-only-if-succeeded: False
-          script-only-if-failed: False
+          script-only-if-failed: True
           builders:
             - shell: !include-raw ../../build/teardown


### PR DESCRIPTION
If the tests succeed tox will clean up everything for us so
we only need to run this on failure.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>