### PR TITLE
report when a build is triggered

### DIFF
--- a/ceph-dev-trigger/build/notify
+++ b/ceph-dev-trigger/build/notify
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+# update shaman with the triggered build status. At this point there aren't any
+# architectures or distro information, so we just report this with the current
+# build information
+BRANCH=`branch_slash_filter ${GIT_BRANCH}`
+SHA1=${GIT_COMMIT}
+
+create_build_status "queued" "ceph"

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -35,6 +35,10 @@
           wipe-workspace: true
 
     builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/notify
       - trigger-builds:
         - project: 'ceph-dev'
           predefined-parameters: |


### PR DESCRIPTION
This will (unfortunately) need to also be ported to `ceph-dev-new-trigger` once it is up and running. It is safer to just use it on ceph-dev-trigger for now 