### PR TITLE
ceph-ansible-pr-syntax-check: change playbook path

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -7,6 +7,8 @@ pkgs=( "ansible")
 install_python_packages "pkgs[@]"
 
 cd $WORKSPACE/ceph-ansible
+cp ./sites/site.yml.sample site.yml.sample
+cp ./sites/site-docker.yml.sample site-docker.yml.sample
 
 $VENV/ansible-playbook -i '127.0.0.1,' site.yml.sample --syntax-check --list-tasks -vv
 $VENV/ansible-playbook -i '127.0.0.1,' site-docker.yml.sample --syntax-check --list-tasks -vv


### PR DESCRIPTION
https://github.com/ceph/ceph-ansible/pull/1140 did a bit of cleanup and
regor so we have to modify the CI as well.

Do not merge before https://github.com/ceph/ceph-ansible/pull/1140

Signed-off-by: Sébastien Han <seb@redhat.com>