### PR TITLE
Abort builds on update

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -71,6 +71,7 @@
 
     triggers:
       - github-pull-request:
+          cancel-builds-on-update: true
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph

--- a/ceph-docker-prs/config/definitions/ceph-docker-prs.yml
+++ b/ceph-docker-prs/config/definitions/ceph-docker-prs.yml
@@ -40,6 +40,7 @@
 
     triggers:
       - github-pull-request:
+          cancel-builds-on-update: true
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph


### PR DESCRIPTION
When a PR is updated, jobs that were launched by the previous PR are not
aborted. It can even happen that you update a PR several times in a
short time. So it's n*x jenkins slave locked until they end.

Adding `cancel-builds-on-update` to the jobs templates force the job to be
aborted to free a jenkins slave quicker.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>