### PR TITLE
ansible: using forked version of python-jenkins until we can fix upstream

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -218,8 +218,10 @@
 
     - name: install python-jenkins
       sudo: true
-      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
-      pip: name=python-jenkins version=0.4.7
+      # HORRIBLY BROKEN. This is temporary until this lands upstream:
+      # https://github.com/ceph/python-jenkins/commit/8e018bf7d88dfc308833d195a6ebd29231a8969d
+      # https://review.openstack.org/460363
+      pip: name=git+https://github.com/ceph/python-jenkins@patched#egg=python-jenkins
 
     - name: add github.com host key
       sudo: true

--- a/ansible/examples/slave_libvirt.yml
+++ b/ansible/examples/slave_libvirt.yml
@@ -188,8 +188,10 @@
 
     - name: install python-jenkins
       sudo: true
-      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
-      pip: name=python-jenkins version=0.4.7
+      # HORRIBLY BROKEN. This is temporary until this lands upstream:
+      # https://github.com/ceph/python-jenkins/commit/8e018bf7d88dfc308833d195a6ebd29231a8969d
+      # https://review.openstack.org/460363
+      pip: name=git+https://github.com/ceph/python-jenkins@patched#egg=python-jenkins
 
     - name: add github.com host key
       sudo: true

--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -6,7 +6,7 @@
 - hosts: all
   sudo: yes
 # this will most likely need changed
-  user: admin 
+  user: admin
   gather_facts: false
   tasks:
     - name: install python-simplejson
@@ -17,7 +17,7 @@
 - hosts: all
   sudo: true
 # this will most likely need changed
-  user: admin 
+  user: admin
   vars:
    - jenkins_user: 'jenkins-build'
    # jenkins API credentials:
@@ -27,7 +27,7 @@
    # this is also set in the example/hosts-static file
    - nodename: '{{ ansible_hostname }}'
    - labels: '{{ labels }}'
-   - use_jnlp: true 
+   - use_jnlp: true
 
   tasks:
     - name: create a {{ jenkins_user }} user
@@ -243,8 +243,10 @@
 
     - name: install python-jenkins
       sudo: true
-      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
-      pip: name=python-jenkins version=0.4.7
+      # HORRIBLY BROKEN. This is temporary until this lands upstream:
+      # https://github.com/ceph/python-jenkins/commit/8e018bf7d88dfc308833d195a6ebd29231a8969d
+      # https://review.openstack.org/460363
+      pip: name=git+https://github.com/ceph/python-jenkins@patched#egg=python-jenkins
 
     - name: add github.com host key
       sudo: true
@@ -297,7 +299,7 @@
         dest: "/home/{{ jenkins_user }}/slave.jar"
       when: use_jnlp
 
-    - name: install the systemd unit file for jenkins 
+    - name: install the systemd unit file for jenkins
       template:
         src: "templates/systemd/jenkins.service.j2"
         dest: "/etc/systemd/system/jenkins.service"

--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -218,8 +218,10 @@
 
     - name: install python-jenkins
       sudo: true
-      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
-      pip: name=python-jenkins version=0.4.7
+      # HORRIBLY BROKEN. This is temporary until this lands upstream:
+      # https://github.com/ceph/python-jenkins/commit/8e018bf7d88dfc308833d195a6ebd29231a8969d
+      # https://review.openstack.org/460363
+      pip: name=git+https://github.com/ceph/python-jenkins@patched#egg=python-jenkins
 
     - name: add github.com host key
       sudo: true

--- a/ansible/slave_libvirt.yml
+++ b/ansible/slave_libvirt.yml
@@ -188,8 +188,10 @@
 
     - name: install python-jenkins
       sudo: true
-      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
-      pip: name=python-jenkins version=0.4.7
+      # HORRIBLY BROKEN. This is temporary until this lands upstream:
+      # https://github.com/ceph/python-jenkins/commit/8e018bf7d88dfc308833d195a6ebd29231a8969d
+      # https://review.openstack.org/460363
+      pip: name=git+https://github.com/ceph/python-jenkins@patched#egg=python-jenkins
 
     - name: add github.com host key
       sudo: true


### PR DESCRIPTION
This is already live in prado.ceph.com for slave.yml