### PR TITLE
ceph-ansible-prs: test against ansible2.3 and luminous only

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -15,7 +15,7 @@ restart_libvirt_services
 
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment
-if ! timeout 3h $VENV/tox -rv -e=$RELEASE-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
+if ! timeout 3h $VENV/tox -rv -e=$RELEASE-$ANSIBLE_VERSION-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
   echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
   exit 1
 fi

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,56 +1,40 @@
 - project:
     name: ceph-ansible-prs
-    release_before_luminous:
-      - jewel
-    release_after_luminous:
+    release:
       - luminous
-    scenario_before_luminous:
-      - ansible2.2-centos7_cluster
-      - ansible2.2-xenial_cluster
-      - ansible2.2-journal_collocation
-      - ansible2.2-dmcrypt_journal
-      - ansible2.2-dmcrypt_journal_collocation
-      - ansible2.2-docker_cluster
-      - ansible2.2-docker_dedicated_journal
-      - ansible2.2-docker_dmcrypt_journal_collocation
-      - ansible2.2-purge_cluster
-      - ansible2.2-purge_dmcrypt
-      - ansible2.2-update_dmcrypt
-      - ansible2.2-update_cluster
-      - ansible2.2-purge_docker_cluster
-      - ansible2.2-update_docker_cluster
-    scenario_after_luminous:
-      - ansible2.2-centos7_cluster
-      - ansible2.2-xenial_cluster
-      - ansible2.2-journal_collocation
-      - ansible2.2-dmcrypt_journal
-      - ansible2.2-dmcrypt_journal_collocation
-      - ansible2.2-docker_cluster
-      - ansible2.2-docker_dedicated_journal
-      - ansible2.2-docker_dmcrypt_journal_collocation
-      - ansible2.2-purge_cluster
-      - ansible2.2-purge_dmcrypt
-      - ansible2.2-update_dmcrypt
-      - ansible2.2-update_cluster
-      - ansible2.2-purge_docker_cluster
-      - ansible2.2-update_docker_cluster
-      - ansible2.2-bluestore_cluster
-      - ansible2.2-bluestore_journal_collocation
-      - ansible2.2-bluestore_dmcrypt_journal
-      - ansible2.2-bluestore_dmcrypt_journal_collocation
-      - ansible2.2-bluestore_docker_cluster
-      - ansible2.2-bluestore_docker_dedicated_journal
-      - ansible2.2-bluestore_docker_dmcrypt_journal_collocation
+    ansible_version:
+      - ansible2.3
+    scenario:
+      - centos7_cluster
+      - xenial_cluster
+      - journal_collocation
+      - dmcrypt_journal
+      - dmcrypt_journal_collocation
+      - docker_cluster
+      - docker_dedicated_journal
+      - docker_dmcrypt_journal_collocation
+      - purge_cluster
+      - purge_dmcrypt
+      - update_dmcrypt
+      - update_cluster
+      - purge_docker_cluster
+      - update_docker_cluster
+      - bluestore_cluster
+      - bluestore_journal_collocation
+      - bluestore_dmcrypt_journal
+      - bluestore_dmcrypt_journal_collocation
+      - bluestore_docker_cluster
+      - bluestore_docker_dedicated_journal
+      - bluestore_docker_dmcrypt_journal_collocation
     jobs:
-        - 'ceph-ansible-prs-{release_before_luminous}-{scenario_before_luminous}'
-        - 'ceph-ansible-prs-{release_after_luminous}-{scenario_after_luminous}'
+        - 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
 
 - job-template:
-    name: 'ceph-ansible-prs-{release_before_luminous}-{scenario_before_luminous}'
+    name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
     node: vagrant&&libvirt
     concurrent: true
     defaults: global
-    display-name: 'ceph-ansible: Pull Requests [{release_before_luminous}-{scenario_before_luminous}]'
+    display-name: 'ceph-ansible: Pull Requests [{release}-{ansible_version}-{scenario}]'
     quiet-period: 5
     block-downstream: false
     block-upstream: false
