### PR TITLE
ceph-volume-nightly: fix usage of ceph_branch

### DIFF
--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -64,7 +64,7 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - ${{ceph_branch}}
+            - '{ceph_branch}'
           browser: auto
           timeout: 20
           skip-tag: true


### PR DESCRIPTION
The jobs will now clone the correct branch of ceph.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>