### PR TITLE
Shaman apt fix

### DIFF
--- a/shaman-pull-requests/setup/playbooks/tasks/postgresql.yml
+++ b/shaman-pull-requests/setup/playbooks/tasks/postgresql.yml
@@ -2,7 +2,7 @@
 - name: update apt cache
   apt:
     update_cache: yes
-  sudo: yes
+  become: yes
 
 - name: install postgresql requirements
   sudo: yes
@@ -23,7 +23,7 @@
     name: postgresql
     state: started
     enabled: yes
-  sudo: yes
+  become: yes
 
 - name: allow users to connect locally
   sudo: yes
@@ -48,4 +48,4 @@
 - service:
     name: postgresql
     state: restarted
-  sudo: true
+  become: yes

--- a/shaman-pull-requests/setup/playbooks/tasks/postgresql.yml
+++ b/shaman-pull-requests/setup/playbooks/tasks/postgresql.yml
@@ -13,7 +13,7 @@
     - postgresql
     - postgresql-common
     - postgresql-contrib
-    - postgresql-server-dev-9.3
+    - postgresql-server-dev-9.5
     - python-psycopg2
   tags:
     - packages
@@ -30,7 +30,7 @@
   lineinfile:
      # TODO: should not hardcode that version
      # 9.3 is available on trusty, 9.5 on Xenial
-     dest: /etc/postgresql/9.3/main/pg_hba.conf
+     dest: /etc/postgresql/9.5/main/pg_hba.conf
      regexp: '^host\s+all\s+all\s+127.0.0.1/32'
      line: 'host    all             all             127.0.0.1/32            trust'
      backrefs: yes


### PR DESCRIPTION
the real "apt fix" was to remove all the garbage left behind in a server in /etc/apt/sources.list.d/ which included a shaman.list

    $ ls /etc/apt/sources.list.d
    ppa_fkrull_deadsnakes_xenial.list  ppa_fkrull_deadsnakes_xenial.list.save  saltstack-ubuntu-salt-xenial.list shaman.list

The rest is just to overcome 9.5 in xenial. This still fails horribly on the shaman side with unittests