### PR TITLE
ceph-{ansible,installer}-rpm: fix mock group addition

### DIFF
--- a/ceph-ansible-rpm/build/build
+++ b/ceph-ansible-rpm/build/build
@@ -14,6 +14,7 @@ sudo yum -y install fedpkg
 
 # Add the Jenkins slave UID to the mock group.
 sudo usermod -a -G mock $(whoami)
+newgrp mock
 
 # Attempt the build. If it fails, print the mock logs to STDOUT.
 make rpm || ( tail -n +1 {root,build}.log && exit 1 )

--- a/ceph-installer-rpm/build/build
+++ b/ceph-installer-rpm/build/build
@@ -14,6 +14,7 @@ sudo yum -y install fedpkg
 
 # Add the Jenkins slave UID to the mock group.
 sudo usermod -a -G mock $(whoami)
+newgrp mock
 
 # Attempt the build. If it fails, print the mock logs to STDOUT.
 make rpm || ( tail -n +1 {root,build}.log && exit 1 )


### PR DESCRIPTION
When an ephemeral slave is first created, we have to add the jenkins-build UID to the `mock` group so that it can run mock.

The problem is that `usermod -a -G ...` will not affect the current login shell. When the ceph-*-rpm jobs run `usermod` for the first time, the jenkins-build UID obtains those group rights for any future jobs, but not the current job.

The result is that every time an ephemeral slave boots, it will fail its first ceph-*-rpm build job (and future ones succeed).

Call `newgrp` to refresh the mock group for this login shell, so that all mock operations succeed, including the first one on each slave.