### PR TITLE
ceph-pr-submodules: explicitly fetch the target branch

### DIFF
--- a/ceph-pr-submodules/build/build
+++ b/ceph-pr-submodules/build/build
@@ -4,6 +4,13 @@ set -ex
 
 cd "$WORKSPACE"
 
+# Ensure that our clone has the very latest target branch.
+# The Jenkins Git plugin may have not updated this particular ref.
+git fetch origin ${ghprbTargetBranch}:refs/remotes/origin/${ghprbTargetBranch}
+
+echo "Comparing the following target branch:"
+git rev-parse origin/${ghprbTargetBranch}
+
 # show diffs between $ghprbTargetBranch (where the merge is going) and
 # $ghprbActualCommit (the tip of the branch that's merging) with '...',
 # which is equivalent to diff $(git merge-base TB AC) AC, or "show


### PR DESCRIPTION
This ceph-pr-submodules job is still giving us false positives in some cases.

We were comparing against a target branch (for example "origin/jewel"), but we could not see the *exact* sha1 that Jenkins thought was "origin/jewel". Sometimes this job would fail, and the failure hinted that Jenkins might be comparing an older target branch.

Explicitly fetch the target branch immediately before doing the "git log" operation, and print the target branch's sha1 ref to stdout in case we need further debugging.