### PR TITLE
ceph-installer-tests: do not send emails on job completion

### DIFF
--- a/ceph-installer-tests/config/definitions/ceph-installer-tests.yml
+++ b/ceph-installer-tests/config/definitions/ceph-installer-tests.yml
@@ -55,7 +55,3 @@
           !include-raw-escape:
             - ../../../scripts/build_utils.sh
             - ../../build/build
-
-    publishers:
-      - email:
-          recipients: aschoen@redhat.com adeza@redhat.com


### PR DESCRIPTION
We don't have a mail server setup, so lets remove this for now.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>