### PR TITLE
Samba+calamari: minor fixes

### DIFF
--- a/calamari/build/build_deb
+++ b/calamari/build/build_deb
@@ -38,7 +38,7 @@ chacra_endpoint="calamari/${BRANCH}/${GIT_COMMIT}/${DISTRO}/${DIST}"
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 
 # push binaries to chacra
-find ../calamari-server*.deb ../calamari-server*.changes | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${DEB_ARCH}/
+find ../calamari-server*.deb ../calamari-server*.changes | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/
 
 # start repo creation
 $VENV/chacractl repo update ${chacra_endpoint}

--- a/samba/build/build_deb
+++ b/samba/build/build_deb
@@ -9,7 +9,7 @@ fi
 
 ## Install any setup-time deps
 # We need these for the build
-sudo apt-get install -y build-essential equivs libgnutls-dev libacl1-dev libldap2-dev ruby ruby-dev
+sudo apt-get update && sudo apt-get install -y build-essential equivs libgnutls-dev libacl1-dev libldap2-dev ruby ruby-dev
 
 # We use fpm to create the deb package
 sudo gem install fpm

--- a/samba/build/build_deb
+++ b/samba/build/build_deb
@@ -49,7 +49,7 @@ chacra_endpoint="samba/${BRANCH}/${GIT_COMMIT}/${DISTRO}/${DIST}"
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 
 # push binaries to chacra
-find *.deb | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${DEB_ARCH}/
+find *.deb | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/
 PACKAGE_MANAGER_VERSION=$(dpkg-deb -f $(find *"$DEB_ARCH".deb | head -1) Version)
 
 # write json file with build info

--- a/samba/config/definitions/samba.yml
+++ b/samba/config/definitions/samba.yml
@@ -10,11 +10,12 @@
       - string:
           name: BRANCH
           description: "The git branch (or tag) to build"
+          default: "master"
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: xenial, centos7, centos6, trusty, precise, wheezy, and jessie"
-          default: "centos7 precise xenial"
+          description: "A list of distros to build for. Available options are: xenial, centos7, centos6, trusty-pbuilder, precise, wheezy, and jessie"
+          default: "centos7 trusty-pbuilder xenial"
 
       - string:
           name: ARCHS


### PR DESCRIPTION
We used DEB_ARCH instead of ARCH when pushing to chacra in
samba/calamari. This meant that we pushed to amd64 instead of x86_64.

Signed-off-by: Boris Ranto <branto@redhat.com>