### PR TITLE
ceph-pr-submodules: fix submodule check.

### DIFF
--- a/ceph-pr-submodules/build/build
+++ b/ceph-pr-submodules/build/build
@@ -4,14 +4,14 @@ set -ex
 
 cd "$WORKSPACE"
 
-# The command below has access to the variables $name, $path, $sha1 and $toplevel:
-# $name is the name of the relevant submodule section in .gitmodules, $path is
-# the name of the submodule directory relative to the superproject, $sha1 is
-# the commit as recorded in the superproject, and $toplevel is the absolute
-# path to the top-level of the superproject.
-modified_submodules=$(git submodule foreach 'cd $toplevel; git diff --ignore-submodules=dirty origin/master -- $path')
+# show diffs between $ghprbTargetBranch (where the merge is going) and
+# $ghprbActualCommit (the tip of the branch that's merging) with '...',
+# which is equivalent to diff $(git merge-base TB AC) AC, or "show
+# diff from common ancestor of the target branch and this branch with the
+# tip of this branch".  With --submodule, also show detail of diff in submodules.
+modified_submodules="$(git diff --submodule=log origin/$ghprbTargetBranch...$ghprbActualCommit | grep ^Submodule || true)"
 
-if [[ $modified_submodules ]]; then
+if [[ -n "$modified_submodules" ]]; then
     echo "Project has modified submodules!"
     echo $modified_submodules
     exit 1


### PR DESCRIPTION
Prior code never generated any output at all.

Fixes: http://tracker.ceph.com/issues/19244
Signed-off-by: Dan Mick <dan.mick@redhat.com>