### PR TITLE
kernel: set git clone/fetch timeout to 20 minutes

### DIFF
--- a/kernel/config/definitions/kernel.yml
+++ b/kernel/config/definitions/kernel.yml
@@ -87,6 +87,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           branches:
             - $BRANCH
           skip-tag: true
+          timeout: 20
           wipe-workspace: true
 
     builders:


### PR DESCRIPTION
Started seeing failures like:

    Resolving deltas:  60% (2773158/4615018)
    Resolving deltas:  60% (2775140/4615018)
    Resolving deltas:  60% (2776500/4615018)
    error: fetch-pack died of signal 15

kernel-trigger and a lot of other jobs use 20.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>