### PR TITLE
kernel: use raw xml for configuring scm module

### DIFF
--- a/kernel-trigger/config/definitions/kernel-trigger.yml
+++ b/kernel-trigger/config/definitions/kernel-trigger.yml
@@ -20,16 +20,49 @@
       - github
 
     scm:
-      - git:
-          url: https://github.com/ceph/ceph-client.git
-          branches:
-            - 'origin/testing*'
-            - 'origin/master*'
-            - 'origin/for-linus'
-          do-not-fetch-tags: true
-          skip-tag: true
-          timeout: 20
-          wipe-workspace: true
+    - raw:
+        xml: |
+          <scm class="hudson.plugins.git.GitSCM">
+            <configVersion>2</configVersion>
+            <userRemoteConfigs>
+              <hudson.plugins.git.UserRemoteConfig>
+                <name>origin</name>
+                <refspec>+refs/heads/*:refs/remotes/origin/*</refspec>
+                <url>https://github.com/ceph/ceph-client.git</url>
+              </hudson.plugins.git.UserRemoteConfig>
+            </userRemoteConfigs>
+            <branches>
+              <hudson.plugins.git.BranchSpec>
+                <name>origin/testing*</name>
+              </hudson.plugins.git.BranchSpec>
+              <hudson.plugins.git.BranchSpec>
+                <name>origin/master*</name>
+              </hudson.plugins.git.BranchSpec>
+              <hudson.plugins.git.BranchSpec>
+                <name>origin/for-linus</name>
+              </hudson.plugins.git.BranchSpec>
+            </branches>
+            <disableSubmodules>false</disableSubmodules>
+            <recursiveSubmodules>false</recursiveSubmodules>
+            <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+            <remotePoll>false</remotePoll>
+            <gitTool>Default</gitTool>
+            <submoduleCfg class="list"/>
+            <reference/>
+            <gitConfigName/>
+            <gitConfigEmail/>
+            <extensions>
+              <hudson.plugins.git.extensions.impl.CloneOption>
+                <shallow>false</shallow>
+                <noTags>true</noTags>
+                <timeout>20</timeout>
+              </hudson.plugins.git.extensions.impl.CloneOption>
+              <hudson.plugins.git.extensions.impl.CheckoutOption>
+                <timeout>20</timeout>
+              </hudson.plugins.git.extensions.impl.CheckoutOption>
+              <hudson.plugins.git.extensions.impl.WipeWorkspace/>
+            </extensions>
+          </scm>
 
     builders:
       - trigger-builds:

--- a/kernel/config/definitions/kernel.yml
+++ b/kernel/config/definitions/kernel.yml
@@ -82,15 +82,43 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - ARCHS
 
     scm:
-      - git:
-          url: https://github.com/ceph/ceph-client.git
-          branches:
-            - $BRANCH
-          do-not-fetch-tags: true
-          skip-tag: true
-          timeout: 20
-          shallow-clone: true
-          wipe-workspace: true
+    - raw:
+        xml: |
+          <scm class="hudson.plugins.git.GitSCM">
+            <configVersion>2</configVersion>
+            <userRemoteConfigs>
+              <hudson.plugins.git.UserRemoteConfig>
+                <name>origin</name>
+                <refspec>+refs/heads/*:refs/remotes/origin/*</refspec>
+                <url>https://github.com/ceph/ceph-client.git</url>
+              </hudson.plugins.git.UserRemoteConfig>
+            </userRemoteConfigs>
+            <branches>
+              <hudson.plugins.git.BranchSpec>
+                <name>$BRANCH</name>
+              </hudson.plugins.git.BranchSpec>
+            </branches>
+            <disableSubmodules>false</disableSubmodules>
+            <recursiveSubmodules>false</recursiveSubmodules>
+            <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+            <remotePoll>false</remotePoll>
+            <gitTool>Default</gitTool>
+            <submoduleCfg class="list"/>
+            <reference/>
+            <gitConfigName/>
+            <gitConfigEmail/>
+            <extensions>
+              <hudson.plugins.git.extensions.impl.CloneOption>
+                <shallow>true</shallow>
+                <noTags>true</noTags>
+                <timeout>20</timeout>
+              </hudson.plugins.git.extensions.impl.CloneOption>
+              <hudson.plugins.git.extensions.impl.CheckoutOption>
+                <timeout>20</timeout>
+              </hudson.plugins.git.extensions.impl.CheckoutOption>
+              <hudson.plugins.git.extensions.impl.WipeWorkspace/>
+            </extensions>
+          </scm>
 
     builders:
       - shell: |


### PR DESCRIPTION
kernel-trigger job needs to specify do-not-fetch-tags, otherwise
cloning fails, "No changes" is reported and nothing gets triggered (see
commit b34f8fa ("kernel: do not fetch git tags") for more details).
do-not-fetch-tags was added to jenkins-job-builder in commit
badab0264717 ("Add do-not-fetch-tags to CloneOption for Git"), which
isn't in any tag.  The version we get from pypi, 2.0.0.0b2, simply
ignores it, leaving us with no kernel builds.

Use raw xml generated with jenkins-job-builder's master to get
<noTags>true</noTags> up there after all.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>