### PR TITLE
ceph-volume-ansible-prs: allow to specify branches not in ceph.git

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -36,6 +36,16 @@ if [ -z "$BRANCH" ]; then
     exit 1
 fi
 
+# if ghprbActualCommit is not available, and the previous checks were not able to determine
+# the SHA1, then the last attempt should be to try and set it to the env passed in as a parameter (GITHUB_SHA)
+SHA="${ghprbActualCommit:-$GITHUB_SHA}"
+if [ -z "$SHA" ]; then
+    echo "Could not determine \$SHA var from \$ghprbActualCommit"
+    echo "or by using \$GIT_PREVIOUS_COMMIT or \$GIT_COMMIT"
+    echo "or even looking at the \$GITHUB_SHA parameter for this job"
+    exit 1
+fi
+
 
 # TODO: at this point a `curl` to shaman is needed to verify that the repo is
 # ready to be consumed

--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -53,8 +53,11 @@
           name: sha1
           description: "A pull request ID, like 'origin/pr/72/head'"
 
-      # these are injected by the ghprb plugin, and are fully optional but may help in manually triggering
+      # this is injected by the ghprb plugin, and is fully optional but may help in manually triggering
       # a job that can end up updating a PR
+      - string:
+          name: ghprbSourceBranch
+          description: "When manually triggered, and the remote PR isn't a branch in the ceph.git repo This can be specified to determine the actual branch."
       - string:
           name: GITHUB_SHA
           description: "The tip (last commit) in the PR, a sha1 like 7d787849556788961155534039886aedfcdb2a88 (if set, will report status to Github)"


### PR DESCRIPTION
This is problematic when dealing with branches that aren't in ceph.git and PRs need to be tested.