### PR TITLE
ceph-pr-docs: install cython, remove python-sphinx

### DIFF
--- a/ceph-pr-docs/build/build
+++ b/ceph-pr-docs/build/build
@@ -8,6 +8,6 @@ sudo rm -f /etc/apt/sources.list.d/shaman*
 
 # Ceph doc build deps, Ubuntu only because ditaa is not packaged for CentOS
 sudo apt-get update
-sudo apt-get install -y gcc python-dev python-pip python-virtualenv libxml2-dev libxslt-dev doxygen graphviz ant ditaa python-sphinx
+sudo apt-get install -y gcc python-dev python-pip python-virtualenv libxml2-dev libxslt-dev doxygen graphviz ant ditaa cython
 
 ./admin/build-doc


### PR DESCRIPTION
cython is needed for generating docs from pyx docstrings and
python-sphinx is not needed because it is installed in a virtualenv by
the admin/build-doc script

Signed-off-by: Alfredo Deza <adeza@redhat.com>