### PR TITLE
build_utils: enable SSL verification

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -110,7 +110,7 @@ make_chacractl_config () {
 url = "$url"
 user = "$CHACRACTL_USER"
 key = "$CHACRACTL_KEY"
-ssl_verify = False
+ssl_verify = True
 EOF
 }
 


### PR DESCRIPTION
All our chacra endpoints (https://*.chacra.ceph.com) use HTTPS certs
signed by LetsEncrypt now. There's no need to disable SSL verification
here any more.

This reverts f5e28bdeb675f6e245c26ae7d0e7f662ac1ed0f1.

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>