### PR TITLE
ceph-ansible-nightly: couple of fixes

### DIFF
--- a/ceph-ansible-nightly/build/build
+++ b/ceph-ansible-nightly/build/build
@@ -18,8 +18,6 @@ if [ "$RELEASE" == 'jewel' ] && [ "$CEPH_ANSIBLE_BRANCH" == 'stable-2.2' -o "$CE
   start_tox tag-stable-3.0-jewel-centos-7
 elif [ "$RELEASE" == 'luminous' ] && [ "$CEPH_ANSIBLE_BRANCH" == 'stable-3.0' ]; then
   # start_tox(): <CEPH_DOCKER_IMAGE_TAG> <CEPH_STABLE_RELEASE>
-  # first, we play stable-3.0 delpoying jewel and then we test a new deployment with luminous.
-  start_tox tag-stable-3.0-jewel-centos-7 jewel
   start_tox tag-stable-3.0-luminous-centos-7
 elif [ "$RELEASE" == 'luminous' ] && [ "$CEPH_ANSIBLE_BRANCH" == 'master' ]; then
   start_tox tag-build-master-luminous-ubuntu-16.04

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -14,6 +14,20 @@
     jobs:
         - 'ceph-ansible-prs-auto'
 
+- project:
+    name: ceph-ansible-2.2-prs
+    slave_labels: 'vagrant && libvirt && smithi'
+    release:
+      - jewel
+    ansible_version:
+      - ansible2.4
+    scenario:
+      - centos7_cluster
+      - xenial_cluster
+      - docker_cluster
+    jobs:
+        - 'ceph-ansible-2.2-prs'
+
 # tests that will not auto start when a PR is created, but
 # they can be requested with a trigger phrase. Run on smithi.
 - project:
@@ -73,6 +87,77 @@
       - bluestore_lvm_osds
     jobs:
       - 'ceph-ansible-prs-trigger'
+
+- job-template:
+    name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
+    id: 'ceph-ansible-2.2-prs'
+    node: '{slave_labels}'
+    concurrent: true
+    defaults: global
+    display-name: 'ceph-ansible: Pull Requests [{release}-{ansible_version}-{scenario}]'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-ansible
+    logrotate:
+      daysToKeep: 15
+      numToKeep: -1
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    parameters:
+      - string:
+          name: sha1
+          description: "A pull request ID, like 'origin/pr/72/head'"
+
+    triggers:
+      - github-pull-request:
+          cancel-builds-on-update: true
+          allow-whitelist-orgs-as-admins: true
+          org-list:
+            - ceph
+          skip-build-phrase: '^jenkins do not test.*'
+          trigger-phrase: '^jenkins test stable-2.2 {release}-{ansible_version}-{scenario}|jenkins test all stable-2.2.*'
+          only-trigger-phrase: true
+          github-hooks: false
+          permit-all: true
+          auto-close-on-fail: false
+          status-context: "Testing: {release}-{ansible_version}-{scenario}"
+          started-status: "Running: {release}-{ansible_version}-{scenario}"
+          success-status: "OK - {release}-{ansible_version}-{scenario}"
+          failure-status: "FAIL - {release}-{ansible_version}-{scenario}"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-ansible.git
+          branches:
+            - ${{sha1}}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: false
+
+    builders:
+      - inject:
+          properties-content: |
+            SCENARIO={scenario}
+            RELEASE={release}
+            ANSIBLE_VERSION={ansible_version}
+      - shell:
+          !include-raw-escape:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+
+    publishers:
+      - postbuildscript:
+          script-only-if-succeeded: False
+          script-only-if-failed: True
+          builders:
+            - shell: !include-raw ../../build/teardown
 
 - job-template:
     name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'


### PR DESCRIPTION
- Remove a useless test in nightlies jobs.
- Add testing for backport to stable-2.2 PRs

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>