### PR TITLE
ceph-ansible-pull-requests: make the job concurrent so other slaves can do work too

### DIFF
--- a/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
+++ b/ceph-ansible-pull-requests/config/definitions/ceph-ansible-pull-requests.yml
@@ -4,6 +4,7 @@
     disabled: false
     # ties it to the one node that has this labels
     node: vagrant&&ceph-ansible
+    concurrent: true
     defaults: global
     display-name: 'ceph-ansible: Pull Requests'
     quiet-period: 5


### PR DESCRIPTION
The idea is to have more slaves and not make every build request wait in line