### PR TITLE
ceph-docker-nightly: test on stable-2.2 of ceph-ansible

### DIFF
--- a/ceph-docker-nightly/config/definitions/ceph-docker-nightly.yml
+++ b/ceph-docker-nightly/config/definitions/ceph-docker-nightly.yml
@@ -1,8 +1,8 @@
 - project:
     name: ceph-docker-nightly
     scenario:
-      - ceph_ansible2.1-jewel-centos7_cluster
-      - ceph_ansible2.1-jewel-xenial_cluster
+      - ceph_ansible2.2-jewel-centos7_cluster
+      - ceph_ansible2.2-jewel-xenial_cluster
       - ceph_ansible-jewel-centos7_cluster
       - ceph_ansible-jewel-xenial_cluster
       - ceph_ansible-kraken-centos7_cluster


### PR DESCRIPTION
We don't need to test on stable-2.1 of ceph-ansible anymore

Signed-off-by: Andrew Schoen <aschoen@redhat.com>