### PR TITLE
ceph-volume-nightly: add parameters for CEPH_BRANCH and CEPH_SHA1

### DIFF
--- a/ceph-volume-nightly/build/build
+++ b/ceph-volume-nightly/build/build
@@ -14,4 +14,4 @@ update_vagrant_boxes
 
 cd src/ceph-volume/ceph_volume/tests/functional/$SUBCOMMAND
 
-CEPH_DEV_BRANCH=$CEPH_BRANCH $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt
+CEPH_DEV_BRANCH=$CEPH_BRANCH CEPH_DEV_SHA1=$CEPH_SHA1 $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt

--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -60,11 +60,21 @@
     triggers:
       - timed: '@daily'
 
+    parameters:
+      - string:
+          name: CEPH_BRANCH
+          description: "The ceph branch to test and checkout"
+          default: "{ceph_branch}"
+      - string:
+          name: CEPH_SHA1
+          description: "The ceph sha1 to test"
+          default: "latest"
+
     scm:
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - '{ceph_branch}'
+            - $CEPH_BRANCH
           browser: auto
           timeout: 20
           skip-tag: true
@@ -77,7 +87,6 @@
             DISTRO={distro}
             OBJECTSTORE={objectstore}
             SUBCOMMAND={subcommand}
-            CEPH_BRANCH={ceph_branch}
       - shell:
           !include-raw-escape:
             - ../../../scripts/build_utils.sh


### PR DESCRIPTION
This will allow these jobs to be triggered manually by inputing any ceph
branch and sha1.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>