### PR TITLE
syntax-check: temporary disable ansible-lint

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -20,5 +20,5 @@ export ANSIBLE_LIBRARY=$WORKSPACE/ceph-ansible/library
 
 $VENV/ansible-playbook -i '127.0.0.1,' infrastructure-playbooks/*.yml --syntax-check --list-tasks -vv
 
-$VENV/ansible-lint site.yml.sample
-$VENV/ansible-lint site-docker.yml.sample
+#$VENV/ansible-lint site.yml.sample
+#$VENV/ansible-lint site-docker.yml.sample


### PR DESCRIPTION
We better to stabilize existing jobs before adding new like this one.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>