### PR TITLE
DNM: cephmetrics: Build for all branches

### DIFF
--- a/cephmetrics/build/build_rpm
+++ b/cephmetrics/build/build_rpm
@@ -4,6 +4,8 @@ set -ex
 # Sanity-check:
 [ -z "$GIT_BRANCH" ] && echo Missing GIT_BRANCH variable && exit 1
 
+BRANCH=`branch_slash_filter $GIT_BRANCH`
+
 # Only do actual work when we are an RPM distro
 if test "$DISTRO" != "fedora" -a "$DISTRO" != "centos" -a "$DISTRO" != "rhel"; then
     exit 0

--- a/cephmetrics/build/build_rpm
+++ b/cephmetrics/build/build_rpm
@@ -1,6 +1,9 @@
 #! /usr/bin/bash
 set -ex
 
+# Sanity-check:
+[ -z "$GIT_BRANCH" ] && echo Missing GIT_BRANCH variable && exit 1
+
 # Only do actual work when we are an RPM distro
 if test "$DISTRO" != "fedora" -a "$DISTRO" != "centos" -a "$DISTRO" != "rhel"; then
     exit 0

--- a/cephmetrics/config/definitions/cephmetrics.yml
+++ b/cephmetrics/config/definitions/cephmetrics.yml
@@ -6,6 +6,9 @@
     block-downstream: false
     block-upstream: false
     concurrent: true
+    properties:
+      - github:
+          url: https://github.com/ceph/cephmetrics
     parameters:
       - string:
           name: BRANCH

--- a/cephmetrics/config/definitions/cephmetrics.yml
+++ b/cephmetrics/config/definitions/cephmetrics.yml
@@ -73,8 +73,6 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           url: git@github.com:ceph/cephmetrics.git
           # Use the SSH key attached to the ceph-jenkins GitHub account.
           credentials-id: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
-          branches:
-            - $BRANCH
           skip-tag: true
           wipe-workspace: false
 


### PR DESCRIPTION
This kicked off a build, but it failed because `BRANCH` was unset :-/

https://jenkins.ceph.com/job/cephmetrics/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=centos7,DIST=centos7,MACHINE_SIZE=small/42/console