### PR TITLE
ansible: use python-jenkins 0.4.15

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -218,10 +218,8 @@
 
     - name: install python-jenkins
       sudo: true
-      # HORRIBLY BROKEN. This is temporary until this lands upstream:
-      # https://github.com/ceph/python-jenkins/commit/8e018bf7d88dfc308833d195a6ebd29231a8969d
-      # https://review.openstack.org/460363
-      pip: name=git+https://github.com/ceph/python-jenkins@patched#egg=python-jenkins
+      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
+      pip: name=python-jenkins version=0.4.7
 
     - name: add github.com host key
       sudo: true

--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -218,8 +218,8 @@
 
     - name: install python-jenkins
       sudo: true
-      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
-      pip: name=python-jenkins version=0.4.7
+      # https://review.openstack.org/460363
+      pip: name=python-jenkins version=0.4.15
 
     - name: add github.com host key
       sudo: true

--- a/ansible/examples/slave_libvirt.yml
+++ b/ansible/examples/slave_libvirt.yml
@@ -188,10 +188,8 @@
 
     - name: install python-jenkins
       sudo: true
-      # HORRIBLY BROKEN. This is temporary until this lands upstream:
-      # https://github.com/ceph/python-jenkins/commit/8e018bf7d88dfc308833d195a6ebd29231a8969d
-      # https://review.openstack.org/460363
-      pip: name=git+https://github.com/ceph/python-jenkins@patched#egg=python-jenkins
+      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
+      pip: name=python-jenkins version=0.4.7
 
     - name: add github.com host key
       sudo: true

--- a/ansible/examples/slave_libvirt.yml
+++ b/ansible/examples/slave_libvirt.yml
@@ -188,8 +188,8 @@
 
     - name: install python-jenkins
       sudo: true
-      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
-      pip: name=python-jenkins version=0.4.7
+      # https://review.openstack.org/460363
+      pip: name=python-jenkins version=0.4.15
 
     - name: add github.com host key
       sudo: true

--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -243,8 +243,8 @@
 
     - name: install python-jenkins
       sudo: true
-      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
-      pip: name=python-jenkins version=0.4.7
+      # https://review.openstack.org/460363
+      pip: name=python-jenkins version=0.4.15
 
     - name: add github.com host key
       sudo: true

--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -243,10 +243,8 @@
 
     - name: install python-jenkins
       sudo: true
-      # HORRIBLY BROKEN. This is temporary until this lands upstream:
-      # https://github.com/ceph/python-jenkins/commit/8e018bf7d88dfc308833d195a6ebd29231a8969d
-      # https://review.openstack.org/460363
-      pip: name=git+https://github.com/ceph/python-jenkins@patched#egg=python-jenkins
+      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
+      pip: name=python-jenkins version=0.4.7
 
     - name: add github.com host key
       sudo: true

--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -218,10 +218,8 @@
 
     - name: install python-jenkins
       sudo: true
-      # HORRIBLY BROKEN. This is temporary until this lands upstream:
-      # https://github.com/ceph/python-jenkins/commit/8e018bf7d88dfc308833d195a6ebd29231a8969d
-      # https://review.openstack.org/460363
-      pip: name=git+https://github.com/ceph/python-jenkins@patched#egg=python-jenkins
+      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
+      pip: name=python-jenkins version=0.4.7
 
     - name: add github.com host key
       sudo: true

--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -218,8 +218,8 @@
 
     - name: install python-jenkins
       sudo: true
-      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
-      pip: name=python-jenkins version=0.4.7
+      # https://review.openstack.org/460363
+      pip: name=python-jenkins version=0.4.15
 
     - name: add github.com host key
       sudo: true

--- a/ansible/slave_libvirt.yml
+++ b/ansible/slave_libvirt.yml
@@ -188,10 +188,8 @@
 
     - name: install python-jenkins
       sudo: true
-      # HORRIBLY BROKEN. This is temporary until this lands upstream:
-      # https://github.com/ceph/python-jenkins/commit/8e018bf7d88dfc308833d195a6ebd29231a8969d
-      # https://review.openstack.org/460363
-      pip: name=git+https://github.com/ceph/python-jenkins@patched#egg=python-jenkins
+      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
+      pip: name=python-jenkins version=0.4.7
 
     - name: add github.com host key
       sudo: true

--- a/ansible/slave_libvirt.yml
+++ b/ansible/slave_libvirt.yml
@@ -188,8 +188,8 @@
 
     - name: install python-jenkins
       sudo: true
-      # https://bugs.launchpad.net/python-jenkins/+bug/1500898
-      pip: name=python-jenkins version=0.4.7
+      # https://review.openstack.org/460363
+      pip: name=python-jenkins version=0.4.15
 
     - name: add github.com host key
       sudo: true


### PR DESCRIPTION
This PR reverts https://github.com/ceph/ceph-build/pull/693 and bumps our pinned version to 0.4.15. This upstream version has support for creating nodes with "+" in the names.

I don't feel great about continuing to pin to an exact version, but let's take the short-term defensive route for now.