### PR TITLE
Build ceph-ansible docs on jenkins.ceph.com

### DIFF
--- a/ceph-ansible-docs/config/JENKINS_URL
+++ b/ceph-ansible-docs/config/JENKINS_URL
@@ -1,1 +1,0 @@
-2.jenkins.ceph.com


### PR DESCRIPTION
Because docs.ceph.com is a slave of jenkins.ceph.com

Signed-off-by: David Galloway <dgallowa@redhat.com>