@@ -75,15 +59,15 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          trigger-phrase: 'jenkins test {release_before_luminous}-{scenario_before_luminous}'
+          trigger-phrase: 'jenkins test {release}-{ansible_version}-{scenario}'
           only-trigger-phrase: false
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false
-          status-context: "Testing: {release_before_luminous}-{scenario_before_luminous}"
-          started-status: "Running: {release_before_luminous}-{scenario_before_luminous}"
-          success-status: "OK - {release_before_luminous}-{scenario_before_luminous}"
-          failure-status: "FAIL - {release_before_luminous}-{scenario_before_luminous}"
+          status-context: "Testing: {release}-{ansible_version}-{scenario}"
+          started-status: "Running: {release}-{ansible_version}-{scenario}"
+          success-status: "OK - {release}-{ansible_version}-{scenario}"
+          failure-status: "FAIL - {release}-{ansible_version}-{scenario}"
 
     scm:
       - git:
@@ -99,76 +83,9 @@
     builders:
       - inject:
           properties-content: |
-            SCENARIO={scenario_before_luminous}
-            RELEASE={release_before_luminous}
-      - shell:
-          !include-raw-escape:
-            - ../../../scripts/build_utils.sh
-            - ../../build/build
-
-    publishers:
-      - postbuildscript:
-          script-only-if-succeeded: False
-          script-only-if-failed: True
-          builders:
-            - shell: !include-raw ../../build/teardown
-
-- job-template:
-    name: 'ceph-ansible-prs-{release_after_luminous}-{scenario_after_luminous}'
-    node: vagrant&&libvirt
-    concurrent: true
-    defaults: global
-    display-name: 'ceph-ansible: Pull Requests [{release_after_luminous}-{scenario_after_luminous}]'
-    quiet-period: 5
-    block-downstream: false
-    block-upstream: false
-    retry-count: 3
-    properties:
-      - github:
-          url: https://github.com/ceph/ceph-ansible
-    logrotate:
-      daysToKeep: 15
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
-
-    parameters:
-      - string:
-          name: sha1
-          description: "A pull request ID, like 'origin/pr/72/head'"
-
-    triggers:
-      - github-pull-request:
-          cancel-builds-on-update: true
-          allow-whitelist-orgs-as-admins: true
-          org-list:
-            - ceph
-          trigger-phrase: 'jenkins test {release_after_luminous}-{scenario_after_luminous}'
-          only-trigger-phrase: false
-          github-hooks: true
-          permit-all: true
-          auto-close-on-fail: false
-          status-context: "Testing: {release_after_luminous}-{scenario_after_luminous}"
-          started-status: "Running: {release_after_luminous}-{scenario_after_luminous}"
-          success-status: "OK - {release_after_luminous}-{scenario_after_luminous}"
-          failure-status: "FAIL - {release_after_luminous}-{scenario_after_luminous}"
-
-    scm:
-      - git:
-          url: https://github.com/ceph/ceph-ansible.git
-          branches:
-            - ${{sha1}}
-          refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: auto
-          timeout: 20
-          skip-tag: true
-          wipe-workspace: false
-
-    builders:
-      - inject:
-          properties-content: |
-            SCENARIO={scenario_after_luminous}
-            RELEASE={release_after_luminous}
+            SCENARIO={scenario}
+            RELEASE={release}
+            ANSIBLE_VERSION={ansible_version}
       - shell:
           !include-raw-escape:
             - ../../../scripts/build_utils.sh


### PR DESCRIPTION
This drops support for testing jewel on PRs and changes the ansible
version to 2.3. If we want to continue testing against jewel we can
schedule nightly tests that run against master. With this approach we
can still get the same coverage and reduce a lot of demand on the CI
caused by PR testing.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>