### PR TITLE
ceph-ansible: get CEPH_STABLE_RELEASE back to tox

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -513,11 +513,10 @@ update_vagrant_boxes() {
 
 start_tox() {
 # $1 = CEPH_DOCKER_IMAGE_TAG
-# $2 = CEPH_STABLE_RELEASE (default value to $RELEASE which is injected by the job template)
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment
 local release=${2:-$RELEASE}
-  if ! CEPH_DOCKER_IMAGE_TAG=$1 CEPH_STABLE_RELEASE=$release timeout 3h $VENV/tox -rv -e=$RELEASE-$ANSIBLE_VERSION-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
+  if ! CEPH_DOCKER_IMAGE_TAG=$1 timeout 3h $VENV/tox -rv -e=$RELEASE-$ANSIBLE_VERSION-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
     echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
     exit 1
   fi


### PR DESCRIPTION
get CEPH_STABLE_RELEASE back to tox.ini so we do not have to set
explicitely CEPH_STABLE_RELEASE when running test locally.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>