### PR TITLE
Discard builds for jobs

### DIFF
--- a/bz-mill/config/definitions/bz-mill.yml
+++ b/bz-mill/config/definitions/bz-mill.yml
@@ -2,6 +2,10 @@
     name: bz-mill
     defaults: global
     display-name: 'bz-mill'
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+          artifact-days-to-keep: 90
 
     triggers:
       - timed: '@hourly'

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -10,6 +10,10 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph
+      - build-discarder:
+          days-to-keep: 30
+          artifact-days-to-keep: 30
+
     execution-strategy:
        combination-filter: |
          DIST == AVAILABLE_DIST && ARCH == AVAILABLE_ARCH &&

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -10,6 +10,10 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph-ci
+      - build-discarder:
+          days-to-keep: 30
+          artifact-days-to-keep: 30
+
     execution-strategy:
        combination-filter: |
          DIST == AVAILABLE_DIST && ARCH == AVAILABLE_ARCH &&

--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -29,6 +29,10 @@
     properties:
       - github:
           url: https://github.com/nfs-ganesha/nfs-ganesha
+      - build-discarder:
+          days-to-keep: 90
+          artifact-days-to-keep: 90
+
     concurrent: true
     parameters:
       - string:


### PR DESCRIPTION
Enables discarding builds after 90 days for a few projects that were just keeping them for ever. 

Once these are in control, we can try and see what others can this be applied. I picked only the top 4 which were beyond 4,000 jobs
![screen shot 2018-02-20 at 8 08 59 pm](https://user-images.githubusercontent.com/317847/36457846-0d9209aa-167a-11e8-9e15-4233377d7ea4.png)
