### PR TITLE
build_utils: fix setuptools installation

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -47,12 +47,12 @@ install_python_packages_no_binary () {
     PIP_SDIST_INDEX="$HOME/.cache/pip"
     mkdir -p $PIP_SDIST_INDEX
 
-    echo "Updating setuptools"
-    $VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" setuptools
-
     echo "Ensuring latest pip is installed"
     $VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" pip
     $VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index pip
+
+    echo "Updating setuptools"
+    $VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" setuptools
 
     pkgs=("${!1}")
     for package in ${pkgs[@]}; do
@@ -81,12 +81,12 @@ install_python_packages () {
     PIP_SDIST_INDEX="$HOME/.cache/pip"
     mkdir -p $PIP_SDIST_INDEX
 
-    echo "Updating setuptools"
-    $VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" setuptools
-
     echo "Ensuring latest pip is installed"
     $VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" pip
     $VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index pip
+
+    echo "Updating setuptools"
+    $VENV/pip install --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" setuptools
 
     pkgs=("${!1}")
     for package in ${pkgs[@]}; do


### PR DESCRIPTION
Hopefully the original order of pip vs. setuptools
in this script was not important, because apparently
we now need latest pip in order to install setuptools.

Fixes: http://tracker.ceph.com/issues/18645
Signed-off-by: John Spray <john.spray@redhat.com>