### PR TITLE
nfs-ganesha: fix build_deb shaman polling loop

### DIFF
--- a/nfs-ganesha/build/build_deb
+++ b/nfs-ganesha/build/build_deb
@@ -14,7 +14,7 @@ REPO_FOUND=0
 # poll shaman for up to 10 minutes
 while [ "$SECONDS" -le "$TIME_LIMIT" ]
 do
-  SHAMAN_MIRROR=`curl --fail -L ${REPO_URL}`
+  SHAMAN_MIRROR=`curl --fail -L ${REPO_URL} || true`
   if [[ ${SHAMAN_MIRROR} ]]; then
     echo "Ceph debian lib repo exists in shaman"
     REPO_FOUND=1


### PR DESCRIPTION
Signed-off-by: Ali Maredia <amaredia@redhat.com>

The curl command sometimes returns 504, since the repository isn't ready yet. That exist status stops the rest of the script from running instead of running through the loop for $TIME_LIMIT and rerunning curl every $INTERVAL. This fix ensures the exit status is always true.

This was inspired by failures such as this: https://jenkins.ceph.com/job/nfs-ganesha/1164/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=trusty,DIST=trusty,MACHINE_SIZE=huge/console repeatedly occurring.