### PR TITLE
ceph-ansible-prs: destroy and undefine libvirt networks on teardown

### DIFF
--- a/ceph-ansible-prs/build/teardown
+++ b/ceph-ansible-prs/build/teardown
@@ -15,5 +15,6 @@ done
 # Sometimes, networks may linger around, so we must ensure they are killed:
 networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
 for network in $networks; do
-    sudo virsh net-destroy $network
+    sudo virsh net-destroy $network || true
+    sudo virsh net-undefine $network || true
 done


### PR DESCRIPTION
Signed-off-by: Andrew Schoen <aschoen@redhat.com>