### PR TITLE
cephmetrics: Add default branch, forbid wipe

### DIFF
--- a/cephmetrics/config/definitions/cephmetrics.yml
+++ b/cephmetrics/config/definitions/cephmetrics.yml
@@ -10,6 +10,7 @@
       - string:
           name: BRANCH
           description: "The git branch (or tag) to build"
+          default: "master"
 
       - string:
           name: DISTROS
@@ -72,6 +73,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           branches:
             - $BRANCH
           skip-tag: true
+          wipe-workspace: false
 
     builders:
       - shell: |


### PR DESCRIPTION
The build job does not work well with empty branch, we should provide a
default master branch to fix it.

It looks like it is not enough to remove the wipe-workspace line, it was
on even without that line. Adding wipe-workspace: false to hopefully fix
it.

Signed-off-by: Boris Ranto <branto@redhat.com>