### PR TITLE
attempt to make libvirt slaves more stable

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -16,6 +16,10 @@ for network in $networks; do
     sudo virsh net-undefine $network || true
 done
 
+# restart libvirt services
+sudo service libvirt-bin restart
+sudo service libvirt-guests restart
+
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment
 $VENV/tox -rv -e=$RELEASE-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt

--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -9,16 +9,8 @@ source $VENV/activate
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
-# Sometimes, networks may linger around, so we must ensure they are killed:
-networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
-for network in $networks; do
-    sudo virsh net-destroy $network || true
-    sudo virsh net-undefine $network || true
-done
-
-# restart libvirt services
-sudo service libvirt-bin restart
-sudo service libvirt-guests restart
+clear_libvirt_networks
+restart_libvirt_services
 
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment

--- a/ceph-ansible-scenario/build/build
+++ b/ceph-ansible-scenario/build/build
@@ -9,16 +9,8 @@ source $VENV/activate
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
-# Sometimes, networks may linger around, so we must ensure they are killed:
-networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
-for network in $networks; do
-    sudo virsh net-destroy $network || true
-    sudo virsh net-undefine $network || true
-done
-
-# restart libvirt services
-sudo service libvirt-bin restart
-sudo service libvirt-guests restart
+clear_libvirt_networks
+restart_libvirt_services
 
 # the $SCENARIO var is injected by the job configuration. It maps
 # to an actual, defined, tox environment

--- a/ceph-docker-nightly/build/build
+++ b/ceph-docker-nightly/build/build
@@ -15,16 +15,8 @@ sudo gpasswd -a ${USER} docker
 sudo systemctl restart docker
 newgrp docker
 
-# Sometimes, networks may linger around, so we must ensure they are killed:
-networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
-for network in $networks; do
-    sudo virsh net-destroy $network || true
-    sudo virsh net-undefine $network || true
-done
-
-# restart libvirt services
-sudo service libvirt-bin restart
-sudo service libvirt-guests restart
+clear_libvirt_networks
+restart_libvirt_services
 
 # adding groups on the fly doesn't guarantee their availability
 # so we must use `sg` to execute the tests as part of the docker group to avoid

--- a/ceph-docker-nightly/build/build
+++ b/ceph-docker-nightly/build/build
@@ -15,6 +15,13 @@ sudo gpasswd -a ${USER} docker
 sudo systemctl restart docker
 newgrp docker
 
+# Sometimes, networks may linger around, so we must ensure they are killed:
+networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
+for network in $networks; do
+    sudo virsh net-destroy $network || true
+    sudo virsh net-undefine $network || true
+done
+
 # adding groups on the fly doesn't guarantee their availability
 # so we must use `sg` to execute the tests as part of the docker group to avoid
 # 'Permission Denied` when tryin to talk over the socket

--- a/ceph-docker-nightly/build/build
+++ b/ceph-docker-nightly/build/build
@@ -22,6 +22,10 @@ for network in $networks; do
     sudo virsh net-undefine $network || true
 done
 
+# restart libvirt services
+sudo service libvirt-bin restart
+sudo service libvirt-guests restart
+
 # adding groups on the fly doesn't guarantee their availability
 # so we must use `sg` to execute the tests as part of the docker group to avoid
 # 'Permission Denied` when tryin to talk over the socket

--- a/ceph-docker-prs/build/build
+++ b/ceph-docker-prs/build/build
@@ -15,16 +15,8 @@ sudo gpasswd -a ${USER} docker
 sudo systemctl restart docker
 newgrp docker
 
-# Sometimes, networks may linger around, so we must ensure they are killed:
-networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
-for network in $networks; do
-    sudo virsh net-destroy $network || true
-    sudo virsh net-undefine $network || true
-done
-
-# restart libvirt services
-sudo service libvirt-bin restart
-sudo service libvirt-guests restart
+clear_libvirt_networks
+restart_libvirt_services
 
 # adding groups on the fly doesn't guarantee their availability
 # so we must use `sg` to execute the tests as part of the docker group to avoid

