### PR TITLE
nfs-ganesha: remove trusty from axis

### DIFF
--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -93,7 +93,6 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           name: AVAILABLE_DIST
           values:
             - centos7
-            - trusty
             - xenial
       - axis:
           type: dynamic


### PR DESCRIPTION
Signed-off-by: Ali Maredia <amaredia@redhat.com>

Trusty builds aren't necessary and I don't want any resources unnecessarily going to them. 