### PR TITLE
cephmetrics-release: sets wipe_workspace to false

### DIFF
--- a/cephmetrics-release/config/definitions/cephmetrics-release.yml
+++ b/cephmetrics-release/config/definitions/cephmetrics-release.yml
@@ -76,7 +76,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           skip-tag: true
           branches:
             - $BRANCH
-          wipe-workspace: true
+          wipe-workspace: false
 
     builders:
       - shell: |


### PR DESCRIPTION
wipe_workspace does not use sudo which causes some of our builds to fail

Signed-off-by: Andrew Schoen <aschoen@redhat.com>