### PR TITLE
Archive ceph logs when CI tests fail

### DIFF
--- a/ceph-ansible-nightly/build/teardown
+++ b/ceph-ansible-nightly/build/teardown
@@ -8,6 +8,8 @@ scenarios=$(find . | grep Vagrantfile | xargs dirname)
 
 for scenario in $scenarios; do
     cd $scenario
+    # collect all ceph logs from all test nodes
+    collect_ceph_logs all
     vagrant destroy -f
     cd -
 done

--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -147,4 +147,12 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell: !include-raw ../../build/teardown
+            - shell:
+                !include-raw-escape:
+                  - ../../../scripts/build_utils.sh
+                  - ../../build/teardown
+
+      - archive:
+          artifacts: 'logs/**'
+          allow-empty: true
+          latest-only: false

--- a/ceph-ansible-prs/build/teardown
+++ b/ceph-ansible-prs/build/teardown
@@ -8,6 +8,8 @@ scenarios=$(find . -name Vagrantfile | xargs dirname)
 
 for scenario in $scenarios; do
     pushd $scenario
+    # collect all ceph logs from all test nodes
+    collect_ceph_logs all
     vagrant destroy -f
     popd
 done

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -162,7 +162,15 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell: !include-raw ../../build/teardown
+            - shell:
+                !include-raw-escape:
+                  - ../../../scripts/build_utils.sh
+                  - ../../build/teardown
+
+      - archive:
+          artifacts: 'logs/**'
+          allow-empty: true
+          latest-only: false
 
 - job-template:
     name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
@@ -233,7 +241,15 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell: !include-raw ../../build/teardown
+            - shell:
+                !include-raw-escape:
+                  - ../../../scripts/build_utils.sh
+                  - ../../build/teardown
+
+      - archive:
+          artifacts: 'logs/**'
+          allow-empty: true
+          latest-only: false
 
 - job-template:
     name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
@@ -304,4 +320,12 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell: !include-raw ../../build/teardown
+            - shell:
+                !include-raw-escape:
+                  - ../../../scripts/build_utils.sh
+                  - ../../build/teardown
+
+      - archive:
+          artifacts: 'logs/**'
+          allow-empty: true
+          latest-only: false

--- a/ceph-ansible-scenario/build/teardown
+++ b/ceph-ansible-scenario/build/teardown
@@ -8,6 +8,8 @@ scenarios=$(find . | grep Vagrantfile | xargs dirname)
 
 for scenario in $scenarios; do
     cd $scenario
+    # collect all ceph logs from all test nodes
+    collect_ceph_logs all
     vagrant destroy -f
     cd -
 done

--- a/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
+++ b/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
@@ -57,4 +57,12 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell: !include-raw ../../build/teardown
+            - shell:
+                !include-raw:
+                  - ../../../scripts/build_utils.sh
+                  - ../../build/teardown
+
+      - archive:
+          artifacts: 'logs/**'
+          allow-empty: true
+          latest-only: false

--- a/ceph-volume-ansible-prs/build/teardown
+++ b/ceph-volume-ansible-prs/build/teardown
@@ -14,6 +14,8 @@ scenarios=$(find . | grep Vagrantfile | xargs dirname)
 
 for scenario in $scenarios; do
     cd $scenario
+    # collect all ceph logs from all test nodes
+    collect_ceph_logs all
     vagrant destroy -f
     cd -
 done

--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -125,3 +125,8 @@
                 !include-raw-escape:
                   - ../../../scripts/build_utils.sh
                   - ../../build/teardown
+
+      - archive:
+          artifacts: 'logs/**'
+          allow-empty: true
+          latest-only: false

--- a/ceph-volume-nightly/build/teardown
+++ b/ceph-volume-nightly/build/teardown
@@ -9,6 +9,8 @@ scenarios=$(find . | grep Vagrantfile | xargs dirname)
 
 for scenario in $scenarios; do
     cd $scenario
+    # collect all ceph logs from all test nodes
+    collect_ceph_logs all
     vagrant destroy -f
     cd -
 done

--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -97,5 +97,11 @@
                 !include-raw-escape:
                   - ../../../scripts/build_utils.sh
                   - ../../build/teardown
+
+      - archive:
+          artifacts: 'logs/**'
+          allow-empty: true
+          latest-only: false
+
       - email:
           recipients: aschoen@redhat.com adeza@redhat.com

