### PR TITLE
kernel: install libelf

### DIFF
--- a/kernel/build/setup
+++ b/kernel/build/setup
@@ -31,10 +31,12 @@ export LC_ALL=C # the following is vulnerable to i18n
 
 if test -f /etc/redhat-release ; then
     $SUDO yum install -y redhat-lsb-core
+    $SUDO yum install -y elfutils-libelf-devel  # for ORC unwinder
 fi
 
 if which apt-get > /dev/null ; then
     $SUDO apt-get install -y lsb-release
+    $SUDO apt-get install -y libelf-dev  # for ORC unwinder
 fi
 
 case $(lsb_release -si) in


### PR DESCRIPTION
ORC unwinder (default on x86 since 4.15) requires it.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>