### PR TITLE
ansible: we now need java-1.8.0-openjdk on rpm nodes

### DIFF
--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -102,7 +102,7 @@
       with_items:
         - createrepo
         - epel-release
-        - java-1.7.0-openjdk
+        - java-1.8.0-openjdk
         - git
         - python-pip
         - python-virtualenv

--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -72,7 +72,7 @@
       with_items:
         - createrepo
         - epel-release
-        - java-1.7.0-openjdk
+        - java-1.8.0-openjdk
         - git
         - python-pip
         - python-virtualenv


### PR DESCRIPTION
After the latest jenkins upgrade to 2.57 our centos slaves failed to
connect to jenkins, upgrading to a 1.8.0 version of java fixed the
issue.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>