--- a/ceph-docker-prs/build/build
+++ b/ceph-docker-prs/build/build
@@ -15,6 +15,13 @@ sudo gpasswd -a ${USER} docker
 sudo systemctl restart docker
 newgrp docker
 
+# Sometimes, networks may linger around, so we must ensure they are killed:
+networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
+for network in $networks; do
+    sudo virsh net-destroy $network || true
+    sudo virsh net-undefine $network || true
+done
+
 # adding groups on the fly doesn't guarantee their availability
 # so we must use `sg` to execute the tests as part of the docker group to avoid
 # 'Permission Denied` when tryin to talk over the socket

--- a/ceph-docker-prs/build/build
+++ b/ceph-docker-prs/build/build
@@ -22,6 +22,10 @@ for network in $networks; do
     sudo virsh net-undefine $network || true
 done
 
+# restart libvirt services
+sudo service libvirt-bin restart
+sudo service libvirt-guests restart
+
 # adding groups on the fly doesn't guarantee their availability
 # so we must use `sg` to execute the tests as part of the docker group to avoid
 # 'Permission Denied` when tryin to talk over the socket

--- a/ceph-installer-tests/build/build
+++ b/ceph-installer-tests/build/build
@@ -6,4 +6,11 @@ WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
 cd $WORKSPACE/tests/functional
 
+# Sometimes, networks may linger around, so we must ensure they are killed:
+networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
+for network in $networks; do
+    sudo virsh net-destroy $network || true
+    sudo virsh net-undefine $network || true
+done
+
 INSTALLER_DEV_BRANCH=$INSTALLER_BRANCH CEPH_ANSIBLE_DEV_BRANCH=$CEPH_ANSIBLE_BRANCH $VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR -- --provider=libvirt

--- a/ceph-installer-tests/build/build
+++ b/ceph-installer-tests/build/build
@@ -6,15 +6,7 @@ WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
 cd $WORKSPACE/tests/functional
 
-# Sometimes, networks may linger around, so we must ensure they are killed:
-networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
-for network in $networks; do
-    sudo virsh net-destroy $network || true
-    sudo virsh net-undefine $network || true
-done
-
-# restart libvirt services
-sudo service libvirt-bin restart
-sudo service libvirt-guests restart
+clear_libvirt_networks
+restart_libvirt_services
 
 INSTALLER_DEV_BRANCH=$INSTALLER_BRANCH CEPH_ANSIBLE_DEV_BRANCH=$CEPH_ANSIBLE_BRANCH $VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR -- --provider=libvirt

--- a/ceph-installer-tests/build/build
+++ b/ceph-installer-tests/build/build
@@ -13,4 +13,8 @@ for network in $networks; do
     sudo virsh net-undefine $network || true
 done
 
+# restart libvirt services
+sudo service libvirt-bin restart
+sudo service libvirt-guests restart
+
 INSTALLER_DEV_BRANCH=$INSTALLER_BRANCH CEPH_ANSIBLE_DEV_BRANCH=$CEPH_ANSIBLE_BRANCH $VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR -- --provider=libvirt

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -406,3 +406,18 @@ setup_pbuilder() {
         --mirror "$mirror"
     fi
 }
+
+clear_libvirt_networks() {
+    # Sometimes, networks may linger around, so we must ensure they are killed:
+    networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
+    for network in $networks; do
+        sudo virsh net-destroy $network || true
+        sudo virsh net-undefine $network || true
+    done
+}
+
+restart_libvirt_services() {
+    # restart libvirt services
+    sudo service libvirt-bin restart
+    sudo service libvirt-guests restart
+}


### PR DESCRIPTION
We continue to have issues with ceph-ansible/docker/installer tests failing because of libvirt networking issues. This is an attempt to get libvirt back into a good state by delete old networks and restarting services before we run tests.

Here is an example of the error we see often: https://jenkins.ceph.com/view/ceph-installer/job/ceph-installer-tests-ansible2.2-nightly_xenial/124/console