### PR TITLE
ceph-ansible-prs: improve teardown

### DIFF
--- a/ceph-ansible-prs/build/teardown
+++ b/ceph-ansible-prs/build/teardown
@@ -4,12 +4,13 @@
 
 cd $WORKSPACE/tests
 
-scenarios=$(find . | grep Vagrantfile | xargs dirname)
+scenarios=$(find . -name Vagrantfile | xargs dirname)
 
 for scenario in $scenarios; do
-    cd $scenario
+    pushd $scenario
     vagrant destroy -f
-    cd -
+    rm -rf fetch/
+    popd
 done
 
 # Sometimes, networks may linger around, so we must ensure they are killed:


### PR DESCRIPTION
Delete with force any `fetch/` directories that could have been left after a
build.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>