### PR TITLE
ceph-ansible-prs: adds the dev-ansible2.3-centos7_cluster scenario

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -36,6 +36,17 @@
     jobs:
         - 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
 
+- project:
+    name: ceph-ansible-prs-dev
+    release:
+      - dev
+    ansible_version:
+      - ansible2.3
+    scenario:
+      - centos7_cluster
+    jobs:
+      - 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
+
 - job-template:
     name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
     node: vagrant&&libvirt


### PR DESCRIPTION
This test will install the latest master version of ceph from shaman.ceph.com
to verify that dev installs still work.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>