### PR TITLE
scripts: Add function to delete leftover vagrant VMs

### DIFF
--- a/ceph-docker-nightly/build/teardown
+++ b/ceph-docker-nightly/build/teardown
@@ -11,3 +11,5 @@ for scenario in $scenarios; do
     vagrant destroy -f
     cd -
 done
+
+delete_vagrant_docker_vms

--- a/ceph-docker-prs/build/teardown
+++ b/ceph-docker-prs/build/teardown
@@ -11,3 +11,5 @@ for scenario in $scenarios; do
     vagrant destroy -f
     cd -
 done
+
+delete_vagrant_docker_vms

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -407,6 +407,19 @@ setup_pbuilder() {
     fi
 }
 
+delete_vagrant_docker_vms() {
+    # Delete any vagrant/libvirt VMs leftover from a failed docker build
+    libvirt_vms=`sudo virsh list --all --name | grep docker`
+    for vm in $libvirt_vms; do
+        # Destroy returns a non-zero rc if the VM's not running
+        sudo virsh destroy $vm || true
+        sudo virsh undefine $vm || true
+    done
+    # Clean up any leftover disk images
+    sudo rm -f /var/lib/libvirt/images/docker*.img
+    sudo virsh pool-refresh default
+}
+
 clear_libvirt_networks() {
     # Sometimes, networks may linger around, so we must ensure they are killed:
     networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`


### PR DESCRIPTION
Some of the network errors thrown by libvirt when running
Docker builds were because the slave had leftover Vagrant VMs that didn't
get destroyed.

This PR ensures all slaves being used for Docker tests will have VMs and disk images cleaned up if the build fails.

Signed-off-by: David Galloway <dgallowa@redhat.com>