### PR TITLE
Abort build on updated PR

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -71,6 +71,7 @@
 
     triggers:
       - github-pull-request:
+          cancel-builds-on-update: true
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
@@ -106,11 +107,6 @@
             - ../../build/build
 
     publishers:
-      - raw:
-          xml: |
-            <org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
-              <overrideGlobal>false</overrideGlobal>
-            </org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
       - postbuildscript:
           script-only-if-succeeded: False
           script-only-if-failed: True
@@ -143,6 +139,7 @@
 
     triggers:
       - github-pull-request:
+          cancel-builds-on-update: true
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
@@ -178,11 +175,6 @@
             - ../../build/build
 
     publishers:
-      - raw:
-          xml: |
-            <org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
-              <overrideGlobal>false</overrideGlobal>
-            </org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
       - postbuildscript:
           script-only-if-succeeded: False
           script-only-if-failed: True

--- a/ceph-docker-prs/config/definitions/ceph-docker-prs.yml
+++ b/ceph-docker-prs/config/definitions/ceph-docker-prs.yml
@@ -40,6 +40,7 @@
 
     triggers:
       - github-pull-request:
+          cancel-builds-on-update: true
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
@@ -74,11 +75,6 @@
             - ../../build/build
 
     publishers:
-      - raw:
-          xml: |
-            <org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
-              <overrideGlobal>false</overrideGlobal>
-            </org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
       - postbuildscript:
           script-only-if-succeeded: False
           script-only-if-failed: True

--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -9,7 +9,7 @@
 set -ex
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "jenkins-job-builder" )
+pkgs=( "jenkins-job-builder==2.0.0.0b2" )
 install_python_packages "pkgs[@]"
 
 # Wipe out JJB's cache if $FORCE is set.


### PR DESCRIPTION
Basically just puts https://github.com/ceph/ceph-build/commit/18a1bbc24552ca0466500b6121818292e645f41b back into place.  JJB>=2.0.0 is needed as well for this to work.