### PR TITLE
ceph-volume-ansible-prs: libvirt cleanup and dmcrypt testing scenarios

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -56,6 +56,11 @@ install_python_packages "pkgs[@]"
 
 GITHUB_STATUS_STATE="pending" $VENV/github-status create
 
+delete_libvirt_vms
+clear_libvirt_networks
+restart_libvirt_services
+update_vagrant_boxes
+
 cd src/ceph-volume/ceph_volume/tests/functional/$SUBCOMMAND
 
 CEPH_DEV_BRANCH=$BRANCH CEPH_DEV_SHA1=$SHA $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt

--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -8,6 +8,7 @@
       - filestore
     scenario:
       - create
+      - dmcrypt
     subcommand:
       - lvm
 


### PR DESCRIPTION
This adds some util functions that libvirt/vagrant jobs typically run that clean up stale libvirt networks and upgrades the vagrant box.

This also adds the ``dmcrypt`` factor to enable the new testing scenarios in https://github.com/ceph/ceph/pull/20054