### PR TITLE
Move ceph-ansible and ceph-docker builds to 2.jenkins.ceph.com

### DIFF
--- a/ceph-ansible-docs-prs/config/JENKINS_URL
+++ b/ceph-ansible-docs-prs/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-ansible-docs/config/JENKINS_URL
+++ b/ceph-ansible-docs/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-ansible-galaxy/config/JENKINS_URL
+++ b/ceph-ansible-galaxy/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-ansible-nightly/config/JENKINS_URL
+++ b/ceph-ansible-nightly/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-ansible-pr-syntax-check/config/JENKINS_URL
+++ b/ceph-ansible-pr-syntax-check/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-ansible-prs/config/JENKINS_URL
+++ b/ceph-ansible-prs/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-ansible-rpm/config/JENKINS_URL
+++ b/ceph-ansible-rpm/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-ansible-scenario/config/JENKINS_URL
+++ b/ceph-ansible-scenario/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-docker-flake8/config/JENKINS_URL
+++ b/ceph-docker-flake8/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-docker-lint/config/JENKINS_URL
+++ b/ceph-docker-lint/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-docker-nightly/config/JENKINS_URL
+++ b/ceph-docker-nightly/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-docker-prs/config/JENKINS_URL
+++ b/ceph-docker-prs/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -15,9 +15,10 @@ install_python_packages "pkgs[@]"
 # Wipe out JJB's cache if $FORCE is set.
 [ "$FORCE" = true ] && rm -rf "$HOME/.cache/jenkins_jobs/"
 
-# workaround for https://issues.jenkins-ci.org/browse/JENKINS-16225
-JENKINS_URL=${JENKINS_URL:-"https://jenkins.ceph.com/"}
-JJB_CONFIG="$HOME/.jenkins_jobs.ini"
+# Each jenkins master will write its own config file when the
+# jenkins-job-builder gets run
+JENKINS_FQDN=$(echo $JENKINS_URL | awk -F/ '{print $3}')
+JJB_CONFIG="$HOME/.jenkins_jobs.$JENKINS_FQDN.ini"
 
 # slap the programatically computed JJB config using env vars from Jenkins
 cat > $JJB_CONFIG << EOF
@@ -34,12 +35,26 @@ for dir in `find . -maxdepth 1 -path ./.git -prune -o -type d -print`; do
     if [ -d "$definitions_dir" ]; then
         echo "found definitions directory: $definitions_dir"
 
-        # Test the definitions first
-        $VENV/jenkins-jobs --log_level DEBUG --conf $JJB_CONFIG test $definitions_dir -o /tmp/output
+        # Set with JJB config file we should use based on if an override
+        # file is present in the job's config dir
+        if [ -f "$dir/config/JENKINS_URL" ]; then
+            JENKINS_URL_OVERRIDE=$(cat $dir/config/JENKINS_URL)
+            echo "found JENKINS_URL override file.  using $JENKINS_URL_OVERRIDE"
+            JJB_CONFIG="$HOME/.jenkins_jobs.$JENKINS_URL_OVERRIDE.ini"
+        else
+            JJB_CONFIG="$HOME/.jenkins_jobs.jenkins.ceph.com.ini"
+        fi
 
-        # Update Jenkins with the output if they passed the test phase
-        # Note that this needs proper permissions with the right credentials to the
-        # correct Jenkins instance.
-        $VENV/jenkins-jobs --log_level DEBUG --conf $JJB_CONFIG update $definitions_dir
+        # Each jenkins-job-builder job should only update the master
+        # that started it.  This prevents collisions.
+        if [[ "$JJB_CONFIG" == "$HOME/.jenkins_jobs.$JENKINS_FQDN.ini" ]]; then
+            # Test the definitions first
+            $VENV/jenkins-jobs --log_level DEBUG --conf $JJB_CONFIG test $definitions_dir -o /tmp/output
+
+            # Update Jenkins with the output if they passed the test phase
+            # Note that this needs proper permissions with the right credentials to the
+            # correct Jenkins instance.
+            $VENV/jenkins-jobs --log_level DEBUG --conf $JJB_CONFIG update $definitions_dir
+        fi
     fi
 done

--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -47,6 +47,6 @@ If this is checked, JJB will wipe out its cache and force each job to align with
     publishers:
       - postbuildscript:
           builders:
-            - shell: 'rm $HOME/.jenkins_jobs.ini'
+            - shell: 'rm $HOME/.jenkins_jobs.*.ini'
         script-only-if-succeeded: false
         script-only-if-failed: false


### PR DESCRIPTION
Once this is merged and JJB gets run, 2.jenkins.ceph.com will then be the source of truth for ceph-ansible and ceph-docker builds.

Signed-off-by: David Galloway <dgallowa@redhat.com>