### PR TITLE
notify of queued builds from trigger job

### DIFF
--- a/ceph-dev-new-trigger/build/notify
+++ b/ceph-dev-new-trigger/build/notify
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+# update shaman with the triggered build status. At this point there aren't any
+# architectures or distro information, so we just report this with the current
+# build information
+BRANCH=`branch_slash_filter ${GIT_BRANCH}`
+SHA1=${GIT_COMMIT}
+
+create_build_status "queued" "ceph"
+

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -28,6 +28,10 @@
           wipe-workspace: true
 
     builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/notify
       - trigger-builds:
         - project: 'ceph-dev-new'
           predefined-parameters: |


### PR DESCRIPTION
We already have this for ceph-dev, this would make it for ceph-dev-new (that builds ceph-ci PRs)