### PR TITLE
ceph-ansible-prs: change trigger-phrase

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -120,7 +120,7 @@
           org-list:
             - ceph
           skip-build-phrase: '^jenkins do not test.*'
-          trigger-phrase: '^jenkins test stable-2.2 {release}-{ansible_version}-{scenario}|jenkins test all stable-2.2.*'
+          trigger-phrase: '^jenkins test stable-2.2 {release}-{ansible_version}-{scenario}|jenkins test stable-2.2.*'
           only-trigger-phrase: true
           github-hooks: false
           permit-all: true


### PR DESCRIPTION
fix ceph-ansible-2.2-prs template because it triggers jobs that
shouldn't for backport to stable-2.2 PRs.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>