### PR TITLE
nfs-ganesha-stable: various rpm build updates

### DIFF
--- a/nfs-ganesha-stable/build/build_rpm
+++ b/nfs-ganesha-stable/build/build_rpm
@@ -48,8 +48,9 @@ libcap-devel
 libnfsidmap-devel
 libwbclient-devel
 krb5-devel
-librgw-devel
-libcephfs-devel
+librados-devel-${CEPH_VERSION}
+librgw-devel-${CEPH_VERSION}
+libcephfs-devel-${CEPH_VERSION}
 "
 
 sudo yum install -y mock
@@ -70,10 +71,11 @@ mkdir build
 cd build
 
 # generate .spec file, edit .spec file for correct versions of libs and make source tarball
-cmake -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=ON -DRADOS_URLS=ON -DUSE_RADOS_RECOV=ON $WORKSPACE/nfs-ganesha/src && make dist || exit 1
+cmake -DCMAKE_BUILD_TYPE=Release -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=ON -DRADOS_URLS=ON -DUSE_RADOS_RECOV=ON $WORKSPACE/nfs-ganesha/src && make dist || exit 1
 
 sed -i 's/libcephfs1-devel/libcephfs-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 sed -i 's/librgw2-devel/librgw-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
+sed -i 's/CMAKE_BUILD_TPYE=Debug/CMAKE_BUILD_TYPE=Release/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 
 ## Create the source rpm
 echo "Building SRPM"

--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -74,6 +74,11 @@
           default: "luminous"
 
       - string:
+          name: CEPH_VERSION
+          description: "The version of Ceph to specify for installing ceph libraries"
+          default: "12.2.2"
+
+      - string:
           name: DISTROS
           description: "A list of distros to build for. Available options are: xenial, centos7"
           default: "centos7 xenial"
@@ -95,6 +100,7 @@ Default: False. When True it will not POST binaries to chacra. Artifacts will no
 If this is unchecked, then nothing is built or pushed if they already exist in chacra. This is the default.
 
 If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
+          default: true
 
       - string:
           name: BUILD_VIRTUALENV


### PR DESCRIPTION
added a $CEPH_VERSION var to specify rpm installations

changed rpm build type to Release

Signed-off-by: Ali Maredia <amaredia@redhat.com>