### PR TITLE
ceph{-,dev-,dev-new-}build: install centos-release-scl-rh repo for arm64

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -30,7 +30,13 @@ cd ceph-*
 pwd
 
 $SUDO yum install -y yum-utils
-$SUDO yum install -y centos-release-scl
+if [ "$ARCH" = x86_64 ]; then
+    $SUDO yum install -y centos-release-scl
+elif [ "$ARCH" = arm64 ]; then
+    $SUDO yum install -y centos-release-scl-rh
+    $SUDO yum-config-manager --disable centos-sclo-rh
+    $SUDO yum-config-manager --enable centos-sclo-rh-testing
+fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 $SUDO yum-builddep -y $DIR/ceph.spec
 

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -30,7 +30,13 @@ cd ceph-*
 pwd
 
 $SUDO yum install -y yum-utils
-$SUDO yum install -y centos-release-scl
+if [ "$ARCH" = x86_64 ]; then
+    $SUDO yum install -y centos-release-scl
+elif [ "$ARCH" = arm64 ]; then
+    $SUDO yum install -y centos-release-scl-rh
+    $SUDO yum-config-manager --disable centos-sclo-rh
+    $SUDO yum-config-manager --enable centos-sclo-rh-testing
+fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 $SUDO yum-builddep -y $DIR/ceph.spec
 

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -30,7 +30,13 @@ cd ceph-*
 pwd
 
 $SUDO yum install -y yum-utils
-$SUDO yum install -y centos-release-scl
+if [ "$ARCH" = x86_64 ]; then
+    $SUDO yum install -y centos-release-scl
+elif [ "$ARCH" = arm64 ]; then
+    $SUDO yum install -y centos-release-scl-rh
+    $SUDO yum-config-manager --disable centos-sclo-rh
+    $SUDO yum-config-manager --enable centos-sclo-rh-testing
+fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 $SUDO yum-builddep -y $DIR/ceph.spec
 


### PR DESCRIPTION
the devtoolset-7 for aarch64 is not offered by centos-release-scl, but
at least centos-release-scl-rh has devtoolset-6.

see https://github.com/sclorg/centos-release-scl
see https://buildlogs.centos.org/centos/7/sclo/aarch64/rh/

Fixes: http://tracker.ceph.com/issues/22301
Signed-off-by: Kefu Chai <kchai@redhat.com>