### PR TITLE
ceph-deploy-build: do not use python to detect the distro

### DIFF
--- a/ceph-deploy-build/build/build
+++ b/ceph-deploy-build/build/build
@@ -83,7 +83,15 @@ then
     DEB_BUILD=$(lsb_release -s -c)
     #XXX only releases until we fix this
     RELEASE=1
-    DISTRO=`python -c "exec 'import platform; print platform.linux_distribution()[0].lower()'"`
+    DISTRO=""
+    case $DIST in
+        jessie|wheezy)
+            DISTRO="debian"
+            ;;
+        *)
+            DISTRO="ubuntu"
+            ;;
+    esac
 
     [ "$TEST" = true ] && chacra_ref="test" || chacra_ref="$BRANCH"
     # ceph-deploy isn't architecture dependant, so we use 'all' as architecture and


### PR DESCRIPTION
We're using pbuilder in many build jobs now so we can't depend on the
host to be the actual distro version that the binaries are being built
for. This uses the value from the JJB matrix to determine what distro
value to use when posting to chacra.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>