### PR TITLE
ceph-ansible-prs: use underscores instead of dashes for scenarios

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,11 +1,11 @@
 - project:
     name: ceph-ansible-prs
     scenario:
-      - ansible2.2-centos7-cluster
-      - ansible2.2-xenial-cluster
-      - ansible2.2-journal-collocation
-      - ansible2.2-dmcrypt-journal
-      - ansible2.2-dmcrypt-journal-collocation
+      - ansible2.2-centos7_cluster
+      - ansible2.2-xenial_cluster
+      - ansible2.2-journal_collocation
+      - ansible2.2-dmcrypt_journal
+      - ansible2.2-dmcrypt_journal_collocation
     jobs:
         - 'ceph-ansible-prs-{scenario}'
 


### PR DESCRIPTION
This avoids an issue in tox where it splits on dashes and picks an
incorrect scenario because we had dashes in our environment names.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>