--- a/ceph-volume-scenario/build/teardown
+++ b/ceph-volume-scenario/build/teardown
@@ -7,23 +7,10 @@ cd $WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
 
 scenarios=$(find . | grep Vagrantfile | xargs dirname)
 
-mkdir -p $WORKSPACE/logs
-
-pkgs=( "ansible" )
-install_python_packages "pkgs[@]"
-
-# in scripts/build_utils.yml
-# writes out the playbook that is used to
-# collect logs from testing vms
-write_collect_logs_playbook
-
 for scenario in $scenarios; do
     cd $scenario
-    if [ -f "./vagrant_ssh_config" ]; then
-        export ANSIBLE_SSH_ARGS='-F ./vagrant_ssh_config'
-        export ANSIBLE_STDOUT_CALLBACK='debug'
-        $VENV/ansible-playbook -vv -i hosts --limit osds --extra-vars "archive_path=$WORKSPACE/logs" $WORKSPACE/collect-logs.yml
-    fi
+    # collect all ceph logs from all test nodes
+    collect_ceph_logs all
     vagrant destroy -f
     cd -
 done

--- a/ceph-volume-scenario/build/teardown
+++ b/ceph-volume-scenario/build/teardown
@@ -12,12 +12,16 @@ mkdir -p $WORKSPACE/logs
 pkgs=( "ansible" )
 install_python_packages "pkgs[@]"
 
+# in scripts/build_utils.yml
+# writes out the playbook that is used to
+# collect logs from testing vms
+write_collect_logs_playbook
+
 for scenario in $scenarios; do
     cd $scenario
     if [ -f "./vagrant_ssh_config" ]; then
         export ANSIBLE_SSH_ARGS='-F ./vagrant_ssh_config'
-        $VENV/ansible -i hosts -b -m fetch -a "src=/var/log/ceph/ceph-volume.log dest=$WORKSPACE/logs/ceph-volume.log flat=yes fail_on_missing=no" osds
-        $VENV/ansible -i hosts -b -m fetch -a "src=/var/log/ceph/ceph-volume-systemd.log dest=$WORKSPACE/logs/ceph-volume-systemd.log flat=yes fail_on_missing=no" osds
+        $VENV/ansible-playbook -i hosts --limit osds --extra-vars "archive_path=$WORKSPACE/logs" $WORKSPACE/collect-logs.yml
     fi
     vagrant destroy -f
     cd -

--- a/ceph-volume-scenario/build/teardown
+++ b/ceph-volume-scenario/build/teardown
@@ -7,8 +7,18 @@ cd $WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
 
 scenarios=$(find . | grep Vagrantfile | xargs dirname)
 
+mkdir -p $WORKSPACE/logs
+
+pkgs=( "ansible" )
+install_python_packages "pkgs[@]"
+
 for scenario in $scenarios; do
     cd $scenario
+    if [ -f "./vagrant_ssh_config" ]; then
+        export ANSIBLE_SSH_ARGS='-F ./vagrant_ssh_config'
+        $VENV/ansible -i hosts -b -m fetch -a "src=/var/log/ceph/ceph-volume.log dest=$WORKSPACE/logs/ceph-volume.log flat=yes fail_on_missing=no" osds
+        $VENV/ansible -i hosts -b -m fetch -a "src=/var/log/ceph/ceph-volume-systemd.log dest=$WORKSPACE/logs/ceph-volume-systemd.log flat=yes fail_on_missing=no" osds
+    fi
     vagrant destroy -f
     cd -
 done

--- a/ceph-volume-scenario/build/teardown
+++ b/ceph-volume-scenario/build/teardown
@@ -21,7 +21,8 @@ for scenario in $scenarios; do
     cd $scenario
     if [ -f "./vagrant_ssh_config" ]; then
         export ANSIBLE_SSH_ARGS='-F ./vagrant_ssh_config'
-        $VENV/ansible-playbook -i hosts --limit osds --extra-vars "archive_path=$WORKSPACE/logs" $WORKSPACE/collect-logs.yml
+        export ANSIBLE_STDOUT_CALLBACK='debug'
+        $VENV/ansible-playbook -vv -i hosts --limit osds --extra-vars "archive_path=$WORKSPACE/logs" $WORKSPACE/collect-logs.yml
     fi
     vagrant destroy -f
     cd -

--- a/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
+++ b/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
@@ -68,5 +68,5 @@
 
       - archive:
           artifacts: 'logs/**'
