### PR TITLE
samba: remove inactive distros and erroneous variable definition

### DIFF
--- a/samba/config/definitions/samba.yml
+++ b/samba/config/definitions/samba.yml
@@ -52,16 +52,10 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           type: label-expression
           name: AVAILABLE_DIST
           values:
-            - centos6
             - centos7
             - trusty-pbuilder
             - xenial
             - jessie
-            - precise
-            - wheezy
-      - axis:
-          type: dynamic
-          name: DIST
       - axis:
           type: dynamic
           name: DIST


### PR DESCRIPTION
Signed-off-by: Dan Mick <dan.mick@redhat.com>