### PR TITLE
ceph-ansible-prs: fix bug with timeout

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -15,4 +15,7 @@ restart_libvirt_services
 
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment
-timeout 5h $VENV/tox -rv -e=$RELEASE-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt || echo "ERROR: Job didn't complete before the timeout has been exceeded (5h)."
+if ! timeout 5h $VENV/tox -rv -e=$RELEASE-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
+  echo "ERROR: Job didn't complete before the timeout exceeded (5h)."
+  exit 1
+fi


### PR DESCRIPTION
it will always return 0 even if tox return an error.
We must check wether the expression is not true instead.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>