### PR TITLE
ceph-installer-rpm: abstract build script

### DIFF
--- a/ceph-installer-rpm/build/build
+++ b/ceph-installer-rpm/build/build
@@ -4,6 +4,10 @@ set -ex
 
 # Sanity-check:
 [ -z "$GIT_BRANCH" ] && echo Missing GIT_BRANCH variable && exit 1
+[ -z "$JOB_NAME" ] && echo Missing JOB_NAME variable && exit 1
+
+# Strip "-rpm" off the job name to get our package's name
+PACKAGE=${JOB_NAME%-rpm}
 
 sudo yum -y install epel-release
 sudo yum -y install fedpkg
@@ -27,7 +31,7 @@ make_chacractl_config $chacra_url
 BRANCH=`branch_slash_filter $GIT_BRANCH`
 
 ## Upload the created RPMs to chacra
-chacra_endpoint="ceph-installer/${BRANCH}/${GIT_COMMIT}/centos/7"
+chacra_endpoint="${PACKAGE}/${BRANCH}/${GIT_COMMIT}/centos/7"
 
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 


### PR DESCRIPTION
Don't hardcode the `ceph-installer` package name in the ceph-installer-rpm build script. Determine the package name from the Jenkins job name instead.

The purpose of this change is to make the build script more re-usable between different packages. (Eventually we could use JJB templates to construct multiple jobs using these same build steps.)