### PR TITLE
A couple more samba fixes

### DIFF
--- a/samba/build/build_deb
+++ b/samba/build/build_deb
@@ -42,7 +42,7 @@ sudo apt-get remove -y librados2 || true
 sudo apt-get remove -y librbd1 || true
 
 # We need these for the build
-sudo apt-get update && sudo apt-get install -y build-essential equivs libgnutls-dev libacl1-dev libldap2-dev ruby ruby-dev libcephfs-dev
+sudo apt-get update && sudo apt-get install -y build-essential equivs libgnutls-dev libacl1-dev libldap2-dev ruby ruby-dev libcephfs-dev libpam-dev
 
 # We use fpm to create the deb package
 sudo gem install fpm

--- a/samba/build/build_deb
+++ b/samba/build/build_deb
@@ -35,13 +35,11 @@ sudo cp $WORKSPACE/shaman.list /etc/apt/sources.list.d/
 
 ## Install any setup-time deps
 # Make sure we use the latest ceph versions, remove any old bits
-xargs sudo apt-get remove -y <<< "
-libcephfs-dev
-libcephfs1
-libcephfs2
-librados2
-librbd1
-"
+sudo apt-get remove -y libcephfs-dev || true
+sudo apt-get remove -y libcephfs2 || true
+sudo apt-get remove -y libcephfs1 || true
+sudo apt-get remove -y librados2 || true
+sudo apt-get remove -y librbd1 || true
 
 # We need these for the build
 sudo apt-get update && sudo apt-get install -y build-essential equivs libgnutls-dev libacl1-dev libldap2-dev ruby ruby-dev libcephfs-dev

--- a/samba/build/build_rpm
+++ b/samba/build/build_rpm
@@ -40,7 +40,7 @@ sudo cp $WORKSPACE/shaman.repo /etc/yum.repos.d/
 sudo yum clean all
 
 # We need these for the build
-sudo yum install -y gnutls-devel libacl-devel openldap-devel rubygems ruby-devel libcephfs-devel
+sudo yum install -y gnutls-devel libacl-devel openldap-devel rubygems ruby-devel libcephfs-devel pam-devel
 
 # We use fpm to create the deb package
 sudo gem install fpm

--- a/samba/config/definitions/samba.yml
+++ b/samba/config/definitions/samba.yml
@@ -8,7 +8,7 @@
     concurrent: true
     parameters:
       - string:
-          name: BRANCH
+          name: SAMBA_BRANCH
           description: "The git branch (or tag) to build"
           default: "master"
 

--- a/samba/config/definitions/samba.yml
+++ b/samba/config/definitions/samba.yml
@@ -25,7 +25,7 @@
       - string:
           name: DISTROS
           description: "A list of distros to build for. Available options are: xenial, centos7, centos6, trusty-pbuilder, precise, wheezy, and jessie"
-          default: "centos7 trusty-pbuilder xenial"
+          default: "centos7 xenial"
 
       - string:
           name: ARCHS


### PR DESCRIPTION
We had random build failures on missing pam library, the xargs command did not work the way I expected it to and we no longer need to build for trusty by default, especially now since we have the builds being triggered automatically.