### PR TITLE
ceph-colume-ansible-prs: add injected ghprb vars to help manual triggering

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -54,6 +54,72 @@
           name: sha1
           description: "A pull request ID, like 'origin/pr/72/head'"
 
+      # these are injected by the ghprb plugin, and are fully optional but may help in manually triggering
+      # a job that can end up updating a PR
+      - string:
+          name: ghprbActualCommit
+          description: "The tip (last commit) in the PR, a sha1 like 7d787849556788961155534039886aedfcdb2a88"
+
+      - string:
+         name: ghprbAuthorRepoGitUrl
+         description: "Injected plugin var: Origin URL like https://github.com/ceph/ceph.git"
+
+      - string:
+         name: ghprbTriggerAuthor
+         description: "Injected plugin var: Full Name of person triggering, like john doe"
+
+      - string:
+         name: ghprbTriggerAuthorLogin
+         description: "Injected plugin var: Github username that triggered, like johndoe"
+
+      - string:
+         name: ghprbTriggerAuthorLoginMention
+         description: "Injected plugin var: Github username that triggered, with '@' like @johndoe"
+
+      - string:
+         name: ghprbPullId
+         description: "Injected plugin var: The ID of the pull request, like 18882"
+
+      - string:
+         name: ghprbTargetBranch
+         description: "Injected plugin var: The destination branch once merged, like master"
+
+      - string:
+         name: ghprbSourceBranch
+         description: "Injected plugin var: The originating branch, like wip-branch"
+
+      - string:
+         name: ghprbPullAuthorLogin
+         description: "Injected plugin var: PR author's Github username like janedoe"
+
+      - string:
+         name: ghprbPullAuthorLoginMention
+         description: "Injected plugin var: PR author's Github username with '@' like @janedoe"
+
+      - string:
+         name: ghprbPullDescription
+         description: "Injected plugin var: like 'GitHub pull request #18882 of commit 7d787849556788961155534039886aedfcdb2a88, no merge conflicts.'"
+
+      - string:
+         name: ghprbPullTitle
+         description: "Injected plugin var: like 'ceph-volume add functional tests'"
+
+      - string:
+         name: ghprbPullLink
+         description: "Injected plugin var: Link to the PR like https://github.com/ceph/ceph/pull/18882"
+
+      - string:
+         name: ghprbCommentBody
+         description: "Injected plugin var: The comment that triggered the job, like 'jenkins test this please'"
+
+      - string:
+         name: ghprbGhRepository
+         description: "Injected plugin var: The url part of the repo, like ceph/ceph"
+
+      - string:
+         name: ghprbCredentialsId
+         description: "Injected plugin var: The credential ID of the user, like eeeeeeee-1111-aaaa-8888-aaaaaaaaaaaa"
+
     triggers:
       - github-pull-request:
           cancel-builds-on-update: true


### PR DESCRIPTION
These vars are injected by the ghprb plugin when the job is triggered by a new PR or by a comment in a PR. The idea here is to see if by passing them manually, one can trigger a job without having to be commenting on a PR.

This addition should be neutral and not affect the job itself.