### PR TITLE
ceph-docker-nightly: scheduled tests for ceph-docker

### DIFF
--- a/ceph-docker-nightly/build/build
+++ b/ceph-docker-nightly/build/build
@@ -1,8 +1,13 @@
 #!/bin/bash
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "pytest" "docker-py==1.10.3" )
+pkgs=( "tox" )
 install_python_packages "pkgs[@]"
+
+# XXX this might not be needed
+source $VENV/activate
+
+WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
 sudo apt-get install -y docker.io
 
@@ -10,8 +15,7 @@ sudo gpasswd -a ${USER} docker
 sudo systemctl restart docker
 newgrp docker
 
-cd tests
 # adding groups on the fly doesn't guarantee their availability
 # so we must use `sg` to execute the tests as part of the docker group to avoid
 # 'Permission Denied` when tryin to talk over the socket
-sg docker -c "$VENV/py.test -v"
+sg docker -c "$VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR"

--- a/ceph-docker-nightly/build/teardown
+++ b/ceph-docker-nightly/build/teardown
@@ -1,0 +1,13 @@
+#!/bin/bash
+# There has to be a better way to do this than this script which just looks
+# for every Vagrantfile in scenarios and then just destroys whatever is left.
+
+cd $WORKSPACE/ceph-ansible/tests/functional
+
+scenarios=$(find . | grep Vagrantfile | xargs dirname)
+
+for scenario in $scenarios; do
+    cd $scenario
+    vagrant destroy -f
+    cd -
+done

--- a/ceph-docker-nightly/config/definitions/ceph-docker-nightly.yml
+++ b/ceph-docker-nightly/config/definitions/ceph-docker-nightly.yml
@@ -1,9 +1,22 @@
-- job:
+- project:
     name: ceph-docker-nightly
-    node: xenial && x86_64
-    project-type: freestyle
+    scenario:
+      - ceph_ansible2.1-jewel-centos7_cluster
+      - ceph_ansible2.1-jewel-xenial_cluster
+      - ceph_ansible-jewel-centos7_cluster
+      - ceph_ansible-jewel-xenial_cluster
+      - ceph_ansible-kraken-centos7_cluster
+      - ceph_ansible-kraken-xenial_cluster
+    jobs:
+        - 'ceph-docker-nightly-{scenario}'
+
+
+- job-template:
+    name: 'ceph-docker-nightly-{scenario}'
+    node: vagrant&&libvirt
+    concurrent: true
     defaults: global
-    display-name: 'ceph-docker: Nightly tests for released containers'
+    display-name: 'ceph-docker: Nightly tests [{scenario}]'
     quiet-period: 5
     block-downstream: false
     block-upstream: false
@@ -12,10 +25,16 @@
       - github:
           url: https://github.com/ceph/ceph-docker
     logrotate:
-      daysToKeep: -1
-      numToKeep: -1
+      daysToKeep: 15
+      numToKeep: 30
       artifactDaysToKeep: -1
       artifactNumToKeep: -1
+
+    parameters:
+      - string:
+          name: BRANCH
+          description: "A ceph-docker branch to test"
+          default: master
 
     triggers:
       - timed: '@daily'
@@ -24,12 +43,22 @@
       - git:
           url: https://github.com/ceph/ceph-docker.git
           branches:
-            - master
+            - ${{BRANCH}}
           browser: auto
           timeout: 20
 
     builders:
+      - inject:
+          properties-content: |
+            SCENARIO={scenario}
       - shell:
-          !include-raw:
+          !include-raw-escape:
             - ../../../scripts/build_utils.sh
             - ../../build/build
+
+    publishers:
+      - postbuildscript:
+          script-only-if-succeeded: False
+          script-only-if-failed: True
+          builders:
+            - shell: !include-raw ../../build/teardown


### PR DESCRIPTION
Creates a set of jobs that test building and deploying jewel and kraken
containers with the master branch of ceph-ansible. It also includes a
test for building and deploying a jewel container with the stable-2.1
branch of ceph-ansible.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>