### PR TITLE
ceph-ansible-prs: fix leftover

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -13,6 +13,18 @@ delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services
 
+# This was initially in teardown but sometimes, it happens that the Jenkins Slave process
+# crashes before teardown is executed, it means we keep leftofver from previous build.
+# We ensure before the test is launched that no fetch directory from previous build is present.
+pushd $WORKSPACE/tests
+scenarios=$(find . -name Vagrantfile | xargs dirname)
+for scenario in $scenarios; do
+  pushd $scenario
+  rm -rf fetch/
+  popd
+done
+popd
+
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment
 if ! timeout 3h $VENV/tox -rv -e=$RELEASE-$ANSIBLE_VERSION-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then

--- a/ceph-ansible-prs/build/teardown
+++ b/ceph-ansible-prs/build/teardown
@@ -9,7 +9,6 @@ scenarios=$(find . -name Vagrantfile | xargs dirname)
 for scenario in $scenarios; do
     pushd $scenario
     vagrant destroy -f
-    rm -rf fetch/
     popd
 done
 


### PR DESCRIPTION
sometimes, it happens that the Jenkins Slave processes crashes before
teardown is executed (ie. `java.io.EOFException`), it means we keep leftofver from previous build.
This commit ensures before the test is launched that no fetch directory
from previous build is present.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>