### PR TITLE
scripts: Be more aggressive with deleting libvirt VMs

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -9,6 +9,7 @@ source $VENV/activate
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
+delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services
 

--- a/ceph-ansible-scenario/build/build
+++ b/ceph-ansible-scenario/build/build
@@ -9,6 +9,7 @@ source $VENV/activate
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
+delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services
 

--- a/ceph-docker-nightly/build/build
+++ b/ceph-docker-nightly/build/build
@@ -15,6 +15,7 @@ sudo gpasswd -a ${USER} docker
 sudo systemctl restart docker
 newgrp docker
 
+delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services
 

--- a/ceph-docker-nightly/build/teardown
+++ b/ceph-docker-nightly/build/teardown
@@ -11,5 +11,3 @@ for scenario in $scenarios; do
     vagrant destroy -f
     cd -
 done
-
-delete_vagrant_docker_vms

--- a/ceph-docker-prs/build/build
+++ b/ceph-docker-prs/build/build
@@ -15,6 +15,7 @@ sudo gpasswd -a ${USER} docker
 sudo systemctl restart docker
 newgrp docker
 
+delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services
 

--- a/ceph-docker-prs/build/teardown
+++ b/ceph-docker-prs/build/teardown
@@ -11,5 +11,3 @@ for scenario in $scenarios; do
     vagrant destroy -f
     cd -
 done
-
-delete_vagrant_docker_vms

--- a/ceph-installer-tests/build/build
+++ b/ceph-installer-tests/build/build
@@ -6,6 +6,7 @@ WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
 cd $WORKSPACE/tests/functional
 
+delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services
 

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -407,16 +407,17 @@ setup_pbuilder() {
     fi
 }
 
-delete_vagrant_docker_vms() {
-    # Delete any vagrant/libvirt VMs leftover from a failed docker build
-    libvirt_vms=`sudo virsh list --all --name | grep docker`
+delete_libvirt_vms() {
+    # Delete any VMs leftover from previous builds.
+    # Primarily used for Vagrant VMs leftover from docker builds.
+    libvirt_vms=`sudo virsh list --all --name`
     for vm in $libvirt_vms; do
         # Destroy returns a non-zero rc if the VM's not running
         sudo virsh destroy $vm || true
         sudo virsh undefine $vm || true
     done
     # Clean up any leftover disk images
-    sudo rm -f /var/lib/libvirt/images/docker*.img
+    sudo rm -f /var/lib/libvirt/images/*.img
     sudo virsh pool-refresh default
 }
 


### PR DESCRIPTION
This PR ensures all slaves that use tox & Vagrant don't have any running libvirt VMs that could cause IP collisions

Builds on https://github.com/ceph/ceph-build/pull/720

Signed-off-by: David Galloway <dgallowa@redhat.com>