### PR TITLE
ceph-ansible-galaxy: fix workspace path

### DIFF
--- a/ceph-ansible-galaxy/build/build
+++ b/ceph-ansible-galaxy/build/build
@@ -2,4 +2,4 @@
 
 # propagates the change in the necessary Ansible Galaxy repos.
 # i.e. https://github.com/ceph/ansible-ceph-common
-bash "$WORKSPACE"/contrib/push-roles-to-ansible-galaxy.sh
+bash "$WORKSPACE"/ceph-ansible/contrib/push-roles-to-ansible-galaxy.sh


### PR DESCRIPTION
The current path to execute the script is wrong, see:
bash:
/home/jenkins-build/build/workspace/ceph-ansible-galaxy/contrib/push-roles-to-ansible-galaxy.sh:
No such file or directory

It tries to execute
ceph-ansible-galaxy/contrib/push-roles-to-ansible-galaxy.sh where the
actual script is in
ceph-ansible-galaxy/ceph-ansible/contrib/push-roles-to-ansible-galaxy.sh

This commit fixes this.

Signed-off-by: Sébastien Han <seb@redhat.com>