### PR TITLE
add ceph-ansible-rpm job

### DIFF
--- a/ceph-ansible-rpm/build/build
+++ b/ceph-ansible-rpm/build/build
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -ex
+
+# Sanity-check:
+[ -z "$GIT_BRANCH" ] && echo Missing GIT_BRANCH variable && exit 1
+[ -z "$JOB_NAME" ] && echo Missing JOB_NAME variable && exit 1
+
+# Strip "-rpm" off the job name to get our package's name
+PACKAGE=${JOB_NAME%-rpm}
+
+sudo yum -y install epel-release
+sudo yum -y install fedpkg
+
+# Add the Jenkins slave UID to the mock group.
+sudo usermod -a -G mock $(whoami)
+
+# Attempt the build. If it fails, print the mock logs to STDOUT.
+make rpm || ( tail -n +1 {root,build}.log && exit 1 )
+
+# Chacra time
+
+pkgs=( "chacractl>=0.0.4" )
+install_python_packages "pkgs[@]"
+
+# ask shaman which chacra instance to use
+chacra_url=`curl -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
+# create the .chacractl config file using global variables
+make_chacractl_config $chacra_url
+
+BRANCH=`branch_slash_filter $GIT_BRANCH`
+
+## Upload the created RPMs to chacra
+chacra_endpoint="${PACKAGE}/${BRANCH}/${GIT_COMMIT}/centos/7"
+
+[ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
+
+# push binaries to chacra
+ls *.rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/noarch/
+
+# start repo creation
+$VENV/chacractl repo update ${chacra_endpoint}
+
+echo Check the status of the repo at: https://shaman.ceph.com/api/repos/${chacra_endpoint}

--- a/ceph-ansible-rpm/config/ceph-ansible-rpm.yml
+++ b/ceph-ansible-rpm/config/ceph-ansible-rpm.yml
@@ -1,0 +1,44 @@
+- job:
+    name: ceph-ansible-rpm
+    node: 'centos7 && x86_64 && small'
+    project-type: freestyle
+    defaults: global
+    disabled: false
+    display-name: 'ceph-ansible: RPMs'
+    description: 'Build RPMs for every ceph-ansible Git branch'
+    concurrent: true
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-ansible
+    discard-old-builds: true
+    logrotate:
+      daysToKeep: 1
+      numToKeep: 10
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    triggers:
+      - github
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-ansible
+          browser: auto
+          skip-tag: true
+          timeout: 20
+          wipe-workspace: true
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../scripts/build_utils.sh
+            - ../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true


### PR DESCRIPTION
This job builds RPMs for each ceph-ansible GitHub branch.

(This is a 99% copy and paste from ceph-installer-rpm, so we probably need to come up with a centralized area for these types of jobs and use JJB templates. I can't come up with a good directory name at the moment, though.)