### PR TITLE
ceph-ansible-prs: add 2 scenarios

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -3,6 +3,8 @@
     scenario:
       - ansible2.2-centos7_cluster
       - ansible2.2-xenial_cluster
+      - ansible2.2-xenial_conf_tests
+      - ansible2.2-xenial_mon_osd
       - ansible2.2-journal_collocation
       - ansible2.2-dmcrypt_journal
       - ansible2.2-dmcrypt_journal_collocation


### PR DESCRIPTION
Both:

* xenial_mon_osd: tests a 1 mon 1 osd xenial cluster using
raw_multi_journal OSD scenario

* xenial_conf_tests: test a 3 mon cluster and ensures
ceph.conf is rendered correctly

were missing, so adding them to the CI.

Signed-off-by: Sébastien Han <seb@redhat.com>