### PR TITLE
ceph-volume-ansible-prs make sure a newer version of github-status is used

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -41,7 +41,7 @@ fi
 # ready to be consumed
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "tox" "github-status" )
+pkgs=( "tox" "github-status>0.0.3" )
 install_python_packages "pkgs[@]"
 
 GITHUB_STATUS_STATE="pending" $VENV/github-status create

--- a/ceph-volume-ansible-prs/build/teardown
+++ b/ceph-volume-ansible-prs/build/teardown
@@ -3,7 +3,7 @@
 # for every Vagrantfile in scenarios and then just destroys whatever is left.
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "github-status" )
+pkgs=( "tox" "github-status>0.0.3" )
 install_python_packages "pkgs[@]"
 
 GITHUB_STATUS_STATE="failure" $VENV/github-status create


### PR DESCRIPTION
Because otherwise the cached, previous (and buggy) version will be used