### PR TITLE
ceph-ansible-prs: set a working directory for tox

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -7,7 +7,8 @@ install_python_packages "pkgs[@]"
 # XXX this might not be needed
 source $VENV/activate
 
+WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment
-$VENV/tox -rv -e=$SCENARIO -- --provider=libvirt
+$VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR -- --provider=libvirt


### PR DESCRIPTION
We need to set a working directory for tox because the default for some
scenarios are too long and the job fails to call pip because it exceeds
the char limit.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>