### PR TITLE
ceph-container: add job to build and push images

### DIFF
--- a/ceph-container-build-push-imgs/build/build
+++ b/ceph-container-build-push-imgs/build/build
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+
+#############
+# FUNCTIONS #
+#############
+
+function login_docker_hub {
+  echo "Login in the Docker Hub"
+  docker login -u "$DOCKER_HUB_USERNAME" -p "$DOCKER_HUB_PASSWORD"
+}
+
+function build_ceph_imgs {
+  make build.parallel
+}
+
+function push_ceph_imgs {
+  make push
+}
+
+
+########
+# MAIN #
+########
+
+login_docker_hub
+set -x
+cd "$WORKSPACE"/ceph-container/ || exit
+build_ceph_imgs
+push_ceph_imgs
+cd - || exit
+

--- a/ceph-container-build-push-imgs/config/JENKINS_URL
+++ b/ceph-container-build-push-imgs/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
@@ -1,0 +1,41 @@
+- job:
+    name: ceph-container-build-push-imgs
+    node: small && trusty
+    project-type: freestyle
+    defaults: global
+    display-name: 'ceph-container: build and push container images to Docker Hub'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-container
+    logrotate:
+      daysToKeep: -1
+      numToKeep: -1
+      artifactDaysToKeep: -1
+      artifactNumToKeep: -1
+
+    triggers:
+      - github
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-container.git
+          branches:
+            - master
+          browser: auto
+          basedir: "ceph-container"
+          timeout: 20
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true


### PR DESCRIPTION
After a PR is merged we trigger a build and a push the newly built
images to the Docker Hub.

Signed-off-by: Sébastien Han <seb@redhat.com>