### PR TITLE
ceph-ansible-prs: remove bluestore_docker_cluster

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -25,7 +25,6 @@
       - bluestore_journal_collocation
       - bluestore_dmcrypt_journal
       - bluestore_dmcrypt_journal_collocation
-      - bluestore_docker_cluster
       - bluestore_docker_dedicated_journal
       - bluestore_docker_dmcrypt_journal_collocation
       - lvm_osds


### PR DESCRIPTION
We don't need to bootstrap a full cluster to bootstrap bluestore. We
have individual scenarios for that.

Signed-off-by: Sébastien Han <seb@redhat.com>