### PR TITLE
ceph-ansible-prs: adds the dev-ansible2.3-bluestore_lvm_osds

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -70,6 +70,7 @@
     scenario:
       - lvm_osds
       - purge_lvm_osds
+      - bluestore_lvm_osds
     jobs:
       - 'ceph-ansible-prs-trigger'
 


### PR DESCRIPTION
This must be a dev scenario for now as the functionality for ceph-volume
to create bluestore osds is not in a luminous release yet.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>