### PR TITLE
ceph-installer-tests: a project to run ceph-installer functional tests

### DIFF
--- a/ceph-installer-tests/build/build
+++ b/ceph-installer-tests/build/build
@@ -6,4 +6,4 @@ WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
 cd $WORKSPACE/tests/functional
 
-INSTALLER_DEV_BRANCH=$INSTALLER_BRANCH CEPH_ANSIBLE_DEV_BRANCH=$CEPH_ANSIBLE_BRANCH $VENV/tox -rv -e=ansible2.2-nightly --workdir=$WORKDIR -- --provider=libvirt
+INSTALLER_DEV_BRANCH=$INSTALLER_BRANCH CEPH_ANSIBLE_DEV_BRANCH=$CEPH_ANSIBLE_BRANCH $VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR -- --provider=libvirt

--- a/ceph-installer-tests/config/definitions/ceph-installer-tests.yml
+++ b/ceph-installer-tests/config/definitions/ceph-installer-tests.yml
@@ -1,9 +1,17 @@
-- job:
-    name: ceph-installer-nightly
+- project:
+    name: ceph-installer-tests
+    scenario:
+      - ansible2.2-nightly_centos7
+      - ansible2.2-nightly_xenial
+    jobs:
+        - 'ceph-installer-tests-{scenario}'
+
+- job-template:
+    name: 'ceph-installer-tests-{scenario}'
     node: vagrant && libvirt 
     project-type: freestyle
     defaults: global
-    display-name: 'ceph-installer: Nightly tests for ceph-installer and ceph-ansible integration'
+    display-name: 'ceph-installer: Tests [{scenario}]'
     quiet-period: 5
     block-downstream: false
     block-upstream: false
@@ -40,8 +48,11 @@
           timeout: 20
 
     builders:
+      - inject:
+          properties-content: |
+            SCENARIO={scenario}
       - shell:
-          !include-raw:
+          !include-raw-escape:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 


### PR DESCRIPTION
This will create a new jenkins job for each testing scenario defined in
the config file. These jobs will run daily and can be trigger manually,
optionally providing which branches of ceph-installer and ceph-ansible
to test with.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>