### PR TITLE
ceph-ansible-prs: only run lvm_osd tests on ceph@master

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -27,8 +27,6 @@
       - bluestore_dmcrypt_journal_collocation
       - bluestore_docker_dedicated_journal
       - bluestore_docker_dmcrypt_journal_collocation
-      - lvm_osds
-      - purge_lvm_osds
       - switch_to_containers
       - shrink_mon
       - shrink_osd
@@ -42,7 +40,8 @@
     ansible_version:
       - ansible2.3
     scenario:
-      - centos7_cluster
+      - lvm_osds
+      - purge_lvm_osds
     jobs:
       - 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
 


### PR DESCRIPTION
These lvm_osd tests won't pass until 12.2.1 is released, but if we have
them use ceph@master then they should pass. After 12.2.1 is out we can
move these back to be a 'luminous' test.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>