### PR TITLE
ceph-ansible-prs: remove old libvirt networks before running tests

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -9,6 +9,13 @@ source $VENV/activate
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
+# Sometimes, networks may linger around, so we must ensure they are killed:
+networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
+for network in $networks; do
+    sudo virsh net-destroy $network || true
+    sudo virsh net-undefine $network || true
+done
+
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment
 $VENV/tox -rv -e=$RELEASE-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt


### PR DESCRIPTION
Occasionally we deal with libvirt network issues on jenkins slaves that
have been used for a couple test runs, this attempts to avoid those.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>