-          allow-empty: false
+          allow-empty: true
           latest-only: false

--- a/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
+++ b/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
@@ -61,4 +61,12 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell: !include-raw ../../build/teardown
+            - shell:
+                !include-raw:
+                  - ../../../scripts/build_utils.sh
+                  - ../../build/teardown
+
+      - archive:
+          artifacts: 'logs/**'
+          allow-empty: false
+          latest-only: false

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -690,7 +690,7 @@ write_collect_logs_playbook() {
     - name: collect ceph logs
       fetch:
         src: "{{ item }}"
-        dest: "{{ archive_path }}"
+        dest: "{{ archive_path }}/{{ inventory_hostname }}/"
         fail_on_missing: no
         flat: yes
       failed_when: false

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -684,7 +684,7 @@ write_collect_logs_playbook() {
   become: yes
   tasks:
     - name: find ceph logs
-      command: find /var/log/ceph -name "ceph*.log"
+      command: find /var/log/ceph -name "{{ cluster|default('ceph') }}*.log"
       register: ceph_logs
 
     - name: collect ceph logs

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -677,3 +677,30 @@ github_status_setup() {
     fi
 
 }
+
+write_collect_logs_playbook() {
+    cat > $WORKSPACE/collect-logs.yml << EOF
+- hosts: all
+  become: yes
+  tasks:
+    - name: collect ceph-volume logs
+      fetch:
+        src: "{{ item }}"
+        dest: "{{ archive_path }}"
+        fail_on_missing: no
+        flat: yes
+      failed_when: false
+      with_fileglob:
+        - "/var/log/ceph-volume*"
+
+    - name: collect ceph-osd logs
+      fetch:
+        src: "{{ item }}"
+        dest: "{{ archive_path }}"
+        fail_on_missing: no
+        flat: yes
+      failed_when: false
+      with_fileglob:
+        - "/var/log/ceph-osd*"
+EOF
+}

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -683,24 +683,17 @@ write_collect_logs_playbook() {
 - hosts: all
   become: yes
   tasks:
-    - name: collect ceph-volume logs
-      fetch:
-        src: "{{ item }}"
-        dest: "{{ archive_path }}"
-        fail_on_missing: no
-        flat: yes
-      failed_when: false
-      with_fileglob:
-        - "/var/log/ceph-volume*"
+    - name: find ceph logs
+      command: find /var/log/ceph -name "ceph*.log"
+      register: ceph_logs
 
-    - name: collect ceph-osd logs
+    - name: collect ceph logs
       fetch:
         src: "{{ item }}"
         dest: "{{ archive_path }}"
         fail_on_missing: no
         flat: yes
       failed_when: false
-      with_fileglob:
-        - "/var/log/ceph-osd*"
+      with_items: "{{ ceph_logs.stdout_lines }}"
 EOF
 }

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -697,3 +697,25 @@ write_collect_logs_playbook() {
       with_items: "{{ ceph_logs.stdout_lines }}"
 EOF
 }
+
+collect_ceph_logs() {
+    # this is meant to be run in a testing scenario directory
+    # with running vagrant vms. the ansible playbook will connect
+    # to your test nodes and fetch any ceph logs that are present
+    # in /var/log/ceph and store them on the jenkins slave.
+    # these logs can then be archived using the JJB archive publisher
+    limit=$1
+
+    if [ -f "./vagrant_ssh_config" ]; then
+        mkdir -p $WORKSPACE/logs
+
+        write_collect_logs_playbook
+
+        pkgs=( "ansible" )
+        install_python_packages "pkgs[@]"
+
+        export ANSIBLE_SSH_ARGS='-F ./vagrant_ssh_config'
+        export ANSIBLE_STDOUT_CALLBACK='debug'
+        $VENV/ansible-playbook -vv -i hosts --limit $limit --extra-vars "archive_path=$WORKSPACE/logs" $WORKSPACE/collect-logs.yml
+    fi
+}


### PR DESCRIPTION
The following jobs will now collect ceph logs from all testing vms and archives them in jenkins when testing fails:

- ceph-volume-scenario
- ceph-volume-ansible-prs
- ceph-volume-nightly
- ceph-ansible-prs
- ceph-ansible-scenario
- ceph-ansible-nightly

You can access these logs in the Jenkins UI. Logs will be found under the 'build artifacts' section, you can see them on this job as an example: https://jenkins.ceph.com/job/ceph-volume-scenario/116/