### PR TITLE
kernel: upload binaries to a dev chacra instance

### DIFF
--- a/kernel/build/build_deb
+++ b/kernel/build/build_deb
@@ -112,7 +112,7 @@ if [ "$THROWAWAY" = false ] ; then
 }
 EOF
     # post the json to repo-extra json to chacra
-    curl -X POST -H "Content-Type:application/json" --data "@$WORKSPACE/repo-extra.json" -u $CHACRACTL_USER:$CHACRACTL_KEY https://chacra.ceph.com/repos/${chacra_endpoint}/extra/
+    curl -X POST -H "Content-Type:application/json" --data "@$WORKSPACE/repo-extra.json" -u $CHACRACTL_USER:$CHACRACTL_KEY ${chacra_url}repos/${chacra_endpoint}/extra/
 
     # start repo creation
     $VENV/chacractl repo update ${chacra_endpoint}

--- a/kernel/build/build_rpm
+++ b/kernel/build/build_rpm
@@ -97,7 +97,7 @@ if [ "$THROWAWAY" = false ] ; then
 }
 EOF
     # post the json to repo-extra json to chacra
-    curl -X POST -H "Content-Type:application/json" --data "@$WORKSPACE/repo-extra.json" -u $CHACRACTL_USER:$CHACRACTL_KEY https://chacra.ceph.com/repos/${chacra_endpoint}/extra/
+    curl -X POST -H "Content-Type:application/json" --data "@$WORKSPACE/repo-extra.json" -u $CHACRACTL_USER:$CHACRACTL_KEY ${chacra_url}repos/${chacra_endpoint}/extra/
 
     # start repo creation
     $VENV/chacractl repo update ${chacra_endpoint}

--- a/kernel/build/setup
+++ b/kernel/build/setup
@@ -56,7 +56,9 @@ esac
 pkgs=( "chacractl>=0.0.4" )
 install_python_packages "pkgs[@]"
 
-make_chacractl_config
+# ask shaman which chacra instance to use
+chacra_url=`curl -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
+make_chacractl_config $chacra_url
 
 # Make sure we execute at the top level directory
 cd "$WORKSPACE"


### PR DESCRIPTION
The chacra instances are now configured to always keep
a build for the 'testing' ref, so it should be safe
to store these in the dev chacra instances now.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>