### PR TITLE
Enforce ceph doc checks on all Ceph prs

### DIFF
--- a/ceph-pr-docs/build/build
+++ b/ceph-pr-docs/build/build
@@ -2,30 +2,12 @@
 
 set -ex
 
-# This job is meant to be triggered from a Github Pull Request, only when the
-# job is executed in that way a few "special" variables become available. So
-# this build script tries to use those first but then it will try to figure it
-# out using Git directly so that if triggered manually it can attempt to
-# actually work.
-PR_ID=$ghprbPullId
+# make sure any shaman list file is removed. At some point if all nodes
+# are clean this will not be needed.
+sudo rm -f /etc/apt/sources.list.d/shaman*
 
-# fallback to just using 'manual' if that ID is not available, for manually
-# triggered builds
-if [ -z "$ghprbPullId" ]; then
-    PR_ID="manual"
-fi
-
+# Ceph doc build deps, Ubuntu only because ditaa is not packaged for CentOS
+sudo apt-get update
+sudo apt-get install -y gcc python-dev python-pip python-virtualenv libxml2-dev libxslt-dev doxygen graphviz ant ditaa python-sphinx
 
 ./admin/build-doc
-
-# publish docs to http://docs.ceph.com/ceph-prs/$PR_ID/
-mkdir -p "/var/ceph-prs/$PR_ID"
-rsync -auv --delete build-doc/output/html/* "/var/ceph-prs/$PR_ID/"
-
-set +e
-set +x
-echo
-echo "Docs available to preview at:"
-echo
-echo "    http://docs.ceph.com/ceph-prs/$PR_ID/"
-echo

--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-pr-docs
     display-name: 'ceph: Pull Requests Docs Check'
-    node: docs
+    node: trusty && x86_64
     project-type: freestyle
     defaults: global
     quiet-period: 5
@@ -20,9 +20,8 @@
           org-list:
             - ceph
           cancel-builds-on-update: true
-          # this job is only triggered by explicitly asking for it
-          only-trigger-phrase: true
-          trigger-phrase: 'jenkins test docs'
+          only-trigger-phrase: false
+          trigger-phrase: 'jenkins test docs.*'
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false
@@ -30,7 +29,6 @@
           started-status: "Docs: building"
           success-status: "OK - docs built"
           failure-status: "Docs: failed with errors"
-          success-comment: "Doc build available at http://docs.ceph.com/ceph-prs/${ghprbPullId}/"
 
     scm:
       - git:

--- a/ceph-pr-render-docs/build/build
+++ b/ceph-pr-render-docs/build/build
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+# This job is meant to be triggered from a Github Pull Request, only when the
+# job is executed in that way a few "special" variables become available. So
+# this build script tries to use those first but then it will try to figure it
+# out using Git directly so that if triggered manually it can attempt to
+# actually work.
+PR_ID=$ghprbPullId
+
+# fallback to just using 'manual' if that ID is not available, for manually
+# triggered builds
+if [ -z "$ghprbPullId" ]; then
+    PR_ID="manual"
+fi
+
+
+./admin/build-doc
+
+# publish docs to http://docs.ceph.com/ceph-prs/$PR_ID/
+mkdir -p "/var/ceph-prs/$PR_ID"
+rsync -auv --delete build-doc/output/html/* "/var/ceph-prs/$PR_ID/"
+
+set +e
+set +x
+echo
+echo "Docs available to preview at:"
+echo
+echo "    http://docs.ceph.com/ceph-prs/$PR_ID/"
+echo

--- a/ceph-pr-render-docs/config/definitions/ceph-pr-render-docs.yml
+++ b/ceph-pr-render-docs/config/definitions/ceph-pr-render-docs.yml
@@ -1,0 +1,48 @@
+- job:
+    name: ceph-pr-render-docs
+    display-name: 'ceph: Pull Requests Render Docs'
+    node: docs
+    project-type: freestyle
+    defaults: global
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph
+    discard-old-builds: true
+    logrotate:
+      daysToKeep: 14
+
+    triggers:
+      - github-pull-request:
+          allow-whitelist-orgs-as-admins: true
+          org-list:
+            - ceph
+          cancel-builds-on-update: true
+          # this job is only triggered by explicitly asking for it
+          only-trigger-phrase: true
+          trigger-phrase: 'jenkins render docs.*'
+          github-hooks: true
+          permit-all: true
+          auto-close-on-fail: false
+          status-context: "Docs: render build"
+          started-status: "Docs: building to render"
+          success-status: "OK - docs rendered"
+          failure-status: "Docs: render failed with errors"
+          success-comment: "Doc render available at http://docs.ceph.com/ceph-prs/${ghprbPullId}/"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph
+          browser: auto
+          branches:
+            - ${sha1}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          skip-tag: true
+          timeout: 20
+          wipe-workspace: true
+
+    builders:
+      - shell:
+          !include-raw ../../build/build


### PR DESCRIPTION
This PR creates 2 jobs (adapting the previous doc check for Ceph). The *previous* one will now be called "render" so that a reviewer (or proponent of a PR) can trigger on demand and get a representation of the rst->html online

The new one will just build (on Ubuntu nodes) and will not publish anything. This is done this way because not every pull request needs HTML rendered (that uses the docs.ceph.com server) and sometimes is sufficient to know that docs are broken by looking at the build.

Now that Ceph docs builds will refuse to publish because the `-W` (treat warnings as errors) this is going to be useful to know what PR broke docs