### PR TITLE
ansible: always update slave.jar

### DIFF
--- a/ansible/examples/slave_libvirt_static.yml
+++ b/ansible/examples/slave_libvirt_static.yml
@@ -310,6 +310,7 @@
       get_url:
         url: "{{ api_uri }}/jnlpJars/slave.jar"
         dest: "/home/{{ jenkins_user }}/slave.jar"
+        force: yes
 
     - name: install the systemd unit file for jenkins
       template:

--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -295,6 +295,7 @@
       get_url:
         url: "{{ api_uri }}/jnlpJars/slave.jar"
         dest: "/home/{{ jenkins_user }}/slave.jar"
+        force: yes
       when: use_jnlp
 
     - name: install the systemd unit file for jenkins


### PR DESCRIPTION
Makes sure latest version of JNLP is being used.  Primarily useful when
re-running the playbook against a static slave.

Signed-off-by: David Galloway <dgallowa@redhat.com>