### PR TITLE
ceph-pr-docs: include the pull request ID for the url as a comment

### DIFF
--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -30,6 +30,7 @@
           started-status: "Docs: building"
           success-status: "OK - docs built"
           failure-status: "Docs: failed with errors"
+          success-comment: "Doc build available at http://docs.ceph.com/ceph-prs/${ghprbPullId}/"
 
     scm:
       - git:


### PR DESCRIPTION
This is so that it is easier for everyone to refer to the actual URL used for the PR docs build. Otherwise it would be tricky to find out (or remember!) where the build is to look at it