### PR TITLE
ceph-ansible-pr-syntax-check: add library path

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -16,5 +16,6 @@ $VENV/ansible-playbook -i '127.0.0.1,' site-docker.yml.sample --syntax-check --l
 cp -r roles infrastructure-playbooks/
 cp -r group_vars infrastructure-playbooks/
 mv infrastructure-playbooks/group_vars/all.yml.sample infrastructure-playbooks/group_vars/all.yml
+export ANSIBLE_LIBRARY=$WORKSPACE/ceph-ansible/library
 
 $VENV/ansible-playbook -i '127.0.0.1,' infrastructure-playbooks/*.yml --syntax-check --list-tasks -vv


### PR DESCRIPTION
Explicitly set the LIBRARY path to avoid the following Ansible error:

ERROR! no action detected in task. This often indicates a misspelled
module name, or incorrect module path.

We need this change because roles path changed from ceph-ansible/ to
ceph-ansible/infrastructure-playbooks so now when we are running the
syntax check it looks in ceph-ansible/infrastructure-playbooks/library
instead of ceph-ansible/library.

Signed-off-by: Sébastien Han <seb@redhat.com>