### PR TITLE
cephmetrics-release: when building for centos7 upload to chacra as rhel7

### DIFF
--- a/cephmetrics-release/build/build_rpm
+++ b/cephmetrics-release/build/build_rpm
@@ -59,7 +59,7 @@ sudo mock -r ${MOCK_TARGET}-${RELEASE}-${ARCH} --resultdir=./dist/rpm/ ${SRPM}
 
 
 ## Upload the created RPMs to chacra
-chacra_endpoint="cephmetrics/${BRANCH}/${GIT_COMMIT}/${DISTRO}/${RELEASE}"
+chacra_endpoint="cephmetrics/${BRANCH}/${GIT_COMMIT}/rhel/${RELEASE}"
 
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 


### PR DESCRIPTION
We need to do this because cephmetrics-deps is uploaded as rhel7 and if
we don't upload cephmetrics as the same chacra won't combine the repos.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>