### PR TITLE
ceph-ansible-prs: adds lvm tests for the luminous release

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -68,6 +68,9 @@
       - shrink_mon_container
       - shrink_osd
       - shrink_osd_container
+      - lvm_osds
+      - purge_lvm_osds
+      - bluestore_lvm_osds
     jobs:
         - 'ceph-ansible-prs-trigger'
 


### PR DESCRIPTION
ceph-volume can now be used in luminous, so we should be able to
test PRs for ceph-volume against luminous.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>