### PR TITLE
build_utils: set CEPH_STABLE_RELEASE in start_tox

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -36,8 +36,6 @@
       - xenial_cluster
       - docker_cluster
       - update_cluster
-      - lvm_osds
-      - purge_lvm_osds
       - docker_cluster_collocation
       - update_docker_cluster
       - switch_to_containers

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -561,8 +561,7 @@ start_tox() {
 # the $SCENARIO var is injected by the job template. It maps
 # to an actual, defined, tox environment
 local release=${2:-$RELEASE}
-  if ! CEPH_DOCKER_IMAGE_TAG=$1 timeout 3h $VENV/tox -rv -e=$RELEASE-$ANSIBLE_VERSION-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then
-    echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
+  if ! CEPH_DOCKER_IMAGE_TAG=$1 CEPH_STABLE_RELEASE=$RELEASE timeout 3h $VENV/tox -rv -e=$RELEASE-$ANSIBLE_VERSION-$SCENARIO --workdir=$WORKDIR -- --provider=libvirt; then echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
     exit 1
   fi
 }


### PR DESCRIPTION
This will tell tox which ceph version to install and test. Without this
some of the nightlies advertised that they were testing jewel
but were actually testing luminous.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>