### PR TITLE
adds the cephmetrics-release job

### DIFF
--- a/cephmetrics-release/build/build_rpm
+++ b/cephmetrics-release/build/build_rpm
@@ -1,0 +1,72 @@
+#! /usr/bin/bash
+set -ex
+
+
+# Only do actual work when we are an RPM distro
+if test "$DISTRO" != "fedora" -a "$DISTRO" != "centos" -a "$DISTRO" != "rhel"; then
+    exit 0
+fi
+
+
+## Install any setup-time deps (to make dist package)
+
+# We need this to get the major version from lsb_release
+sudo yum install -y redhat-lsb-core mock git wget
+
+# Run the install-deps.sh upstream script if it exists
+if [ -x install-deps.sh ]; then
+    echo "Ensuring dependencies are installed"
+    sudo ./install-deps.sh
+fi
+
+
+## Get some basic information about the system and the repository
+RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
+VERSION="0.1"
+REVISION="$(git rev-list --count HEAD)-g$(git rev-parse --short HEAD)"
+RPM_RELEASE=$(echo $REVISION | tr '-' '_') # the '-' has a special meaning
+
+
+## Build the source tarball
+echo "Building source distribution"
+git archive --format=zip --prefix=cephmetrics-${VERSION}/ HEAD > dist/cephmetrics-${VERSION}.zip
+wget https://grafana.com/api/plugins/vonage-status-panel/versions/1.0.4/download -O dist/vonage-status-panel-1.0.4.zip
+wget https://grafana.com/api/plugins/grafana-piechart-panel/versions/1.1.5/download -O dist/grafana-piechart-panel-1.1.5.zip
+
+
+## Prepare the spec file for build
+sed -e "s/@VERSION@/${VERSION}/g" -e "s/@RELEASE@/${RPM_RELEASE}/g" < cephmetrics.spec.in > dist/cephmetrics.spec
+
+
+## Create the source rpm
+echo "Building SRPM"
+rpmbuild \
+    --define "_sourcedir ./dist" \
+    --define "_specdir ." \
+    --define "_builddir ." \
+    --define "_srcrpmdir ." \
+    --define "_rpmdir ." \
+    --define "dist .any" \
+    --define "fedora 21" \
+    --define "rhel 7" \
+    --nodeps -bs dist/cephmetrics.spec
+SRPM=$(readlink -f *.src.rpm)
+
+
+## Build the binaries with mock
+echo "Building RPMs"
+sudo mock -r ${MOCK_TARGET}-${RELEASE}-${ARCH} --resultdir=./dist/rpm/ ${SRPM}
+
+
+## Upload the created RPMs to chacra
+chacra_endpoint="cephmetrics/${BRANCH}/${GIT_COMMIT}/${DISTRO}/${RELEASE}"
+
+[ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
+
+# push binaries to chacra
+find ./dist/rpm/ | egrep '\.rpm$' | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/$ARCH/
+
+# start repo creation
+$VENV/chacractl repo update ${chacra_endpoint}
+
+echo Check the status of the repo at: https://shaman.ceph.com/api/repos/${chacra_endpoint}

--- a/cephmetrics-release/build/setup
+++ b/cephmetrics-release/build/setup
@@ -1,0 +1,42 @@
+#! /usr/bin/bash
+#
+# Ceph distributed storage system
+#
+# Copyright (C) 2016 Red Hat <contact@redhat.com>
+#
+# Author: Boris Ranto <branto@redhat.com>
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+set -ex
+
+# Make sure we execute at the top level directory before we do anything
+cd $WORKSPACE
+
+# This will set the DISTRO and MOCK_TARGET variables
+get_distro_and_target
+
+# Perform a clean-up
+sudo git clean -fxd
+
+# Make sure the dist directory is clean
+sudo rm -rf dist
+mkdir -p dist
+
+# Print some basic system info
+HOST=$(hostname --short)
+echo "Building on $(hostname) with the following env"
+echo "*****"
+env
+echo "*****"
+
+export LC_ALL=C # the following is vulnerable to i18n
+
+pkgs=( "chacractl>=0.0.4" )
+install_python_packages "pkgs[@]"
+
+# create the .chacractl config file using global variables
+make_chacractl_config

--- a/cephmetrics-release/config/definitions/cephmetrics-release.yml
+++ b/cephmetrics-release/config/definitions/cephmetrics-release.yml
@@ -1,0 +1,97 @@
+- job:
+    name: cephmetrics-release
+    project-type: matrix
+    defaults: global
+    display-name: 'cephmetrics-release'
+    block-downstream: false
+    block-upstream: false
+    concurrent: true
+    properties:
+      - github:
+          url: https://github.com/ceph/cephmetrics
+    parameters:
+      - string:
+          name: BRANCH
+          description: "The git branch (or tag) to build"
+          default: "master"
+
+      - string:
+          name: DISTROS
+          description: "A list of distros to build for. Available options are: centos7, centos6"
+          default: "centos7"
+
+      - string:
+          name: ARCHS
+          description: "A list of architectures to build for. Available options are: x86_64, and arm64"
+          default: "x86_64"
+
+      - bool:
+          name: FORCE
+          description: "
+If this is unchecked, then nothing is built or pushed if they already exist in chacra. This is the default.
+
+If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
+
+      - string:
+          name: BUILD_VIRTUALENV
+          description: "Base parent path for virtualenv locations, set to avoid issues with extremely long paths that are incompatible with tools like pip. Defaults to '/tmp/' (note the trailing slash, which is required)."
+          default: "/tmp/"
+
+    execution-strategy:
+       combination-filter: DIST==AVAILABLE_DIST && ARCH==AVAILABLE_ARCH && (ARCH=="x86_64" || (ARCH == "arm64" && (DIST == "xenial" || DIST == "centos7")))
+    axes:
+      - axis:
+          type: label-expression
+          name: MACHINE_SIZE
+          values:
+            - small
+      - axis:
+          type: label-expression
+          name: AVAILABLE_ARCH
+          values:
+            - x86_64
+            - arm64
+      - axis:
+          type: label-expression
+          name: AVAILABLE_DIST
+          values:
+            - centos6
+            - centos7
+      - axis:
+          type: dynamic
+          name: DIST
+          values:
+            - DISTROS
+      - axis:
+          type: dynamic
+          name: ARCH
+          values:
+            - ARCHS
+
+    scm:
+      - git:
+          url: git@github.com:ceph/cephmetrics.git
+          # Use the SSH key attached to the ceph-jenkins GitHub account.
+          credentials-id: '39fa150b-b2a1-416e-b334-29a9a2c0b32d'
+          skip-tag: true
+          branches:
+            - $BRANCH
+          wipe-workspace: true
+
+    builders:
+      - shell: |
+          echo "Cleaning up top-level workarea (shared among workspaces)"
+          sudo rm -rf dist
+          sudo rm -rf venv
+          sudo rm -rf release
+      # rpm build scripts
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/setup
+            - ../../build/build_rpm
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true


### PR DESCRIPTION
The purpose of this job is to allow for manual
builds of cephmetrics that will be stored on chacra.ceph.com
where the repo can be combined with cephmetrics-debs.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>