### PR TITLE
ansible: double the time for nginx-to-jenkins for timeouts

### DIFF
--- a/ansible/roles/ansible-jenkins/templates/jenkins.conf
+++ b/ansible/roles/ansible-jenkins/templates/jenkins.conf
@@ -21,7 +21,7 @@ server {
       proxy_set_header        X-Forwarded-Proto $scheme;
 
       proxy_pass          http://127.0.0.1:8080;
-      proxy_read_timeout  90;
+      proxy_read_timeout  180;
 
       # Redirect all plaintext HTTP to HTTPS
       if ($scheme != "https") {


### PR DESCRIPTION
Specifically introducing this change because JJB was hitting gateway timeouts since the POST requests are large enough that it was taking longer than the 90 seconds allowed.