### PR TITLE
ceph-pull-requests-arm64: make ghprb config like amd64 version

### DIFF
--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -73,20 +73,18 @@
           </scm>
     triggers:
     - github-pull-request:
-        admin-list:
-        - alfredodeza
-        - ktdreyer
-        allow-whitelist-orgs-as-admins: false
-        auth-id: 2f99aa21-4f3c-4a7e-93d9-f85361aff591
-        auto-close-on-fail: false
-        build-desc-template: null
-        cron: null
-        github-hooks: true
-        only-trigger-phrase: false
+        allow-whitelist-orgs-as-admins: true
         org-list:
         - ceph
+        trigger-phrase: ''
+        only-trigger-phrase: false
+        github-hooks: true
         permit-all: true
-        trigger-phrase: null
+        auto-close-on-fail: false
+        status-context: "make check (arm64)"
+        started-status: "running make check"
+        success-status: "make check succeeded"
+        failure-status: "make check failed"
         white-list-target-branches:
         - master
     wrappers: []


### PR DESCRIPTION
Specifically reinstate the 'status-context/*-status' fields, but also
regularize like ceph-pull-requests job.  (This one originally came from
jjw and probably lost the fields/gained a lot of defaults in the
process)

Signed-off-by: Dan Mick <dan.mick@redhat.com>