### PR TITLE
scripts: fix virsh pool-refresh issue

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -418,7 +418,7 @@ delete_libvirt_vms() {
     done
     # Clean up any leftover disk images
     sudo rm -f /var/lib/libvirt/images/*.img
-    sudo virsh pool-refresh default
+    sudo virsh pool-refresh default || true
 }
 
 clear_libvirt_networks() {


### PR DESCRIPTION
c7edf24 introduced a new behavior regarding teardown.
`virsh pool-refresh default` might fail if the pool doesn't exist yet.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>