### PR TITLE
kernel: do not fetch git tags

### DIFF
--- a/kernel-trigger/config/definitions/kernel-trigger.yml
+++ b/kernel-trigger/config/definitions/kernel-trigger.yml
@@ -26,6 +26,7 @@
             - 'origin/testing*'
             - 'origin/master*'
             - 'origin/for-linus'
+          do-not-fetch-tags: true
           skip-tag: true
           timeout: 20
           wipe-workspace: true

--- a/kernel/config/definitions/kernel.yml
+++ b/kernel/config/definitions/kernel.yml
@@ -86,6 +86,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           url: https://github.com/ceph/ceph-client.git
           branches:
             - $BRANCH
+          do-not-fetch-tags: true
           skip-tag: true
           timeout: 20
           shallow-clone: true


### PR DESCRIPTION
After a recent jenkins/plugins update, jenkins started listing tags and
attempting git rev-parse ^{commit} on them:

  Seen branch in repository origin/wip-tighter-types
  Seen 39 remote branches
  > git tag -l # timeout=10
  > git rev-parse refs/tags/v4.7-rc7^{commit} # timeout=10
  > git rev-parse refs/tags/v2.6.30-rc7^{commit} # timeout=10

On the Linux kernel repo, this eventually fails with:

  > git rev-parse refs/tags/v2.6.11^{commit} # timeout=10
  FATAL: Command "git rev-parse refs/tags/v2.6.11^{commit}" returned status code 128:
  stdout: refs/tags/v2.6.11^{commit}
  stderr: error: refs/tags/v2.6.11^{commit}: expected commit type, but
  the object dereferences to tree type

Only "trigger" jobs seem to be affected, but we don't really need tags,
so don't fetch them for both kernel-trigger and kernel.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>