### PR TITLE
ceph-ansible-prs: limit certain scenarios to smithi nodes

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,6 +1,7 @@
-# tests that will auto start for every PR created
+# tests that will auto start for every PR created and run on smithi
 - project:
     name: ceph-ansible-prs-auto
+    slave_labels: 'vagrant && libvirt && smithi'
     release:
       - luminous
     ansible_version:
@@ -14,9 +15,27 @@
         - 'ceph-ansible-prs-auto'
 
 # tests that will not auto start when a PR is created, but
-# they can be requested with a trigger phrase
+# they can be requested with a trigger phrase. Run on smithi.
 - project:
-    name: ceph-ansible-prs-trigger
+    name: ceph-ansible-prs-trigger-smithi
+    slave_labels: 'vagrant && libvirt && smithi'
+    release:
+      - luminous
+    ansible_version:
+      - ansible2.3
+    scenario:
+      - purge_cluster
+      - update_docker_cluster
+      - switch_to_containers
+      - purge_docker_cluster
+    jobs:
+        - 'ceph-ansible-prs-trigger'
+
+# tests that will not auto start when a PR is created, but
+# they can be requested with a trigger phrase. Run on OVH.
+- project:
+    name: ceph-ansible-prs-trigger-ovh
+    slave_labels: 'vagrant && libvirt && !smithi'
     release:
       - luminous
     ansible_version:
@@ -30,18 +49,14 @@
       - docker_cluster_collocation
       - docker_dedicated_journal
       - docker_dmcrypt_journal_collocation
-      - purge_cluster
       - purge_dmcrypt
       - update_dmcrypt
-      - purge_docker_cluster
-      - update_docker_cluster
       - bluestore_cluster
       - bluestore_journal_collocation
       - bluestore_dmcrypt_journal
       - bluestore_dmcrypt_journal_collocation
       - bluestore_docker_dedicated_journal
       - bluestore_docker_dmcrypt_journal_collocation
-      - switch_to_containers
       - shrink_mon
       - shrink_mon_container
       - shrink_osd
@@ -54,6 +69,7 @@
 # requested with a trigger phrase
 - project:
     name: ceph-ansible-prs-dev
+    slave_labels: 'vagrant && libvirt && !smithi'
     release:
       - dev
     ansible_version:
@@ -67,7 +83,7 @@
 - job-template:
     name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
     id: 'ceph-ansible-prs-auto'
-    node: vagrant&&libvirt
+    node: '{slave_labels}'
     concurrent: true
     defaults: global
     display-name: 'ceph-ansible: Pull Requests [{release}-{ansible_version}-{scenario}]'
@@ -138,7 +154,7 @@
 - job-template:
     name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
     id: 'ceph-ansible-prs-trigger'
-    node: vagrant&&libvirt
+    node: '{slave_labels}'
     concurrent: true
     defaults: global
     display-name: 'ceph-ansible: Pull Requests [{release}-{ansible_version}-{scenario}]'


### PR DESCRIPTION
Scenarios requested by leseb to run only on smithi:
* luminous-ansible2.3-xenial_cluster
* luminous-ansible2.3-centos7_cluster
* luminous-ansible2.3-docker_cluster
* luminous-ansible2.3-purge_cluster
* luminous-ansible2.3-update_cluster
* luminous-ansible2.3-update_docker_cluster
* luminous-ansible2.3-switch_to_containers
* luminous-ansible2.3-purge_docker_cluster


Building/testing old yaml
```
dgalloway@w541 ceph-build (wip-limit-smithi)$ jenkins-jobs --conf ~/.jenkins_jobs.2.jenkins.ceph.com.ini test ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml.old -o /tmp/output-old
INFO:jenkins_jobs.cli.subcommand.update:Updating jobs in ['ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml.old'] ([])
INFO:jenkins_jobs.local_yaml:Including file '../../../scripts/build_utils.sh' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
INFO:jenkins_jobs.local_yaml:Including file '../../build/build' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
INFO:jenkins_jobs.local_yaml:Including file '../../../scripts/build_utils.sh' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
INFO:jenkins_jobs.local_yaml:Including file '../../build/build' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
WARNING:jenkins_jobs.local_yaml:tag '!include-raw' is deprecated, switch to using '!include-raw:'
INFO:jenkins_jobs.local_yaml:Including file '../../build/teardown' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
WARNING:jenkins_jobs.local_yaml:tag '!include-raw' is deprecated, switch to using '!include-raw:'
INFO:jenkins_jobs.local_yaml:Including file '../../build/teardown' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
WARNING:root:logrotate is deprecated on jenkins>=1.637, the property build-discarder on newer jenkins instead
INFO:jenkins_jobs.builder:Number of jobs generated:  30
INFO:jenkins_jobs.builder:Number of views generated:  0
```

Building/testing new yaml
```
dgalloway@w541 ceph-build (wip-limit-smithi)$ jenkins-jobs --conf ~/.jenkins_jobs.2.jenkins.ceph.com.ini test ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml -o /tmp/output-new
INFO:jenkins_jobs.cli.subcommand.update:Updating jobs in ['ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml'] ([])
INFO:jenkins_jobs.local_yaml:Including file '../../../scripts/build_utils.sh' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
INFO:jenkins_jobs.local_yaml:Including file '../../build/build' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
INFO:jenkins_jobs.local_yaml:Including file '../../../scripts/build_utils.sh' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
INFO:jenkins_jobs.local_yaml:Including file '../../build/build' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
WARNING:jenkins_jobs.local_yaml:tag '!include-raw' is deprecated, switch to using '!include-raw:'
INFO:jenkins_jobs.local_yaml:Including file '../../build/teardown' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
WARNING:jenkins_jobs.local_yaml:tag '!include-raw' is deprecated, switch to using '!include-raw:'
INFO:jenkins_jobs.local_yaml:Including file '../../build/teardown' from path '/home/dgalloway/git/ceph/ceph-build/ceph-ansible-prs/config/definitions'
WARNING:root:logrotate is deprecated on jenkins>=1.637, the property build-discarder on newer jenkins instead
INFO:jenkins_jobs.builder:Number of jobs generated:  30
INFO:jenkins_jobs.builder:Number of views generated:  0
```

Diff of a scenario we want to run on smithi
```
dgalloway@w541 ceph-build (wip-limit-smithi)$ diff /tmp/output-old/ceph-ansible-prs-luminous-ansible2.3-xenial_cluster /tmp/output-new/ceph-ansible-prs-luminous-ansible2.3-xenial_cluster
11c11
<   <assignedNode>vagrant&amp;&amp;libvirt</assignedNode>
---
>   <assignedNode>vagrant &amp;&amp; libvirt &amp;&amp; smithi</assignedNode>
```

Diff of a scenario we *don't* want on a smithi
```
dgalloway@w541 ceph-build (wip-limit-smithi)$ diff /tmp/output-old/ceph-ansible-prs-luminous-ansible2.3-shrink_osd /tmp/output-new/ceph-ansible-prs-luminous-ansible2.3-shrink_osd
11c11
<   <assignedNode>vagrant&amp;&amp;libvirt</assignedNode>
---
>   <assignedNode>vagrant &amp;&amp; libvirt !smithi</assignedNode>
```
Signed-off-by: David Galloway <dgallowa@redhat.com>