### PR TITLE
add ceph-docker-build job

### DIFF
--- a/ceph-docker-build/build/build
+++ b/ceph-docker-build/build/build
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -eux
+
+sudo yum -y install docker
+
+sudo systemctl start docker
+
+# Authenticate to Docker Hub
+sudo docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+
+# Copy the files to the root for the type of image we're going to build
+mkdir -p daemon demo
+cp -Lrv ceph-releases/"$CEPH_RELEASE"/centos/7/daemon/* daemon
+# TODO: make demo image optional in build_imgs.sh
+# (instead of building it here and throwing it away)
+cp -Lrv ceph-releases/"$CEPH_RELEASE"/centos/7/demo/* demo
+
+# TODO: manipulate the Dockerfile here to insert the chacra Yum repo?
+# Proj Atomic does that with https://github.com/DBuildService/dockerfile-parse
+
+sudo "$WORKSPACE"/travis-builds/build_imgs.sh
+
+# Show our new images, for debugging:
+sudo docker images
+
+REGISTRY=docker.io
+
+# Determine our image's tag for the registry:
+BRANCH=${GIT_BRANCH//origin\//}
+TAG=ci-build-${BRANCH}-${CEPH_RELEASE}-centos-7
+
+# Tag the image we just built for the registry:
+sudo docker tag ceph/daemon "${REGISTRY}/cephjenkins/daemon:${TAG}"
+
+# Apparently this avoids a race condition between the tagging and the push
+# which causes this to sometimes fail when run by Jenkins
+sleep 1
+sudo docker --debug push "${REGISTRY}/cephjenkins/daemon:${TAG}"
+
+# Clean up registry credentials
+sudo docker logout

--- a/ceph-docker-build/config/definitions/ceph-docker-build.yml
+++ b/ceph-docker-build/config/definitions/ceph-docker-build.yml
@@ -1,0 +1,52 @@
+- project:
+    name: ceph-docker-build
+    ceph-release:
+      - jewel
+      - kraken
+      - luminous
+    jobs:
+        - 'ceph-docker-build-{ceph-release}'
+
+- job-template:
+    name: 'ceph-docker-build-{ceph-release}'
+    node: 'centos7 && x86_64 && small && !sepia'
+    concurrent: true
+    defaults: global
+    display-name: 'ceph-docker: image builds for {ceph-release}'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-docker
+    logrotate:
+      daysToKeep: 15
+      numToKeep: 30
+
+    triggers:
+      - github
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-docker
+
+    builders:
+      - inject:
+          properties-content: |
+            CEPH_RELEASE={ceph-release}
+      - shell:
+          !include-raw-escape:
+            - ../../build/build
+
+    wrappers:
+      - credentials-binding:
+          - username-password-separated:
+             credential-id: 68874f10-f019-4875-afb2-5cf63594dc0d
+             username: DOCKER_USERNAME
+             password: DOCKER_PASSWORD
+
+    publishers:
+      - postbuildscript:
+          builders:
+            - shell: 'sudo docker logout'


### PR DESCRIPTION
Build docker images for every Git branch in https://github.com/ceph/ceph-docker .

Use the credentials-id plugin to authenticate to the Docker Hub and push images.