### PR TITLE
ceph-ansible-prs: adds skip-build-phrase

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -77,6 +77,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
+          skip-build-phrase: 'no-tests'
           trigger-phrase: 'jenkins test {release}-{ansible_version}-{scenario}'
           only-trigger-phrase: false
           github-hooks: true


### PR DESCRIPTION
Adding the string 'no-tests' to either the PR title
or description will keep CI jobs from triggering on PR updates or
creation.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>