### PR TITLE
Adds a nightly job that tests ceph-installer

### DIFF
--- a/ceph-installer-nightly/build/build
+++ b/ceph-installer-nightly/build/build
@@ -1,0 +1,9 @@
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "tox" )
+install_python_packages "pkgs[@]"
+
+WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
+
+cd $WORKSPACE/tests/functional
+
+INSTALLER_DEV_BRANCH=$INSTALLER_BRANCH CEPH_ANSIBLE_DEV_BRANCH=$CEPH_ANSIBLE_BRANCH $VENV/tox -rv -e=ansible2.2-nightly --workdir=$WORKDIR -- --provider=libvirt

--- a/ceph-installer-nightly/config/definitions/ceph-installer-nightly.yml
+++ b/ceph-installer-nightly/config/definitions/ceph-installer-nightly.yml
@@ -44,3 +44,7 @@
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
+
+    publishers:
+      - email:
+          recipients: aschoen@redhat.com adeza@redhat.com

--- a/ceph-installer-nightly/config/definitions/ceph-installer-nightly.yml
+++ b/ceph-installer-nightly/config/definitions/ceph-installer-nightly.yml
@@ -1,0 +1,46 @@
+- job:
+    name: ceph-installer-nightly
+    node: vagrant && libvirt 
+    project-type: freestyle
+    defaults: global
+    display-name: 'ceph-installer: Nightly tests for ceph-installer and ceph-ansible integration'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-installer
+    logrotate:
+      daysToKeep: -1
+      numToKeep: -1
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    parameters:
+      - string:
+          name: INSTALLER_BRANCH
+          description: "The ceph-installer branch (or tag) to test"
+          default: master
+
+      - string:
+          name: CEPH_ANSIBLE_BRANCH
+          description: "The ceph-ansible branch (or tag) to test"
+          default: master
+
+    triggers:
+      - timed: '@daily'
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-installer.git
+          branches:
+            - $INSTALLER_BRANCH 
+          browser: auto
+          timeout: 20
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build


### PR DESCRIPTION
This job is parametrized so that we can also run it manually or
trigger it easily from other jobs.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>