### PR TITLE
ceph-ansible-scenario: adds the CEPH_DEV_BRANCH and CEPH_DEV_SHA1 params

### DIFF
--- a/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
+++ b/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
@@ -26,6 +26,14 @@
           name: BRANCH
           description: "The ceph-ansible branch to test against"
           default: "master"
+      - string:
+          name: CEPH_DEV_BRANCH
+          description: "The ceph dev branch to test against if using a dev-* scenario"
+          default: "master"
+      - string:
+          name: CEPH_DEV_SHA1
+          description: "The ceph sha1 to test against if using a dev-* scenario"
+          default: "latest"
 
     scm:
       - git:


### PR DESCRIPTION
With these parameters, if you are using a dev-* testing scenario, you can
control which ceph branch and sha1 is deployed and tested.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>