### PR TITLE
samba: Strip out origin/ for CEPH_BRANCH

### DIFF
--- a/samba/build/setup
+++ b/samba/build/setup
@@ -38,6 +38,10 @@ export LC_ALL=C # the following is vulnerable to i18n
 pkgs=( "chacractl>=0.0.4" )
 install_python_packages "pkgs[@]"
 
+SAMBA_BRANCH=$(branch_slash_filter $SAMBA_BRANCH)
+CEPH_BRANCH=$(branch_slash_filter $CEPH_BRANCH)
+BRANCH=${SAMBA_BRANCH}
+
 # ask shaman which chacra instance to use
 chacra_url=`curl -f -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
 # create the .chacractl config file using global variables

--- a/samba/config/definitions/samba.yml
+++ b/samba/config/definitions/samba.yml
@@ -89,7 +89,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           # Use the SSH key attached to the ceph-jenkins GitHub account.
           credentials-id: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
           branches:
-            - $BRANCH
+            - $SAMBA_BRANCH
           skip-tag: true
           wipe-workspace: true
 

--- a/samba/config/definitions/samba.yml
+++ b/samba/config/definitions/samba.yml
@@ -62,16 +62,10 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           type: label-expression
           name: AVAILABLE_DIST
           values:
-            - centos6
             - centos7
             - trusty-pbuilder
             - xenial
             - jessie
-            - precise
-            - wheezy
-      - axis:
-          type: dynamic
-          name: DIST
       - axis:
           type: dynamic
           name: DIST


### PR DESCRIPTION
When we pass the CEPH_BRANCH from ceph-dev-build, it contains
origin/<branch>, we need to strip out the remote from the CEPH_BRANCH
before we can use it.

Signed-off-by: Boris Ranto <branto@redhat.com>