### PR TITLE
rtslib-fb/tcmu-runner: strip 'v' prefix from RPM version

### DIFF
--- a/rtslib-fb/build/build_rpm
+++ b/rtslib-fb/build/build_rpm
@@ -20,8 +20,8 @@ sudo gem install fpm
 ## Get some basic information about the system and the repository
 # Get version
 RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
-VERSION="$(git describe --abbrev=0 --tags HEAD)"
-REVISION="$(git describe --tags HEAD | cut -d - -f 2- | sed 's/-/./')"
+VERSION="$(git describe --abbrev=0 --tags HEAD | sed -e 's/v//1;')"
+REVISION="$(git describe --tags HEAD | sed -e 's/v//1;' | cut -d - -f 2- | sed 's/-/./')"
 if [ "$VERSION" = "$REVISION" ]; then
   REVISION="1"
 fi

--- a/tcmu-runner/build/build_rpm
+++ b/tcmu-runner/build/build_rpm
@@ -79,8 +79,8 @@ gzip ${DESTDIR}/usr/share/man/man8/tcmu-runner.8
 ## Get some basic information about the system and the repository
 # Get version
 RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
-VERSION="$(git describe --abbrev=0 --tags HEAD | cut -d - -f 1)"
-REVISION="$(git describe --tags HEAD | cut -d - -f 2- | sed 's/-/./g' | sed 's/^rc/0./')"
+VERSION="$(git describe --abbrev=0 --tags HEAD | sed -e 's/v//1;' | cut -d - -f 1)"
+REVISION="$(git describe --tags HEAD | sed -e 's/v//1;' | cut -d - -f 2- | sed 's/-/./g' | sed 's/^rc/0./')"
 if [ "$VERSION" = "$REVISION" ]; then
   REVISION="1"
 fi


### PR DESCRIPTION
Signed-off-by: Jason Dillaman <dillaman@redhat.com>