### PR TITLE
nfs-ganesha: change shaman polling time to 20 mins

### DIFF
--- a/nfs-ganesha/build/build_deb
+++ b/nfs-ganesha/build/build_deb
@@ -7,7 +7,7 @@ if test "$DISTRO" != "debian" -a "$DISTRO" != "ubuntu"; then
 fi
 
 REPO_URL="https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/$CEPH_SHA1/$DISTRO/$DIST/repo"
-TIME_LIMIT=600
+TIME_LIMIT=1200
 INTERVAL=30
 REPO_FOUND=0
 

--- a/nfs-ganesha/build/build_rpm
+++ b/nfs-ganesha/build/build_rpm
@@ -11,7 +11,7 @@ RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
 
 # Get .repo file from appropriate shaman build
 REPO_URL="https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/$CEPH_SHA1/$DISTRO/$RELEASE/flavors/default/repo"
-TIME_LIMIT=600
+TIME_LIMIT=1200
 INTERVAL=30
 REPO_FOUND=0
 


### PR DESCRIPTION
Certain Trusty builds were failing because the
repos weren't available until 11-15 mins after
the job was run

Signed-off-by: Ali Maredia <amaredia@redhat.com>