### PR TITLE
samba: Fix-up the build

### DIFF
--- a/samba/build/build_deb
+++ b/samba/build/build_deb
@@ -8,77 +8,48 @@ fi
 
 
 ## Install any setup-time deps
-# TODO -- upload install-deps.sh script that installs the setup time deps
-# to upstream repo or update this section to install these packages
+# We need these for the build
+sudo apt-get install -y build-essential equivs libgnutls-dev libacl1-dev libldap2-dev ruby ruby-dev
 
-# We need this for mk-build-deps
-sudo apt-get install -y equivs
-
-# Run the install-deps.sh upstream script if it exists
-if [ -x install-deps.sh ]; then
-    echo "Ensuring dependencies are installed"
-    sudo ./install-deps.sh
-fi
+# We use fpm to create the deb package
+sudo gem install fpm
 
 
-## Setup the pbuilder
-# TODO remove if you do not want to use pbuilders
-setup_pbuilder
+## Do the actual build
+# Prepare the build
+DESTDIR="install.tmp"
+install -d -m0755 -- "$DESTDIR"
+./configure
+
+# Perform the build and install the files to DESTDIR
+NCPU=$(grep -c processor /proc/cpuinfo)
+make -j$NCPU
+make -j$NCPU install DESTDIR=${DESTDIR}
 
 
 ## Get some basic information about the system and the repository
-# TODO -- update this to get the proper VERSION/REVISION
+# Get version
+export LD_LIBRARY_PATH=${DESTDIR}/usr/local/samba/lib/:${DESTDIR}/usr/local/samba/lib/private/
 DEB_ARCH=$(dpkg-architecture -qDEB_BUILD_ARCH)
-VERSION="$(./get-version.sh)"
-REVISION="$(./get-revision.sh)"
+VERSION=$(${DESTDIR}/usr/local/samba/sbin/smbd --version | sed -e "s|Version ||")
+REVISION="$(git rev-parse HEAD)"
 
 
-## Build the source tarball
-# TODO -- upload make-dist script that stores the tarball in dist/ to upstream repo or update this section
-echo "Building source distribution"
-if [ -x make-dist ]; then
-    echo "Ensuring dependencies are installed"
-    ./make-dist
-fi
+## Create the deb package
+# Make sure there are no other deb packages, first
+rm -f *.deb
+
+# Create the deb package
+fpm -s dir -t deb -n samba -v ${VERSION} -C ${DESTDIR} -d krb5-user usr
 
 
-## Prepare the debian files
-# TODO -- Make sure the debian folder is tracked upstream
-# Bump the changelog
-dch -v "$VERSION" "New release ($VERSION)"
-
-# Install debian build-time dependencies
-yes | sudo mk-build-deps --install debian/control
-
-# Create .dsc and source tarball
-sudo dpkg-buildpackage -S -us -uc
-
-
-## Build with pbuilder
-echo "Building debs"
-
-PBUILDDIR="/srv/debian-base"
-
-sudo pbuilder --clean
-
-mkdir -p dist/deb
-
-echo "Building debs for $DIST"
-sudo pbuilder build \
-    --distribution $DIST \
-    --basetgz $PBUILDDIR/$DIST.tgz \
-    --buildresult dist/deb/ \
-    --debbuildopts "-j`grep -c processor /proc/cpuinfo`" \
-    dist/samba_$VERSION.dsc
-
-
-## Upload the created RPMs to chacra
+## Upload the created DEB to chacra
 chacra_endpoint="samba/${BRANCH}/${GIT_COMMIT}/${DISTRO}/${DIST}"
 
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 
 # push binaries to chacra
