### PR TITLE
scripts: Be more aggressive with libvirt network destruction

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -423,7 +423,7 @@ delete_libvirt_vms() {
 
 clear_libvirt_networks() {
     # Sometimes, networks may linger around, so we must ensure they are killed:
-    networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
+    networks=`sudo virsh net-list --all --name`
     for network in $networks; do
         sudo virsh net-destroy $network || true
         sudo virsh net-undefine $network || true


### PR DESCRIPTION
See https://github.com/vagrant-libvirt/vagrant-libvirt/issues/670#issuecomment-261964248

Can confirm that deleting the default network still allows vagrant-libvirt to run fine on Ubuntu 16.04.

Signed-off-by: David Galloway <dgallowa@redhat.com>