### PR TITLE
ceph-container-build-push-imgs: use a script from ceph-container

### DIFF
--- a/ceph-container-build-push-imgs/build/build
+++ b/ceph-container-build-push-imgs/build/build
@@ -2,32 +2,5 @@
 set -e
 
 
-#############
-# FUNCTIONS #
-#############
-
-function login_docker_hub {
-  echo "Login in the Docker Hub"
-  docker login -u "$DOCKER_HUB_USERNAME" -p "$DOCKER_HUB_PASSWORD"
-}
-
-function build_ceph_imgs {
-  make build.parallel
-}
-
-function push_ceph_imgs {
-  make push
-}
-
-
-########
-# MAIN #
-########
-
-login_docker_hub
-set -x
 cd "$WORKSPACE"/ceph-container/ || exit
-build_ceph_imgs
-push_ceph_imgs
-cd - || exit
-
+bash -x contrib/build-push-ceph-container-imgs.sh


### PR DESCRIPTION
Let's execute a script in the ceph-container project instead of writting
the script here.
ceph-build does the CI so let's keep it that way.

Signed-off-by: Sébastien Han <seb@redhat.com>