### PR TITLE
ceph-ansible-scenario: use include-raw instead of include-raw-escape

### DIFF
--- a/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
+++ b/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
@@ -40,7 +40,7 @@
 
     builders:
       - shell:
-          !include-raw-escape:
+          !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 


### PR DESCRIPTION
This job is not using a job-template and fails with the following error
when using include-raw-escape:

  syntax error near unexpected token `{{'

Signed-off-by: Andrew Schoen <aschoen@redhat.com>