### PR TITLE
ceph-volume-ansible-prs: add a trigger phrase to start all jobs

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -127,7 +127,7 @@
           org-list:
             - ceph
           only-trigger-phrase: true
-          trigger-phrase: 'jenkins test ceph-volume {subcommand} {distro}-{objectstore}-{scenario}'
+          trigger-phrase: '^jenkins test ceph-volume {subcommand} {distro}-{objectstore}-{scenario}|jenkins test ceph-volume all.*'
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false


### PR DESCRIPTION
This will allow you to comment 'jenkins test ceph-volume all' and
all jobs will trigger.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>