### PR TITLE
Abort on updated pr

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -106,6 +106,11 @@
             - ../../build/build
 
     publishers:
+      - raw:
+          xml: |
+            <org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
+              <overrideGlobal>false</overrideGlobal>
+            </org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
       - postbuildscript:
           script-only-if-succeeded: False
           script-only-if-failed: True
@@ -173,6 +178,11 @@
             - ../../build/build
 
     publishers:
+      - raw:
+          xml: |
+            <org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
+              <overrideGlobal>false</overrideGlobal>
+            </org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
       - postbuildscript:
           script-only-if-succeeded: False
           script-only-if-failed: True

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -71,7 +71,6 @@
 
     triggers:
       - github-pull-request:
-          cancel-builds-on-update: true
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph

--- a/ceph-docker-prs/config/definitions/ceph-docker-prs.yml
+++ b/ceph-docker-prs/config/definitions/ceph-docker-prs.yml
@@ -40,7 +40,6 @@
 
     triggers:
       - github-pull-request:
-          cancel-builds-on-update: true
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph

--- a/ceph-docker-prs/config/definitions/ceph-docker-prs.yml
+++ b/ceph-docker-prs/config/definitions/ceph-docker-prs.yml
@@ -74,6 +74,11 @@
             - ../../build/build
 
     publishers:
+      - raw:
+          xml: |
+            <org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
+              <overrideGlobal>false</overrideGlobal>
+            </org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
       - postbuildscript:
           script-only-if-succeeded: False
           script-only-if-failed: True


### PR DESCRIPTION
    Add CancelOnUpdate option in raw/xml format

    The option `cancel-builds-on-update` doesn't work in job template
    because we are not using a recent version of JJB, therefore we had to
    revert the previous commit.

    This commit adds the cancel-builds-on-update option but in raw/xml
    format instead.

    Fixes: #817

    Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>