### PR TITLE
ceph-ansible-prs: Change group for jenkins_user

### DIFF
--- a/ansible/examples/slave_libvirt_static.yml
+++ b/ansible/examples/slave_libvirt_static.yml
@@ -75,10 +75,18 @@
         - default-jdk
         - default-jre
 
+    - set_fact:
+        jenkins_group: 'libvirtd'
+      when: ansible_distribution_version == '16.04'
+
+    - set_fact:
+        jenkins_group: 'libvirt'
+      when: ansible_distribution_version == '16.10'
+
     - name: "create a {{ jenkins_user }} user"
       user:
         name: "{{ jenkins_user }}"
-        groups: libvirtd
+        groups: "{{ jenkins_group }}"
         append: yes
         comment: "Jenkins Build Slave User"
 

--- a/ansible/slave_libvirt.yml
+++ b/ansible/slave_libvirt.yml
@@ -48,10 +48,18 @@
         - vagrant
       when: ansible_pkg_mgr  == "apt"
 
+    - set_fact:
+        jenkins_group: 'libvirtd'
+      when: ansible_distribution_version == '16.04'
+
+    - set_fact:
+        jenkins_group: 'libvirt'
+      when: ansible_distribution_version == '16.10'
+
     - name: create a {{ jenkins_user }} user
       user:
         name: "{{ jenkins_user }}"
-        groups: libvirtd
+        groups: "{{ jenkins_group }}"
         append: yes
         comment: "Jenkins Build Slave User"
 


### PR DESCRIPTION
Required to switch to Ubuntu 16.10.
The group `libvirtd` have been renamed to `libvirt`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>