### PR TITLE
ceph-dev-trigger support mimic* branches, to include mimic-dev

### DIFF
--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -31,6 +31,7 @@
             - 'origin/kraken'
             - 'origin/hammer'
             - 'origin/luminous'
+            - 'origin/mimic*'
           skip-tag: true
           timeout: 20
           wipe-workspace: true


### PR DESCRIPTION
This is already working, this should persist the config.