### PR TITLE
ceph-volume-ansible-prs: use subcommand to build the testing path

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -44,6 +44,6 @@ fi
 pkgs=( "tox" )
 install_python_packages "pkgs[@]"
 
-cd $TEST_PATH
+cd src/ceph-volume/ceph_volume/tests/functional/$SUBCOMMAND
 
 CEPH_DEV_BRANCH=$BRANCH CEPH_DEV_SHA1=$SHA $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt

--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -9,8 +9,6 @@
     scenario:
       - create
       - prepare_activate
-    test_path:
-      - src/ceph-volume/ceph_volume/tests/functional/lvm
     subcommand:
       - lvm
 
@@ -27,8 +25,6 @@
       - filestore
     scenario:
       - activate
-    test_path:
-      - src/ceph-volume/ceph_volume/tests/functional/simple
     subcommand:
       - simple
 
@@ -91,7 +87,7 @@
             SCENARIO={scenario}
             DISTRO={distro}
             OBJECTSTORE={objectstore}
-            TEST_PATH={test_path}
+            SUBCOMMAND={subcommand}
       - shell:
           !include-raw-escape:
             - ../../../scripts/build_utils.sh


### PR DESCRIPTION
I'm not exactly sure of the reason but ``TEST_PATH`` was being rendered by jjb as a list. However, we can easily build the testing path by using the ``subcommand`` factor that we already have.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>