### PR TITLE
ceph-volume-pr: trigger tox tests manually

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -3,49 +3,10 @@ set -ex
 env
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
-# This job is meant to be triggered from a Github Pull Request, only when the
-# job is executed in that way a few "special" variables become available. So
-# this build script tries to use those first but then it will try to figure it
-# out using Git directly so that if triggered manually it can attempt to
-# actually work.
-SHA=$ghprbActualCommit
-BRANCH=$ghprbSourceBranch
-
-
-# Find out the name of the remote branch from the Pull Request. This is otherwise not
-# available by the plugin. Without grepping for `heads` output will look like:
-#
-# 855ce630695ed9ca53c314b7e261ec3cc499787d    refs/heads/wip-volume-tests
-if [ -z "$ghprbSourceBranch" ]; then
-    BRANCH=`git ls-remote origin | grep $GIT_PREVIOUS_COMMIT | grep heads | cut -d '/' -f 3`
-    SHA=$GIT_PREVIOUS_COMMIT
-fi
-
-# sometimes, $GIT_PREVIOUS_COMMIT will not help grep from ls-remote, so we fallback
-# to looking for GIT_COMMIT (e.g. if the branch has not been rebased to be the tip)
-if [ -z "$BRANCH" ]; then
-    BRANCH=`git ls-remote origin | grep $GIT_COMMIT | grep heads | cut -d '/' -f 3`
-    SHA=$GIT_COMMIT
-fi
-
-# Finally, we verify one last time to bail if nothing really worked here to determine
-# this
-if [ -z "$BRANCH" ]; then
-    echo "Could not determine \$BRANCH var from \$ghprbSourceBranch"
-    echo "or by using \$GIT_PREVIOUS_COMMIT and \$GIT_COMMIT"
-    exit 1
-fi
-
-# if ghprbActualCommit is not available, and the previous checks were not able to determine
-# the SHA1, then the last attempt should be to try and set it to the env passed in as a parameter (GITHUB_SHA)
-SHA="${ghprbActualCommit:-$GITHUB_SHA}"
-if [ -z "$SHA" ]; then
-    echo "Could not determine \$SHA var from \$ghprbActualCommit"
-    echo "or by using \$GIT_PREVIOUS_COMMIT or \$GIT_COMMIT"
-    echo "or even looking at the \$GITHUB_SHA parameter for this job"
-    exit 1
-fi
-
+# set up variables needed for
+# githubstatus to report back to the github PR
+# if this project was started manually
+github_status_setup
 
 # TODO: at this point a `curl` to shaman is needed to verify that the repo is
 # ready to be consumed

--- a/ceph-volume-pr/build/build
+++ b/ceph-volume-pr/build/build
@@ -1,12 +1,21 @@
 #!/bin/bash
 set -ex
 
+# set up variables needed for
+# githubstatus to report back to the github PR
+# if this project was started manually
+github_status_setup
+
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "tox" )
+pkgs=( "tox" "github-status>0.0.3")
 install_python_packages "pkgs[@]"
 
 cd src/ceph-volume
 
+GITHUB_STATUS_STATE="pending" $VENV/github-status create
+
 # ceph-volume has a 3.6 environ but most machines don't have it,
 # so until then, we do them piecemeal
 $VENV/tox -v -e py27,py35,flake8
+
+GITHUB_STATUS_STATE="success" $VENV/github-status create

--- a/ceph-volume-pr/build/teardown
+++ b/ceph-volume-pr/build/teardown
@@ -1,0 +1,9 @@
+#!/bin/bash
+# There has to be a better way to do this than this script which just looks
+# for every Vagrantfile in scenarios and then just destroys whatever is left.
+
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "github-status>0.0.3" )
+install_python_packages "pkgs[@]"
+
+GITHUB_STATUS_STATE="failure" $VENV/github-status create

--- a/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
@@ -14,6 +14,20 @@
     logrotate:
       daysToKeep: 14
 
+    parameters:
+      - string:
+          name: sha1
+          description: "A pull request ID, like 'origin/pr/72/head'"
+
+      # this is injected by the ghprb plugin, and is fully optional but may help in manually triggering
+      # a job that can end up updating a PR
+      - string:
+          name: ghprbSourceBranch
+          description: "When manually triggered, and the remote PR isn't a branch in the ceph.git repo This can be specified to determine the actual branch."
+      - string:
+          name: GITHUB_SHA
+          description: "The tip (last commit) in the PR, a sha1 like 7d787849556788961155534039886aedfcdb2a88 (if set, will report status to Github)"
+
     triggers:
       - github-pull-request:
           cancel-builds-on-update: true
@@ -39,7 +53,30 @@
           wipe-workspace: true
 
     builders:
+      - inject:
+          properties-content: |
+            GITHUB_REPOSITORY="ceph/ceph"
+            GITHUB_STATUS_CONTEXT="ceph-volume tox tests"
+            GITHUB_STATUS_STARTED="running"
+            GITHUB_STATUS_SUCCESS="OK"
+            GITHUB_STATUS_FAILURE="failed"
+            GITHUB_STATUS_ERROR="completed with errors"
       - shell:
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+
+    publishers:
+      - postbuildscript:
+          script-only-if-succeeded: False
+          script-only-if-failed: True
+          builders:
+            - shell:
+                !include-raw-escape:
+                  - ../../../scripts/build_utils.sh
+                  - ../../build/teardown


### PR DESCRIPTION
This allows the ceph-volume tox tests to be run manually but still report back to an open PR with the results of the test.