### PR TITLE
ceph-docker-nightly: nightlies run on centos now

### DIFF
--- a/ceph-docker-nightly/build/build
+++ b/ceph-docker-nightly/build/build
@@ -9,21 +9,12 @@ source $VENV/activate
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
-sudo apt-get install -y docker.io
-
-sudo gpasswd -a ${USER} docker
-sudo systemctl restart docker
-newgrp docker
-
 delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services
 update_vagrant_boxes
 
-# adding groups on the fly doesn't guarantee their availability
-# so we must use `sg` to execute the tests as part of the docker group to avoid
-# 'Permission Denied` when tryin to talk over the socket
-if ! timeout 3h sg docker -c "$VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR"; then
+if ! timeout 3h $VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR; then
   echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
   exit 1
 fi


### PR DESCRIPTION
Related: https://github.com/ceph/ceph-build/pull/886

Signed-off-by: David Galloway <dgallowa@redhat.com>