### PR TITLE
ceph-ansible-pr-syntax-check: add a trigger phrase

### DIFF
--- a/ceph-ansible-pr-syntax-check/config/definitions/ceph-ansible-pr-syntax-check.yml
+++ b/ceph-ansible-pr-syntax-check/config/definitions/ceph-ansible-pr-syntax-check.yml
@@ -42,14 +42,14 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          trigger-phrase: ''
+          trigger-phrase: 'jenkins test playbook syntax'
           only-trigger-phrase: false
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false
-          status-context: "Testing Playbook Syntax"
+          status-context: "Testing: playbook syntax"
           started-status: "Running syntax checks on all playbooks"
-          success-status: "OK - checks completed"
+          success-status: "OK - syntax checks completed"
           failure-status: "Syntax check failed with errors"
 
     scm:


### PR DESCRIPTION
Adds the trigger phrase 'jenkins test playbook syntax' to start a build
of this job.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>