### PR TITLE
ceph-{ansible,installer}-rpms: do not use sepia slaves or sg

### DIFF
--- a/ceph-ansible-rpm/build/build
+++ b/ceph-ansible-rpm/build/build
@@ -14,9 +14,10 @@ sudo yum -y install fedpkg
 
 # Add the Jenkins slave UID to the mock group.
 sudo usermod -a -G mock $(whoami)
+newgrp mock
 
 # Attempt the build. If it fails, print the mock logs to STDOUT.
-sg mock -c "make rpm" || ( tail -n +1 {root,build}.log && exit 1 )
+make rpm || ( tail -n +1 {root,build}.log && exit 1 )
 
 # Chacra time
 

--- a/ceph-ansible-rpm/config/definitions/ceph-ansible-rpm.yml
+++ b/ceph-ansible-rpm/config/definitions/ceph-ansible-rpm.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-ansible-rpm
-    node: 'centos7 && x86_64 && small'
+    node: 'centos7 && x86_64 && small && !sepia'
     project-type: freestyle
     defaults: global
     disabled: false

--- a/ceph-installer-rpm/build/build
+++ b/ceph-installer-rpm/build/build
@@ -14,9 +14,10 @@ sudo yum -y install fedpkg
 
 # Add the Jenkins slave UID to the mock group.
 sudo usermod -a -G mock $(whoami)
+newgrp mock
 
 # Attempt the build. If it fails, print the mock logs to STDOUT.
-sg mock -c "make rpm" || ( tail -n +1 {root,build}.log && exit 1 )
+make rpm || ( tail -n +1 {root,build}.log && exit 1 )
 
 # Chacra time
 

--- a/ceph-installer-rpm/config/definitions/ceph-installer-rpm.yml
+++ b/ceph-installer-rpm/config/definitions/ceph-installer-rpm.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-installer-rpm
-    node: 'centos7 && x86_64 && small'
+    node: 'centos7 && x86_64 && small && !sepia'
     project-type: freestyle
     defaults: global
     disabled: false


### PR DESCRIPTION
Our slaves in sepia, which use JNLP, are having troubles building these repos. The first issue we found was that the ``jenkins-build`` user was not added to the ``mock`` group properly on these sepia slaves. The attempted solution to that was proposed in: https://github.com/ceph/ceph-build/pull/600

The solution from https://github.com/ceph/ceph-build/pull/600 worked in that the mock command was able to execute without permissions errors but the builds were failing to build the 'noarch' rpm.  Here's an example of one of those repos: https://1.chacra.ceph.com/r/ceph-installer/master/1cd19fb1217c4f1b2083d85f3d148375e4106eb6/centos/7/flavors/default/noarch/

Let's just use the OVH slaves which we know can build these rpms until we have some automated tests in place, then we can use those tests to verify changes in these build scripts are working correctly.