### PR TITLE
ceph-ansible-galaxy: update the splitup script

### DIFF
--- a/ceph-ansible-galaxy/build/build
+++ b/ceph-ansible-galaxy/build/build
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# the following method exists in scripts/build_utils.sh
-pkgs=( "ansible" )
-install_python_packages "pkgs[@]"
-
-cd "$WORKSPACE"/ceph-ansible
 # propagates the change in the necessary Ansible Galaxy repos.
 # i.e. https://github.com/ceph/ansible-ceph-common
-$VENV/ansible-playbook -i dummy-ansible-hosts contrib/splitup.yml --tags update 
+bash "$WORKSPACE"/contrib/push-roles-to-ansible-galaxy.sh


### PR DESCRIPTION
We now use the latest version of the splitup.sh script that now pushes
branches and tags from ceph-ansible to ansible-ceph-* repositories.

Signed-off-by: Sébastien Han <seb@redhat.com>