### PR TITLE
Ceph volume fixes for PRs

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -3,12 +3,23 @@ set -ex
 env
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
+# This job is meant to be triggered from a Github Pull Request, only when the
+# job is executed in that way a few "special" variables become available. So
+# this build script tries to use those first but then it will try to figure it
+# out using Git directly so that if triggered manually it can attempt to
+# actually work.
+SHA=$ghprbActualCommit
+BRANCH=$ghprbSourceBranch
+
+
 # Find out the name of the remote branch from the Pull Request. This is otherwise not
 # available by the plugin. Without grepping for `heads` output will look like:
 #
 # 855ce630695ed9ca53c314b7e261ec3cc499787d    refs/heads/wip-volume-tests
-BRANCH=`git ls-remote origin | grep $GIT_PREVIOUS_COMMIT | grep heads | cut -d '/' -f 3`
-SHA=$GIT_PREVIOUS_COMMIT
+if [ -z "$ghprbSourceBranch" ]; then
+    BRANCH=`git ls-remote origin | grep $GIT_PREVIOUS_COMMIT | grep heads | cut -d '/' -f 3`
+    SHA=$GIT_PREVIOUS_COMMIT
+fi
 
 # sometimes, $GIT_PREVIOUS_COMMIT will not help grep from ls-remote, so we fallback
 # to looking for GIT_COMMIT (e.g. if the branch has not been rebased to be the tip)
@@ -17,15 +28,21 @@ if [ -z "$BRANCH" ]; then
     SHA=$GIT_COMMIT
 fi
 
-echo $BRANCH
-echo $SHA
+# Finally, we verify one last time to bail if nothing really worked here to determine
+# this
+if [ -z "$BRANCH" ]; then
+    echo "Could not determine \$BRANCH var from \$ghprbSourceBranch"
+    echo "or by using \$GIT_PREVIOUS_COMMIT and \$GIT_COMMIT"
+    exit 1
+fi
 
+
+# TODO: at this point a `curl` to shaman is needed to verify that the repo is
+# ready to be consumed
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
 install_python_packages "pkgs[@]"
-
-
 
 cd src/ceph-volume/ceph_volume/tests/functional
 

--- a/ceph-volume-pr/build/build
+++ b/ceph-volume-pr/build/build
@@ -5,4 +5,8 @@ set -ex
 pkgs=( "tox" )
 install_python_packages "pkgs[@]"
 
-cd src/ceph-volume && $VENV/tox -rv
+cd src/ceph-volume
+
+# ceph-volume has a 3.6 environ but most machines don't have it,
+# so until then, we do them piecemeal
+$VENV/tox -v -e py27,py35,flake8

--- a/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-volume-pr
     display-name: 'ceph-volume: Pull Request tox tests'
-    node: x86_64
+    node: python3
     project-type: freestyle
     defaults: global
     quiet-period: 5
@@ -16,9 +16,7 @@
 
     triggers:
       - github-pull-request:
-          allow-whitelist-orgs-as-admins: true
-          org-list:
-            - ceph
+          cancel-builds-on-update: true
           only-trigger-phrase: true
           trigger-phrase: 'jenkins test ceph-volume tox'
           github-hooks: true
@@ -28,6 +26,17 @@
           started-status: "ceph-volume tox running"
           success-status: "ceph-volume tox OK"
           failure-status: "ceph-volume tox failed"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph
+          browser: auto
+          branches:
+            - ${sha1}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          skip-tag: true
+          timeout: 20
+          wipe-workspace: true
 
     builders:
       - shell:


### PR DESCRIPTION
It now requires a python3 node to be able to run py35 tests. Had to omit Python 3.6 tests for now as that is not available in build nodes (yet).

Fixes the `scm` section to correctly narrow down the scope to the PR only (before it would just build any PR or any merge even)