### PR TITLE
ceph-ansible-prs: update labels required

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -9,7 +9,7 @@
 
 - job-template:
     name: 'ceph-ansible-prs-{scenario}'
-    node: vagrant&&ceph-ansible
+    node: vagrant&&libvirt
     concurrent: true
     defaults: global
     display-name: 'ceph-ansible: Pull Requests [{scenario}]'


### PR DESCRIPTION
Using a '-' breaks the service that creates machines based on labels
since it evaluates it as Python and '-' is seen as an operator

Signed-off-by: Alfredo Deza <adeza@redhat.com>