### PR TITLE
kernel: use shallow clones

### DIFF
--- a/kernel/config/definitions/kernel.yml
+++ b/kernel/config/definitions/kernel.yml
@@ -88,6 +88,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - $BRANCH
           skip-tag: true
           timeout: 20
+          shallow-clone: true
           wipe-workspace: true
 
     builders:


### PR DESCRIPTION
Setting the timeout to 20 minutes helped some, but I'm still seeing
failures during the CPU-intensive "Resolving deltas" stage.  Use git
clone --depth 1 for kernel to avoid stressing slaves.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>