### PR TITLE
samba: Clean old ceph bits before getting new

### DIFF
--- a/samba/build/build_deb
+++ b/samba/build/build_deb
@@ -34,8 +34,14 @@ fi
 sudo cp $WORKSPACE/shaman.list /etc/apt/sources.list.d/
 
 ## Install any setup-time deps
-# Make sure we use the latest version of libcephfs-dev
-sudo apt-get remove -y libcephfs-dev || true
+# Make sure we use the latest ceph versions, remove any old bits
+xargs sudo apt-get remove -y <<< "
+libcephfs-dev
+libcephfs1
+libcephfs2
+librados2
+librbd1
+"
 
 # We need these for the build
 sudo apt-get update && sudo apt-get install -y build-essential equivs libgnutls-dev libacl1-dev libldap2-dev ruby ruby-dev libcephfs-dev


### PR DESCRIPTION
Debian/Ubuntu does not tie the package versions the same way the rpm
packagin does so upgrading a single package won't remove any old
packages. Remove the old bits before installing any new.

This should fix a build failure on xenial where there were two libcephfs
libraries present on the system at the time of build which broke the
build.

Signed-off-by: Boris Ranto <branto@redhat.com>