### PR TITLE
nfs-ganesha-stable: fixes to get build scripts working

### DIFF
--- a/nfs-ganesha-stable/build/build_deb
+++ b/nfs-ganesha-stable/build/build_deb
@@ -34,23 +34,30 @@ sudo dpkg-buildpackage -S -us -uc -d
 
 ## Setup the pbuilder
 setup_pbuilder
+PBUILDDIR="/srv/debian-base"
 
 ## Build with pbuilder
 echo "Building ntirpc debs"
 
-sudo pbuilder --clean
+sudo pbuilder --clean \
+    --distribution $DIST \
+    --basetgz $PBUILDDIR/$DIST.tgz
 
 # add missing packages and components to pbuilder
 sudo pbuilder update \
+    --distribution $DIST \
+    --basetgz $PBUILDDIR/$DIST.tgz \
     --extrapackages "cmake libkrb5-dev libjemalloc-dev debhelper apt-transport-https apt-utils ca-certificates" \
     --components "main restricted universe multiverse" \
     --override-config
 
-echo "Building debs for $DIST"
 sudo pbuilder build \
+    --distribution $DIST \
+    --basetgz $PBUILDDIR/$DIST.tgz \
     --buildresult $WORKSPACE/dist/ntirpc/deb/ \
     $WORKSPACE/libntirpc_${NTIRPC_VERSION}-1${DIST}.dsc
 
+sudo chown -R jenkins-build:jenkins-build $WORKSPACE/dist/ntirpc/deb
 cd $WORKSPACE/dist/ntirpc/deb
 apt-ftparchive packages . > Packages
 
@@ -134,16 +141,19 @@ dch -v "$VERSION-1${DIST}" "$VERSION for Shaman"
 sudo dpkg-buildpackage -S -us -uc -d
 
 ## Build with pbuilder
-echo "Building debs"
+echo "Building nfs-ganesha debs"
 
-PBUILDDIR="/srv/debian-base"
+sudo pbuilder --clean \
+    --distribution $DIST \
+    --basetgz $PBUILDDIR/$DIST.tgz
 
-sudo pbuilder --clean
 
 mkdir -p $WORKSPACE/dist/deb
 
 # add missing packages and components to pbuilder
 sudo pbuilder update \
+    --distribution $DIST \
+    --basetgz $PBUILDDIR/$DIST.tgz \
     --extrapackages "apt-transport-https apt-utils ca-certificates librados-dev libcephfs-dev librgw-dev libntirpc-dev debhelper python-all" \
     --components "main restricted universe multiverse" \
     --othermirror "${SHAMAN_MIRROR}" \

--- a/nfs-ganesha-stable/build/setup
+++ b/nfs-ganesha-stable/build/setup
@@ -27,6 +27,9 @@ git clean -fxd
 cd $WORKSPACE/nfs-ganesha-debian
 git clean -fxd
 
+cd $WORKSPACE/ntirpc
+git clean -fxd
+
 # Make sure the dist directory is clean
 cd $WORKSPACE
 rm -rf dist

--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -19,6 +19,7 @@
           skip-tag: true
           wipe-workspace: true
           basedir: "nfs-ganesha-debian"
+
 - scm:
     name: ntirpc
     scm:
@@ -29,6 +30,7 @@
           skip-tag: true
           wipe-workspace: true
           basedir: "ntirpc"
+
 - job:
     name: nfs-ganesha-stable
     project-type: matrix
@@ -135,6 +137,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
     scm:
       - nfs-ganesha
       - nfs-ganesha-debian
+      - ntirpc
 
     builders:
       - shell: |


### PR DESCRIPTION
-ntirpc scm wasn't applying properly
-clean up ntirpc directory
-various pbuilder related fixes
-directory ownership fix for creating local ntirpc repo

Signed-off-by: Ali Maredia <amaredia@redhat.com>