### PR TITLE
Ceph pr docs fixes

### DIFF
--- a/ceph-pr-docs/build/build
+++ b/ceph-pr-docs/build/build
@@ -2,7 +2,16 @@
 
 set -ex
 
+# make sure any shaman list file is removed. At some point if all nodes
+# are clean this will not be needed.
+sudo rm -f /etc/apt/sources.list.d/shaman*
+
+# Ceph doc build deps, Ubuntu only because ditaa is not packaged for CentOS
+sudo apt-get update
+sudo apt-get install -y gcc python-dev python-pip python-virtualenv libxml2-dev libxslt-dev doxygen graphviz ant ditaa
+sudo apt-get install -y python-sphinx
+
 ./admin/build-doc
 
+# XXX to be removed after it is all working, here for debug only
 ls -l build-doc/output/html/
-

--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-pr-docs
     display-name: 'ceph: Pull Requests Docs Check'
-    node: (centos7 || trusty) && x86_64
+    node: trusty && x86_64
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -38,6 +38,10 @@
           timeout: 20
           wipe-workspace: true
 
+    builders:
+      - shell:
+          !include-raw ../../build/build
+
     publishers:
       - html-publisher:
           name: "Ceph Pull Request Docs"
@@ -48,7 +52,3 @@
           keep-all: true
           allow-missing: true
           link-to-last-build: true
-
-    builders:
-      - shell:
-          !include-raw ../../build/build


### PR DESCRIPTION
* I suspect the order of `publishers` is making the job not configure it (build was last item in yaml before)

* use ubuntu only because the deps (mainly ditaa) are not available in CentOS7

* remove frigging lingering shaman.list files that can mess up builds (temporary only)