### PR TITLE
ceph-ansible-prs: add bluestore scenarios

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -18,6 +18,8 @@
       - ansible2.2-update_cluster
       - ansible2.2-purge_docker_cluster
       - ansible2.2-update_docker_cluster
+      - ansible2.2-bluestore_cluster
+      - ansible2.2-bluestore_journal_collocation
     jobs:
         - 'ceph-ansible-prs-{release}-{scenario}'
 


### PR DESCRIPTION
ceph-ansible-prs: adds the ansible2.2-cluster_bluestore and
ansible2.2-journal_collocation_bluestore scenarios.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>