### PR TITLE
ceph-ansible-nightly: run tests against jewel and ansible2.2 and 2.3

### DIFF
--- a/ceph-ansible-nightly/build/build
+++ b/ceph-ansible-nightly/build/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "tox" )
+install_python_packages "pkgs[@]"
+
+# XXX this might not be needed
+source $VENV/activate
+
+WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
+
+delete_libvirt_vms
+clear_libvirt_networks
+restart_libvirt_services
+
+# the $SCENARIO var is injected by the job template. It maps
+# to an actual, defined, tox environment
+if ! timeout 3h $VENV/tox -rv -e=$RELEASE-$ANSIBLE_VERSION-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
+  echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
+  exit 1
+fi

--- a/ceph-ansible-nightly/build/teardown
+++ b/ceph-ansible-nightly/build/teardown
@@ -1,0 +1,20 @@
+#!/bin/bash
+# There has to be a better way to do this than this script which just looks
+# for every Vagrantfile in scenarios and then just destroys whatever is left.
+
+cd $WORKSPACE/tests
+
+scenarios=$(find . | grep Vagrantfile | xargs dirname)
+
+for scenario in $scenarios; do
+    cd $scenario
+    vagrant destroy -f
+    cd -
+done
+
+# Sometimes, networks may linger around, so we must ensure they are killed:
+networks=`sudo virsh net-list --all | grep active | egrep -v "(default|libvirt)" | cut -d ' ' -f 2`
+for network in $networks; do
+    sudo virsh net-destroy $network || true
+    sudo virsh net-undefine $network || true
+done

--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -1,0 +1,80 @@
+- project:
+    name: ceph-ansible-nightly
+    release:
+      - jewel 
+    ansible_version:
+      - ansible2.3
+      - ansible2.2
+    scenario:
+      - centos7_cluster
+      - xenial_cluster
+      - journal_collocation
+      - dmcrypt_journal
+      - dmcrypt_journal_collocation
+      - docker_cluster
+      - docker_dedicated_journal
+      - docker_dmcrypt_journal_collocation
+      - purge_cluster
+      - purge_dmcrypt
+      - update_dmcrypt
+      - update_cluster
+      - purge_docker_cluster
+      - update_docker_cluster
+    jobs:
+        - 'ceph-ansible-nightly-{release}-{ansible_version}-{scenario}'
+
+- job-template:
+    name: 'ceph-ansible-nightly-{release}-{ansible_version}-{scenario}'
+    node: vagrant&&libvirt
+    concurrent: true
+    defaults: global
+    display-name: 'ceph-ansible: Nightly [{release}-{ansible_version}-{scenario}]'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-ansible
+    logrotate:
+      daysToKeep: 15
+      numToKeep: -1
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    parameters:
+      - string:
+          name: CEPH_ANSIBLE_BRANCH
+          description: "The ceph-ansible branch (or tag) to test"
+          default: master
+
+    triggers:
+      - timed: '@daily'
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-ansible.git
+          branches:
+            - $CEPH_ANSIBLE_BRANCH
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+
+    builders:
+      - inject:
+          properties-content: |
+            SCENARIO={scenario}
+            RELEASE={release}
+            ANSIBLE_VERSION={ansible_version}
+      - shell:
+          !include-raw-escape:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+
+    publishers:
+      - postbuildscript:
+          script-only-if-succeeded: False
+          script-only-if-failed: True
+          builders:
+            - shell: !include-raw ../../build/teardown


### PR DESCRIPTION
These tests are scheduled to be run automatically by jenkins daily. They can
also be triggered manually and given a branch of ceph-ansible to test
against.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>