### PR TITLE
ceph-docker-prs: remove kraken tests

### DIFF
--- a/ceph-docker-prs/config/definitions/ceph-docker-prs.yml
+++ b/ceph-docker-prs/config/definitions/ceph-docker-prs.yml
@@ -5,7 +5,6 @@
       - xenial
     ceph-version:
       - jewel
-      - kraken
       - luminous
     test:
       - cluster


### PR DESCRIPTION
As it has been decided to stop testing against kraken, this commit
remove all tests for kraken.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>