### PR TITLE
samba: Minor fix-ups

### DIFF
--- a/samba/build/build_deb
+++ b/samba/build/build_deb
@@ -19,7 +19,7 @@ sudo gem install fpm
 # Prepare the build
 DESTDIR="install.tmp"
 install -d -m0755 -- "$DESTDIR"
-./configure
+./configure --without-lttng
 
 # Perform the build and install the files to DESTDIR
 NCPU=$(grep -c processor /proc/cpuinfo)

--- a/samba/build/build_rpm
+++ b/samba/build/build_rpm
@@ -9,8 +9,7 @@ fi
 
 ## Install any setup-time deps
 # We need these for the build
-sudo yum remove -y lttng-ust-devel # HACK: This package fails the build if installed :-/
-sudo yum install -y gnutls-devel libacl-devel openldap-devel rubygems ruby-devel docbook-xsl lttng-ust-devel
+sudo yum install -y gnutls-devel libacl-devel openldap-devel rubygems ruby-devel
 
 # We use fpm to create the deb package
 sudo gem install fpm
@@ -20,7 +19,7 @@ sudo gem install fpm
 # Prepare the build
 DESTDIR="install.tmp"
 install -d -m0755 -- "$DESTDIR"
-./configure
+./configure --without-lttng
 
 # Perform the build and install the files to DESTDIR
 NCPU=$(grep -c processor /proc/cpuinfo)

--- a/samba/config/definitions/samba.yml
+++ b/samba/config/definitions/samba.yml
@@ -53,7 +53,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           values:
             - centos6
             - centos7
-            - trusty
+            - trusty-pbuilder
             - xenial
             - jessie
             - precise

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -281,10 +281,24 @@ get_distro_and_target() {
     # Get distro from DIST for chacra uploads
     DISTRO=""
     case $DIST in
-        jessie|wheezy)
+        jessie*)
+            DIST=jessie
             DISTRO="debian"
             ;;
-        xenial|precise|trusty)
+        wheezy*)
+            DIST=wheezy
+            DISTRO="debian"
+            ;;
+        xenial*)
+            DIST=xenial
+            DISTRO="ubuntu"
+            ;;
+        precise*)
+            DIST=precise
+            DISTRO="ubuntu"
+            ;;
+        trusty*)
+            DIST=trusty
             DISTRO="ubuntu"
             ;;
         centos*)


### PR DESCRIPTION
This also fixes the get_distro_and_target function to get the proper
DIST and DISTRO for the new trusty-pbuilder-like tags.

Signed-off-by: Boris Ranto <branto@redhat.com>