### PR TITLE
reconfigure apt during every "pbuilder update"

### DIFF
--- a/ceph-build/build/setup_pbuilder
+++ b/ceph-build/build/setup_pbuilder
@@ -91,7 +91,8 @@ if [ -e $basedir/$DIST.tgz ]; then
     sudo pbuilder update \
     --basetgz $basedir/$DIST.tgz \
     --distribution $DIST \
-    --mirror "$mirror"
+    --mirror "$mirror" \
+    --override-config
 else
     echo building $DIST base.tgz
     sudo pbuilder create \

--- a/ceph-dev-build/build/setup_pbuilder
+++ b/ceph-dev-build/build/setup_pbuilder
@@ -91,7 +91,8 @@ if [ -e $basedir/$DIST.tgz ]; then
     sudo pbuilder update \
     --basetgz $basedir/$DIST.tgz \
     --distribution $DIST \
-    --mirror "$mirror"
+    --mirror "$mirror" \
+    --override-config
 else
     echo building $DIST base.tgz
     sudo pbuilder create \

--- a/ceph-dev-new-build/build/setup_pbuilder
+++ b/ceph-dev-new-build/build/setup_pbuilder
@@ -91,7 +91,8 @@ if [ -e $basedir/$DIST.tgz ]; then
     sudo pbuilder update \
     --basetgz $basedir/$DIST.tgz \
     --distribution $DIST \
-    --mirror "$mirror"
+    --mirror "$mirror" \
+    --override-config
 else
     echo building $DIST base.tgz
     sudo pbuilder create \

--- a/diamond-build/build/setup_pbuilder
+++ b/diamond-build/build/setup_pbuilder
@@ -81,7 +81,8 @@ if [ -e $basedir/$DIST.tgz ]; then
     sudo pbuilder update \
     --basetgz $basedir/$DIST.tgz \
     --distribution $DIST \
-    --mirror "$mirror"
+    --mirror "$mirror" \
+    --override-config
 else
     echo building $DIST base.tgz
     sudo pbuilder create \

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -396,7 +396,8 @@ setup_pbuilder() {
         sudo pbuilder update \
         --basetgz $basedir/$DIST.tgz \
         --distribution $DIST \
-        --mirror "$mirror"
+        --mirror "$mirror" \
+        --override-config
     else
         echo building $DIST base.tgz
         sudo pbuilder create \


### PR DESCRIPTION
The nfs-ganesha pbuilder setup code configures the pbuilder caches to
point at repos from shaman. Since all Jenkins jobs uses the same
pbuilder cache tarballs, this means that these shaman repositories will
still be enabled in the next jobs that run on a slave.

  1) nfs-ganesha job runs on a slave
  2) nfs-ganesha job configures pbuilder cache to use shaman repo
  3) nfs-ganesha job finishes
  4) ceph-build job runs on same slave slave
  5) ceph-build job uses same pbuilder cache with shaman repo configured

In addition to polluting the pbuilder environment, this can also lead to
pbuilder failures when shaman/chacra garbage-collects old repositories,
because Apt wants to download repo metadata from old ceph repos that
are no longer available.

Force every job that runs "pbuilder update" to also run with
"--override-config" in order to wipe out any apt repositories that may
have been configured in the cache.