### PR TITLE
ceph-ansible: set CEPH_STABLE_RELEASE in start_tox()

### DIFF
--- a/ceph-ansible-nightly/build/build
+++ b/ceph-ansible-nightly/build/build
@@ -17,7 +17,9 @@ update_vagrant_boxes
 if [ "$RELEASE" == 'jewel' ] && [ "$CEPH_ANSIBLE_BRANCH" == 'stable-2.2' -o "$CEPH_ANSIBLE_BRANCH" == 'stable-3.0' ]; then
   start_tox tag-stable-3.0-jewel-centos-7
 elif [ "$RELEASE" == 'luminous' ] && [ "$CEPH_ANSIBLE_BRANCH" == 'stable-3.0' ]; then
-  start_tox tag-stable-3.0-jewel-centos-7
+  # start_tox(): <CEPH_DOCKER_IMAGE_TAG> <CEPH_STABLE_RELEASE>
+  # first, we play stable-3.0 delpoying jewel and then we test a new deployment with luminous.
+  start_tox tag-stable-3.0-jewel-centos-7 jewel
   start_tox tag-stable-3.0-luminous-centos-7
 elif [ "$RELEASE" == 'luminous' ] && [ "$CEPH_ANSIBLE_BRANCH" == 'master' ]; then
   start_tox tag-build-master-luminous-ubuntu-16.04

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -457,9 +457,12 @@ update_vagrant_boxes() {
 }
 
 start_tox() {
+# $1 = CEPH_DOCKER_IMAGE_TAG
+# $2 = CEPH_STABLE_RELEASE (default value to $RELEASE which is injected by the job template)
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment
-  if ! CEPH_DOCKER_IMAGE_TAG=$1 timeout 3h $VENV/tox -rv -e=$RELEASE-$ANSIBLE_VERSION-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
+local release=${2:-$RELEASE}
+  if ! CEPH_DOCKER_IMAGE_TAG=$1 CEPH_STABLE_RELEASE=$release timeout 3h $VENV/tox -rv -e=$RELEASE-$ANSIBLE_VERSION-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
     echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
     exit 1
   fi


### PR DESCRIPTION
according to ceph/ceph-ansible#2165 we need to set `CEPH_STABLE_RELEASE`
in ceph/ceph-build.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>