### PR TITLE
ceph-ansible-scenario: wipe the workspace before each job

### DIFF
--- a/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
+++ b/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
@@ -44,7 +44,7 @@
           browser: auto
           timeout: 20
           skip-tag: true
-          wipe-workspace: false
+          wipe-workspace: true
 
     builders:
       - shell:


### PR DESCRIPTION
In testing I noticed that without this set sometimes the latest sha1 from the
ceph-ansible branch wasn't fetched if the jenkins slave had already been
used for this job.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>