### PR TITLE
script/build_utils.sh: import ppa key into apt's keyring

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -457,8 +457,10 @@ echo "deb http://mirror.cs.uchicago.edu/ubuntu-toolchain-r $DIST main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
 echo deb http://mirror.yandex.ru/mirrors/launchpad/ubuntu-toolchain-r $DIST main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
+# import PPA's signing key into APT's keyring
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F
 apt-get update
-apt-get install -y --allow-unauthenticated g++-7
+apt-get install -y g++-7
 EOF
 
         cat > $hookdir/E10update-gcc-alternatives <<EOF


### PR DESCRIPTION
to be immune from the MITM attack

Signed-off-by: Kefu Chai <kchai@redhat.com>