### PR TITLE
jenkins-job-builder: install a newer jenkins-job-builder

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -3,7 +3,8 @@
 set -e
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "ansible" "jenkins-job-builder" "urllib3" "pyopenssl" "ndg-httpsclient" "pyasn1" )
+# kernel jobs need do-not-fetch-tags option, added in badab0264717
+pkgs=( "ansible" "git+https://github.com/openstack-infra/jenkins-job-builder.git@badab0264717" "urllib3" "pyopenssl" "ndg-httpsclient" "pyasn1" )
 install_python_packages "pkgs[@]"
 
 

--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -9,7 +9,8 @@
 set -ex
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "jenkins-job-builder==2.0.0.0b2" )
+# kernel jobs need do-not-fetch-tags option, added in badab0264717
+pkgs=( "git+https://github.com/openstack-infra/jenkins-job-builder.git@badab0264717" )
 install_python_packages "pkgs[@]"
 
 # Wipe out JJB's cache if $FORCE is set.


### PR DESCRIPTION
kernel-trigger job needs to specify do-not-fetch-tags, otherwise
cloning fails, "No changes" is reported up and nothing gets triggered
(see commit b34f8faa08d4 ("kernel: do not fetch git tags") for more
details).  do-not-fetch-tags was added to jenkins-job-builder in commit
badab0264717 ("Add `do-not-fetch-tags` to CloneOption for Git"), which
isn't in any tag.  The version we get from pypi, 2.0.0.0b2, simply
ignores it, leaving us with no kernel builds.

Let's install from github until a new version is pushed to pypi.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>