### PR TITLE
Add timeout for ceph-docker

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -15,7 +15,7 @@ restart_libvirt_services
 
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment
-if ! timeout 5h $VENV/tox -rv -e=$RELEASE-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
-  echo "ERROR: Job didn't complete before the timeout exceeded (5h)."
+if ! timeout 3h $VENV/tox -rv -e=$RELEASE-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
+  echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
   exit 1
 fi

--- a/ceph-docker-prs/build/build
+++ b/ceph-docker-prs/build/build
@@ -22,4 +22,7 @@ restart_libvirt_services
 # adding groups on the fly doesn't guarantee their availability
 # so we must use `sg` to execute the tests as part of the docker group to avoid
 # 'Permission Denied` when tryin to talk over the socket
-sg docker -c "$VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR"
+if ! timeout 3h sg docker -c "$VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR"; then
+  echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
+  exit 1
+fi


### PR DESCRIPTION
- Add the same timeout than for ceph-ansible PRs in ceph-docker PRs.
- Change logged error message

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>