-find ../*.deb | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${DEB_ARCH}/
+find *.deb | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${DEB_ARCH}/
 
 # start repo creation
 $VENV/chacractl repo update ${chacra_endpoint}

--- a/samba/build/build_rpm
+++ b/samba/build/build_rpm
@@ -7,62 +7,41 @@ if test "$DISTRO" != "fedora" -a "$DISTRO" != "centos" -a "$DISTRO" != "rhel"; t
 fi
 
 
-## Install any setup-time deps (to make dist package)
-# TODO -- upload install-deps.sh script that installs the setup time deps
-# to upstream repo or update this section to install these packages
+## Install any setup-time deps
+# We need these for the build
+sudo yum remove -y lttng-ust-devel # HACK: This package fails the build if installed :-/
+sudo yum install -y gnutls-devel libacl-devel openldap-devel rubygems ruby-devel docbook-xsl lttng-ust-devel
 
-# We need this to get the major version from lsb_release
-sudo yum install -y redhat-lsb-core mock
+# We use fpm to create the deb package
+sudo gem install fpm
 
-# Run the install-deps.sh upstream script if it exists
-if [ -x install-deps.sh ]; then
-    echo "Ensuring dependencies are installed"
-    sudo ./install-deps.sh
-fi
+
+## Do the actual build
+# Prepare the build
+DESTDIR="install.tmp"
+install -d -m0755 -- "$DESTDIR"
+./configure
+
+# Perform the build and install the files to DESTDIR
+NCPU=$(grep -c processor /proc/cpuinfo)
+make -j$NCPU
+make -j$NCPU install DESTDIR=${DESTDIR}
 
 
 ## Get some basic information about the system and the repository
-# TODO -- update this to get the proper VERSION/REVISION
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
-VERSION="$(./get-version.sh)"
-REVISION="$(./get-revision.sh)"
-RPM_RELEASE=$(echo $REVISION | tr '-' '_') # the '-' has a special meaning
+# Get version
+export LD_LIBRARY_PATH=${DESTDIR}/usr/local/samba/lib/:${DESTDIR}/usr/local/samba/lib/private/
+RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
+VERSION=$(${DESTDIR}/usr/local/samba/sbin/smbd --version | sed -e "s|Version ||")
+REVISION="$(git rev-parse HEAD)"
 
 
-## Build the source tarball
-# TODO -- upload make-dist script that stores the tarball in dist/ to upstream repo or update this section
-echo "Building source distribution"
-if [ -x make-dist ]; then
-    echo "Ensuring dependencies are installed"
-    ./make-dist
-fi
+## Create the deb package
+# Make sure there are no other deb packages, first
+rm -f *.rpm
 
-
-## Prepare the spec file for build
-# TODO -- Make sure the spec(.in) file is tracked upstream
-sed -e "s/@VERSION@/${VERSION}/g" -e "s/@RELEASE@/${RPM_RELEASE}/g" < samba.spec.in > dist/samba.spec
-
-
-## Create the source rpm
-# TODO -- update the paths to match the location of source package (dist/ by
-# default) and the spec file (PWD by default)
-echo "Building SRPM"
-rpmbuild \
-    --define "_sourcedir ./dist" \
-    --define "_specdir ." \
-    --define "_builddir ." \
-    --define "_srcrpmdir ." \
-    --define "_rpmdir ." \
-    --define "dist .any" \
-    --define "fedora 21" \
-    --define "rhel 7" \
-    --nodeps -bs dist/samba.spec
-SRPM=$(readlink -f *.src.rpm)
-
-
-## Build the binaries with mock
-echo "Building RPMs"
-sudo mock -r ${MOCK_TARGET}-${RELEASE}-${ARCH} --resultdir=./dist/rpm/ ${SRPM}
+# Create the deb package
+fpm -s dir -t rpm -n samba -v ${VERSION} -C ${DESTDIR} -d krb5-user usr
 
 
 ## Upload the created RPMs to chacra
@@ -71,7 +50,7 @@ chacra_endpoint="samba/${BRANCH}/${GIT_COMMIT}/${DISTRO}/${RELEASE}"
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 
 # push binaries to chacra
-find ./dist/rpm/ | egrep '\.rpm$' | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/$ARCH/
+find *.rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/$ARCH/
 
 # start repo creation
 $VENV/chacractl repo update ${chacra_endpoint}


### PR DESCRIPTION
I was able to perform a centos7 build with these changes. The ubuntu
builds fail because the libgnutls-dev version is too knew [1] -- this should
be fixable in samba sources.

Signed-off-by: Boris Ranto <branto@redhat.com>

[1] I hit the same issue as https://lists.samba.org/archive/samba/2015-April/191253.html but the workaround did not work for me as the libgnutls28-dev was in the failing 3.4 version as well :-/