### PR TITLE
ceph-volume-ansible-prs: remove prepare_activate and add subcommand trigger

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -8,7 +8,6 @@
       - filestore
     scenario:
       - create
-      - prepare_activate
     subcommand:
       - lvm
 

--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -67,7 +67,7 @@
           org-list:
             - ceph
           only-trigger-phrase: true
-          trigger-phrase: '^jenkins test ceph-volume {subcommand} {distro}-{objectstore}-{scenario}|jenkins test ceph-volume all.*'
+          trigger-phrase: '^jenkins test ceph-volume {subcommand} {distro}-{objectstore}-{scenario}|jenkins test ceph-volume all.*|jenkins test ceph-volume {subcommand} all.*'
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false


### PR DESCRIPTION
This removes the ``prepare_activate`` scenario has it has not been implemented yet, so no need to create a job for it.

Also, you can now trigger all tests by their subcommand by commenting ``jenkins test ceph-volume lvm all`` or ``jenkins test ceph-volume simple all``.