### PR TITLE
ceph-{ansible,installer}-rpm: use "sg" for mock group

### DIFF
--- a/ceph-ansible-rpm/build/build
+++ b/ceph-ansible-rpm/build/build
@@ -14,10 +14,9 @@ sudo yum -y install fedpkg
 
 # Add the Jenkins slave UID to the mock group.
 sudo usermod -a -G mock $(whoami)
-newgrp mock
 
 # Attempt the build. If it fails, print the mock logs to STDOUT.
-make rpm || ( tail -n +1 {root,build}.log && exit 1 )
+sg mock -c "make rpm" || ( tail -n +1 {root,build}.log && exit 1 )
 
 # Chacra time
 

--- a/ceph-installer-rpm/build/build
+++ b/ceph-installer-rpm/build/build
@@ -14,10 +14,9 @@ sudo yum -y install fedpkg
 
 # Add the Jenkins slave UID to the mock group.
 sudo usermod -a -G mock $(whoami)
-newgrp mock
 
 # Attempt the build. If it fails, print the mock logs to STDOUT.
-make rpm || ( tail -n +1 {root,build}.log && exit 1 )
+sg mock -c "make rpm" || ( tail -n +1 {root,build}.log && exit 1 )
 
 # Chacra time
 


### PR DESCRIPTION
The previous commit (0d90b3c5fec43fe66fc1e9c3856519f91e4454cf) attempted to use newgrp to refresh groups, but I did not realize that this just spawns a new shell (at least in my experiments in a bash interactive shell), and it is ineffective on our JNLP slaves.

Use the approach we implemented for Docker (in f9cc49aec026c2ae17b1db2603d262f5cb1c8a00), and run mock through `sg` to
set the group.