### PR TITLE
ceph-docker: run flake8 and lint jobs on 2.jenkins

### DIFF
--- a/ceph-docker-flake8/build/build
+++ b/ceph-docker-flake8/build/build
@@ -28,8 +28,8 @@ function check(){
 }
 
 function main() {
-    # install some of our dependencies
-    if [ "${HUDSON_URL}" = "https://jenkins.ceph.com/" ]
+    # install some of our dependencies if running on a jenkins slave
+    if [[ -n "$HUDSON_URL" ]]
     then
         sudo yum -y install epel-release
         sudo yum -y install docker jq

--- a/ceph-docker-lint/build/build
+++ b/ceph-docker-lint/build/build
@@ -32,8 +32,8 @@ function check(){
 }
 
 function main() {
-    # install some of our dependencies
-    if [ "${HUDSON_URL}" = "https://jenkins.ceph.com/" ]
+    # install some of our dependencies if running on a jenkins slave
+    if [[ -n "$HUDSON_URL" ]]
     then
         sudo yum -y install epel-release
         sudo yum -y install docker jq


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>