### PR TITLE
ceph-ansible-docs: adds the stable-2.2 and stable-3.0 branches

### DIFF
--- a/ceph-ansible-docs/config/definitions/ceph-ansible-docs.yml
+++ b/ceph-ansible-docs/config/definitions/ceph-ansible-docs.yml
@@ -26,9 +26,8 @@
           branches:
             - master
             - stable-2.1
-            # as more stable branches are published, they need to be
-            # added here
-            #- stable-2.2
+            - stable-2.2
+            - stable-3.0
           browser: auto
           skip-tag: true
           timeout: 20


### PR DESCRIPTION
The stable-3.0 branch has not been created yet, but putting this in
place now will ensure we get docs built when it is.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>