### PR TITLE
ceph-pr-submodules: increase verbosity to try and get values out of vars

### DIFF
--- a/ceph-pr-submodules/build/build
+++ b/ceph-pr-submodules/build/build
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 cd "$WORKSPACE"
 
 # The command below has access to the variables $name, $path, $sha1 and $toplevel:


### PR DESCRIPTION
The check is returning false positives and it is hard to tell why without these -ex flags