### PR TITLE
ceph-deploy-pull-requests: project does not need 2.6 anymore

### DIFF
--- a/ceph-deploy-pull-requests/setup/playbooks/tasks/ubuntu.yml
+++ b/ceph-deploy-pull-requests/setup/playbooks/tasks/ubuntu.yml
@@ -1,7 +1,4 @@
 ---
-  - name: add deadsnakes ppa
-    action: apt_repository repo=ppa:fkrull/deadsnakes state=present
-
   - name: "update apt repo"
     action: apt update_cache=yes
 
@@ -10,10 +7,8 @@
     with_items:
       - python-software-properties
       - python-dev
-      - python2.6-dev
-      - python-setuptools
-      - python2.6
       - python2.7
+      - python3.5
 
   - name: install pip
     action: easy_install name=pip


### PR DESCRIPTION
Removes the 'dead snakes' PPA, and just ensures that python 2.7 and 3.5 are available. Which is not a problem in Xenial