### PR TITLE
ceph-ansible/-installer: explicitly install mock

### DIFF
--- a/ceph-ansible-rpm/build/build
+++ b/ceph-ansible-rpm/build/build
@@ -10,7 +10,7 @@ set -ex
 PACKAGE=${JOB_NAME%-rpm}
 
 sudo yum -y install epel-release
-sudo yum -y install fedpkg
+sudo yum -y install fedpkg mock
 
 # Add the Jenkins slave UID to the mock group.
 sudo usermod -a -G mock $(whoami)

--- a/ceph-installer-rpm/build/build
+++ b/ceph-installer-rpm/build/build
@@ -10,7 +10,7 @@ set -ex
 PACKAGE=${JOB_NAME%-rpm}
 
 sudo yum -y install epel-release
-sudo yum -y install fedpkg
+sudo yum -y install fedpkg mock
 
 # Add the Jenkins slave UID to the mock group.
 sudo usermod -a -G mock $(whoami)


### PR DESCRIPTION
It appears that Yum is not installing "mock" when installing fedpkg
(with fedpkg-1.28-1.el7). Explicitly install it in our build steps.