### PR TITLE
ceph-ansible-pr-syntax-check: adds a x86_64 label

### DIFF
--- a/ceph-ansible-pr-syntax-check/config/definitions/ceph-ansible-pr-syntax-check.yml
+++ b/ceph-ansible-pr-syntax-check/config/definitions/ceph-ansible-pr-syntax-check.yml
@@ -14,7 +14,7 @@
 
 - job:
     name: ceph-ansible-pr-syntax-check
-    node: centos7 || trusty
+    node: (centos7 || trusty) && x86_64
     project-type: freestyle
     defaults: global
     concurrent: true


### PR DESCRIPTION
We don't want this job picking up our arm64 slaves.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>