### PR TITLE
ceph-volume-ansible-prs: add trigger phrase per scenario

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -71,7 +71,7 @@
           org-list:
             - ceph
           only-trigger-phrase: true
-          trigger-phrase: '^jenkins test ceph-volume {subcommand} {distro}-{objectstore}-{scenario}|jenkins test ceph-volume all.*|jenkins test ceph-volume {subcommand} all.*'
+          trigger-phrase: '^jenkins test ceph-volume {subcommand} {distro}-{objectstore}-{scenario}|jenkins test ceph-volume all.*|jenkins test ceph-volume {subcommand} all.*|jenkins test ceph-volume {subcommand} {scenario}.*'
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false


### PR DESCRIPTION
So we can start all 'create' tests like 'jenkins test ceph-volume lvm
create'

Signed-off-by: Andrew Schoen <aschoen@redhat.com>