### PR TITLE
ceph-docker-lint: exclude codes

### DIFF
--- a/ceph-docker-lint/build/build
+++ b/ceph-docker-lint/build/build
@@ -4,16 +4,18 @@ set -e
 set -x
 
 IGNORE_THESE_CODES="SC1091,SC2015,SC2009,SC2001"
+IGNORE_THESE_FILES="variables_entrypoint.sh" # pipe-separated file names, e.g: foo|bar|foobar, this avoids shellcheck complaining that vars are not used (see: SC2034)
 
 function generate_filelist(){
    if [[ "$pull_request_id" -eq "" || "${ghprbCommentBody:-}" = "jenkins lint all" ]]
    then
-       find . -name '*.sh'
+       find . -name '*.sh' | grep -vE "$IGNORE_THESE_FILES"
    else
        curl -XGET "https://api.github.com/repos/ceph/ceph-docker/pulls/$pull_request_id/files" |
        jq '.[].filename' |  # just the files please
        tr -d '"' |  # remove the quoting from JSON
-       grep ".sh$"  # just the bash
+       grep ".sh$" | # just the bash
+       grep -vE "$IGNORE_THESE_FILES"
    fi
 
 }

--- a/ceph-docker-lint/build/build
+++ b/ceph-docker-lint/build/build
@@ -3,8 +3,7 @@
 set -e
 set -x
 
-#IGNORE_THESE_CODES="SC2005,SC2068,SC2086,SC2148,SC2162"
-IGNORE_THESE_CODES=""
+IGNORE_THESE_CODES="SC1091,SC2015,SC2009,SC2001"
 
 function generate_filelist(){
    if [[ "$pull_request_id" -eq "" || "${ghprbCommentBody:-}" = "jenkins lint all" ]]


### PR DESCRIPTION
Excluding the following code:

* SC1091: since our entrypoint copies files in / during this shellcheck
the files can not be found. Basically we source ./file but presently the
file is under osd_directory/file so can not be found.
* SC2015: because we use 'set -e' we don't have other choice to use '||
true' here.
* SC2009: pgrep returns processes ID where we are looking for a specific
string in the process line.
* SC2001: our sed expressions are too complex we can not substitute them
with bash ${variable//search/replace}.

Signed-off-by: Sébastien Han <seb@redhat.com>