### PR TITLE
ceph-ansible-prs: skip-build-phrase must be a regex

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -77,7 +77,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          skip-build-phrase: 'no-tests'
+          skip-build-phrase: '^jenkins do not test.*'
           trigger-phrase: 'jenkins test {release}-{ansible_version}-{scenario}'
           only-trigger-phrase: false
           github-hooks: true


### PR DESCRIPTION
Signed-off-by: Andrew Schoen <aschoen@redhat.com>