### PR TITLE
ceph{-,dev-,dev-new-}build: install centos-release-scl repo

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -39,6 +39,7 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
                 $SUDO yum install -y yum-utils
                 ;;
         esac
+        $SUDO yum install -y centos-release-scl
         sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
         $SUDO yum-builddep -y $DIR/ceph.spec
         ;;

--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -29,24 +29,10 @@ tar xzf *.orig.tar.gz
 cd ceph-*
 pwd
 
-case $(lsb_release -si) in
-CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
-        case $(lsb_release -si) in
-            SUSE*)
-                $SUDO zypper -y yum-utils
-                ;;
-            *)
-                $SUDO yum install -y yum-utils
-                ;;
-        esac
-        $SUDO yum install -y centos-release-scl
-        sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-        $SUDO yum-builddep -y $DIR/ceph.spec
-        ;;
-*)
-        echo "$(lsb_release -si) is unknown, dependencies will have to be installed manually."
-        ;;
-esac
+$SUDO yum install -y yum-utils
+$SUDO yum install -y centos-release-scl
+sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
+$SUDO yum-builddep -y $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -39,6 +39,7 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
                 $SUDO yum install -y yum-utils
                 ;;
         esac
+        $SUDO yum install -y centos-release-scl
         sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
         $SUDO yum-builddep -y $DIR/ceph.spec
         ;;

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -29,24 +29,10 @@ tar xzf *.orig.tar.gz
 cd ceph-*
 pwd
 
-case $(lsb_release -si) in
-CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
-        case $(lsb_release -si) in
-            SUSE*)
-                $SUDO zypper -y yum-utils
-                ;;
-            *)
-                $SUDO yum install -y yum-utils
-                ;;
-        esac
-        $SUDO yum install -y centos-release-scl
-        sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-        $SUDO yum-builddep -y $DIR/ceph.spec
-        ;;
-*)
-        echo "$(lsb_release -si) is unknown, dependencies will have to be installed manually."
-        ;;
-esac
+$SUDO yum install -y yum-utils
+$SUDO yum install -y centos-release-scl
+sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
+$SUDO yum-builddep -y $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -39,6 +39,7 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
                 $SUDO yum install -y yum-utils
                 ;;
         esac
+        $SUDO yum install -y centos-release-scl
         sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
         $SUDO yum-builddep -y $DIR/ceph.spec
         ;;

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -29,24 +29,10 @@ tar xzf *.orig.tar.gz
 cd ceph-*
 pwd
 
-case $(lsb_release -si) in
-CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
-        case $(lsb_release -si) in
-            SUSE*)
-                $SUDO zypper -y yum-utils
-                ;;
-            *)
-                $SUDO yum install -y yum-utils
-                ;;
-        esac
-        $SUDO yum install -y centos-release-scl
-        sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-        $SUDO yum-builddep -y $DIR/ceph.spec
-        ;;
-*)
-        echo "$(lsb_release -si) is unknown, dependencies will have to be installed manually."
-        ;;
-esac
+$SUDO yum install -y yum-utils
+$SUDO yum install -y centos-release-scl
+sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
+$SUDO yum-builddep -y $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 


### PR DESCRIPTION
enable/install centos-release-scl on rhel7/centos7, so we can use
newer gcc/toolchain offered by Software Collections (scl)'s devtoolset
see https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/

Signed-off-by: Kefu Chai <kchai@redhat.com>