### PR TITLE
ceph-dev-*: fix tcmalloc args for pre-cmake builds

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -75,6 +75,7 @@ echo building debs for $DIST
 # pass only those env vars specifically noted
 sudo \
     CEPH_EXTRA_CMAKE_ARGS=$CEPH_EXTRA_CMAKE_ARGS \
+    CEPH_EXTRA_CONFIGURE_ARGS=$CEPH_EXTRA_CONFIGURE_ARGS \
     pbuilder build \
     --distribution $DIST \
     --basetgz $pbuilddir/$DIST.tgz \

--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -34,7 +34,7 @@ cp -a rpm/*.patch ${BUILDAREA}/SOURCES/. || true
 # Build RPMs
 BUILDAREA=`readlink -fn ${BUILDAREA}`   ### rpm wants absolute path
 cd ${BUILDAREA}/SPECS
-rpmbuild -ba --define "_topdir ${BUILDAREA}" ceph.spec
+rpmbuild -ba --define "_topdir ${BUILDAREA}" ${CEPH_EXTRA_RPMBUILD_ARGS} ceph.spec
 
 echo done
 

--- a/ceph-dev-build/build/build_deb
+++ b/ceph-dev-build/build/build_deb
@@ -75,6 +75,7 @@ echo building debs for $DIST
 # pass only those env vars specifically noted
 sudo \
     CEPH_EXTRA_CMAKE_ARGS=$CEPH_EXTRA_CMAKE_ARGS \
+    CEPH_EXTRA_CONFIGURE_ARGS=$CEPH_EXTRA_CONFIGURE_ARGS \
     pbuilder build \
     --distribution $DIST \
     --basetgz $pbuilddir/$DIST.tgz \

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -45,7 +45,7 @@ cp -a rpm/*.patch ${BUILDAREA}/SOURCES/. || true
 # Build RPMs
 BUILDAREA=`readlink -fn ${BUILDAREA}`   ### rpm wants absolute path
 cd ${BUILDAREA}/SPECS
-rpmbuild -ba --define "_topdir ${BUILDAREA}" ceph.spec
+rpmbuild -ba --define "_topdir ${BUILDAREA}" ${CEPH_EXTRA_RPMBUILD_ARGS} ceph.spec
 
 # The following was copied from autobuild-ceph/build-ceph-rpm.sh
 # which creates the ceph-release rpm meant to create the repository file for the repo

--- a/ceph-dev-new-build/build/build_deb
+++ b/ceph-dev-new-build/build/build_deb
@@ -75,6 +75,7 @@ echo building debs for $DIST
 # pass only those env vars specifically noted
 sudo \
     CEPH_EXTRA_CMAKE_ARGS=$CEPH_EXTRA_CMAKE_ARGS \
+    CEPH_EXTRA_CONFIGURE_ARGS=$CEPH_EXTRA_CONFIGURE_ARGS \
     pbuilder build \
     --distribution $DIST \
     --basetgz $pbuilddir/$DIST.tgz \

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -45,7 +45,7 @@ cp -a rpm/*.patch ${BUILDAREA}/SOURCES/. || true
 # Build RPMs
 BUILDAREA=`readlink -fn ${BUILDAREA}`   ### rpm wants absolute path
 cd ${BUILDAREA}/SPECS
-rpmbuild -ba --define "_topdir ${BUILDAREA}" ceph.spec
+rpmbuild -ba --define "_topdir ${BUILDAREA}" ${CEPH_EXTRA_RPMBUILD_ARGS} ceph.spec
 
 # The following was copied from autobuild-ceph/build-ceph-rpm.sh
 # which creates the ceph-release rpm meant to create the repository file for the repo

--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -57,10 +57,14 @@ if [ "${FLAVOR}" == "notcmalloc" ]
 then
     echo "Detected notcmalloc flavor: will use flag: --without-tcmalloc or -DALLOCATOR=libc"
     AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --without-tcmalloc"
-    export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
+    CEPH_EXTRA_CONFIGURE_ARGS="--without-tcmalloc"
+    CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
+    CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
 else
     AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --with-tcmalloc"
-    export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
+    CEPH_EXTRA_CONFIGURE_ARGS="--with-tcmalloc"
+    CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
+    CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
 fi
 
 # When using autotools/autoconf it is possible to see output from `git diff`
@@ -209,6 +213,10 @@ cat > dist/branch << EOF
 BRANCH=${BRANCH}
 EOF
 
+# CEPH_EXTRA_{CONFIGURE,RPMBUILD}_ARGS are consumed by ceph-build before
+# the switch to cmake; CEPH_EXTRA_CMAKE_ARGS is for after cmake
 cat > dist/other_envvars << EOF
+CEPH_EXTRA_CONFIGURE_ARGS=${CEPH_EXTRA_CONFIGURE_ARGS}
+CEPH_EXTRA_RPMBUILD_ARGS=${CEPH_EXTRA_RPMBUILD_ARGS}
 CEPH_EXTRA_CMAKE_ARGS=${CEPH_EXTRA_CMAKE_ARGS}
 EOF

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -52,10 +52,14 @@ if [ "${FLAVOR}" == "notcmalloc" ]
 then
     echo "Detected notcmalloc flavor: will use flag: --without-tcmalloc or -DALLOCATOR=libc"
     AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --without-tcmalloc"
-    export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
+    CEPH_EXTRA_CONFIGURE_ARGS="--without-tcmalloc"
+    CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
+    CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
 else
     AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --with-tcmalloc"
-    export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
+    CEPH_EXTRA_CONFIGURE_ARGS="--with-tcmalloc"
+    CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
+    CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
 fi
 
 # When using autotools/autoconf it is possible to see output from `git diff`
@@ -204,6 +208,10 @@ cat > dist/branch << EOF
 BRANCH=${BRANCH}
 EOF
 
+# CEPH_EXTRA_{CONFIGURE,RPMBUILD}_ARGS are consumed by ceph-build before
+# the switch to cmake; CEPH_EXTRA_CMAKE_ARGS is for after cmake
 cat > dist/other_envvars << EOF
+CEPH_EXTRA_CONFIGURE_ARGS=${CEPH_EXTRA_CONFIGURE_ARGS}
+CEPH_EXTRA_RPMBUILD_ARGS=${CEPH_EXTRA_RPMBUILD_ARGS}
 CEPH_EXTRA_CMAKE_ARGS=${CEPH_EXTRA_CMAKE_ARGS}
 EOF

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -47,10 +47,14 @@ if [ "${FLAVOR}" == "notcmalloc" ]
 then
     echo "Detected notcmalloc flavor: will use flag: --without-tcmalloc or -DALLOCATOR=libc"
     AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --without-tcmalloc"
-    export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
+    CEPH_EXTRA_CONFIGURE_ARGS="--without-tcmalloc"
+    CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
+    CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
 else
     AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --with-tcmalloc"
-    export CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
+    CEPH_EXTRA_CONFIGURE_ARGS="--with-tcmalloc"
+    CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
+    CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
 fi
 
 
@@ -192,6 +196,10 @@ cat > dist/sha1 << EOF
 SHA1=${GIT_COMMIT}
 EOF
 
+# CEPH_EXTRA_{CONFIGURE,RPMBUILD}_ARGS are consumed by ceph-build before
+# the switch to cmake; CEPH_EXTRA_CMAKE_ARGS is for after cmake
 cat > dist/other_envvars << EOF
+CEPH_EXTRA_CONFIGURE_ARGS=${CEPH_EXTRA_CONFIGURE_ARGS}
+CEPH_EXTRA_RPMBUILD_ARGS=${CEPH_EXTRA_RPMBUILD_ARGS}
 CEPH_EXTRA_CMAKE_ARGS=${CEPH_EXTRA_CMAKE_ARGS}
 EOF


### PR DESCRIPTION
Prior to cmake, --with(out)-tcmalloc must be passed to the
configure done during the actual build.  For rpm, that means an
extra arg to the invocation of rpmbuild in build_rpm; for deb,
debian/rules invokes configure.  Also, no reason to export
the shell variables; they're used locally and passed as
property files between Jenkins jobs.

Fixes: http://tracker.ceph.com/issues/18744
Signed-off-by: Dan Mick <dan.mick@redhat.com>