### PR TITLE
ceph-ansible-syntax: update syntax check

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -15,6 +15,6 @@ $VENV/ansible-playbook -i '127.0.0.1,' site-docker.yml.sample --syntax-check --l
 # infrastructure-playbooks directory for easier syntax checking
 cp -r roles infrastructure-playbooks/
 cp -r group_vars infrastructure-playbooks/
-mv infrastructure-playbooks/group_vars/all.sample infrastructure-playbooks/group_vars/all
+mv infrastructure-playbooks/group_vars/all.yml.sample infrastructure-playbooks/group_vars/all
 
 $VENV/ansible-playbook -i '127.0.0.1,' infrastructure-playbooks/*.yml --syntax-check --list-tasks -vv


### PR DESCRIPTION
We now use group_vars/alll.yml files. So only yaml files, this
ceph-ansible PR introduced that:
https://github.com/ceph/ceph-ansible/pull/1113

So we apply the change here as well.

Signed-off-by: Sébastien Han <seb@redhat.com>