### PR TITLE
ceph-ansible-prs: add two default scenarios

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -8,6 +8,8 @@
     scenario:
       - centos7_cluster
       - xenial_cluster
+      - docker_cluster
+      - update_cluster
     jobs:
         - 'ceph-ansible-prs-auto'
 
@@ -25,14 +27,12 @@
       - journal_collocation_auto_dmcrypt
       - dmcrypt_journal
       - dmcrypt_journal_collocation
-      - docker_cluster
       - docker_cluster_collocation
       - docker_dedicated_journal
       - docker_dmcrypt_journal_collocation
       - purge_cluster
       - purge_dmcrypt
       - update_dmcrypt
-      - update_cluster
       - purge_docker_cluster
       - update_docker_cluster
       - bluestore_cluster


### PR DESCRIPTION
Adding update_cluster and docker_cluster to test by default on each new
PR.

Signed-off-by: Sébastien Han <seb@redhat.com>