### PR TITLE
ceph-lvm-docs: define BRANCH to sync it to the right dir

### DIFF
--- a/ceph-lvm-docs/build/build
+++ b/ceph-lvm-docs/build/build
@@ -6,6 +6,9 @@ set -ex
 pkgs=( "tox" )
 install_python_packages "pkgs[@]"
 
+# trims leading slashes
+BRANCH=${GIT_BRANCH#*/}
+
 # create the docs build with tox
 $VENV/tox -rv -e docs
 

--- a/ceph-lvm-docs/build/build
+++ b/ceph-lvm-docs/build/build
@@ -7,7 +7,7 @@ pkgs=( "tox" )
 install_python_packages "pkgs[@]"
 
 # trims leading slashes
-BRANCH=${GIT_BRANCH#*/}
+BRANCH=`branch_slash_filter ${GIT_BRANCH}`
 
 # create the docs build with tox
 $VENV/tox -rv -e docs


### PR DESCRIPTION
This was causing the build to just sync to the root directory which we don't want, we really want to be able to have the same behavior as ceph-ansible and ceph docs