### PR TITLE
migrate from logrotate to build-discarder

### DIFF
--- a/calamari-clients-setup/config/definitions/calamari-clients-setup.yml
+++ b/calamari-clients-setup/config/definitions/calamari-clients-setup.yml
@@ -5,15 +5,15 @@
     # FIXME: unpin when this gets ported over
     node: small && centos7
     display-name: 'calamari-clients-setup'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
     block-downstream: false
     block-upstream: false
     concurrent: true
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/calamari-clients
 

--- a/calamari-clients/config/definitions/calamari-clients.yml
+++ b/calamari-clients/config/definitions/calamari-clients.yml
@@ -5,14 +5,14 @@
     defaults: global
     concurrent: true
     display-name: 'calamari-clients'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: 25
-      artifactNumToKeep: 25
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: 25
+          artifact-num-to-keep: 25
       - github:
           url: https://github.com/ceph/calamari-clients
 

--- a/ceph-ansible-docs-prs/config/definitions/ceph-ansible-docs-prs.yml
+++ b/ceph-ansible-docs-prs/config/definitions/ceph-ansible-docs-prs.yml
@@ -9,13 +9,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-ansible
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-ansible-docs/config/definitions/ceph-ansible-docs.yml
+++ b/ceph-ansible-docs/config/definitions/ceph-ansible-docs.yml
@@ -9,13 +9,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-ansible
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-ansible-galaxy/config/definitions/ceph-ansible-galaxy.yml
+++ b/ceph-ansible-galaxy/config/definitions/ceph-ansible-galaxy.yml
@@ -9,13 +9,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-ansible
-    logrotate:
-      daysToKeep: -1
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -105,11 +105,11 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph-ansible
-    logrotate:
-      daysToKeep: 90
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
 
     parameters:
       - string:

--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -147,10 +147,11 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell:
-                !include-raw-escape:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/teardown
+            - build-steps:
+                - shell:
+                    !include-raw-escape:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown
 
       - archive:
           artifacts: 'logs/**'

--- a/ceph-ansible-pr-syntax-check/config/definitions/ceph-ansible-pr-syntax-check.yml
+++ b/ceph-ansible-pr-syntax-check/config/definitions/ceph-ansible-pr-syntax-check.yml
@@ -24,13 +24,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-ansible
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -107,11 +107,11 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph-ansible
-    logrotate:
-      daysToKeep: 90
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
 
     parameters:
       - string:
@@ -186,11 +186,11 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph-ansible
-    logrotate:
-      daysToKeep: 90
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
+      - build-discarder:
+        days-to-keep: 90
+        num-to-keep: -1
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: -1
 
     parameters:
       - string:
@@ -265,11 +265,11 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph-ansible
-    logrotate:
-      daysToKeep: 90
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
 
     parameters:
       - string:

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -162,10 +162,11 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell:
-                !include-raw-escape:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/teardown
+            - build-steps:
+                - shell:
+                    !include-raw-escape:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown
 
       - archive:
           artifacts: 'logs/**'
@@ -187,10 +188,10 @@
       - github:
           url: https://github.com/ceph/ceph-ansible
       - build-discarder:
-        days-to-keep: 90
-        num-to-keep: -1
-        artifact-days-to-keep: -1
-        artifact-num-to-keep: -1
+          days-to-keep: 90
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
 
     parameters:
       - string:
@@ -241,10 +242,11 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell:
-                !include-raw-escape:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/teardown
+            - build-steps:
+                - shell:
+                    !include-raw-escape:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown
 
       - archive:
           artifacts: 'logs/**'
@@ -320,10 +322,11 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell:
-                !include-raw-escape:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/teardown
+            - build-steps:
+                - shell:
+                    !include-raw-escape:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown
 
       - archive:
           artifacts: 'logs/**'

--- a/ceph-ansible-rpm/config/definitions/ceph-ansible-rpm.yml
+++ b/ceph-ansible-rpm/config/definitions/ceph-ansible-rpm.yml
@@ -12,14 +12,14 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-ansible
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
+++ b/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
@@ -10,13 +10,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-ansible
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
+++ b/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
@@ -57,10 +57,11 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell:
-                !include-raw:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/teardown
+            - build-steps:
+                - shell:
+                    !include-raw:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown
 
       - archive:
           artifacts: 'logs/**'

--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -10,13 +10,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-build
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -83,10 +83,11 @@
           script-only-if-failed: True
           script-only-if-succeeded: False
           builders:
-            - inject:
-                properties-file: ${WORKSPACE}/build_info
-            - shell:
-                !include-raw:
+            - build-steps:
+                - inject:
+                    properties-file: ${WORKSPACE}/build_info
+                - shell:
+                    !include-raw:
                   - ../../../scripts/build_utils.sh
                   - ../../build/failure
 

--- a/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
@@ -9,13 +9,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-container
-    logrotate:
-      daysToKeep: -1
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-container-flake8/config/definitions/ceph-container-flake8.yml
+++ b/ceph-container-flake8/config/definitions/ceph-container-flake8.yml
@@ -18,13 +18,13 @@
     defaults: global
     display-name: 'ceph-container-flake8'
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-container/
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-container-lint/config/definitions/ceph-container-lint.yml
+++ b/ceph-container-lint/config/definitions/ceph-container-lint.yml
@@ -18,13 +18,13 @@
     defaults: global
     display-name: 'ceph-container-lint'
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-container/
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
+++ b/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
@@ -66,4 +66,5 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell: !include-raw ../../build/teardown
+            - build-steps:
+                - shell: !include-raw ../../build/teardown

--- a/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
+++ b/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
@@ -29,11 +29,11 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph-container
-    logrotate:
-      daysToKeep: -1
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
 
     parameters:
       - string:

--- a/ceph-container-prs/config/definitions/ceph-container-prs.yml
+++ b/ceph-container-prs/config/definitions/ceph-container-prs.yml
@@ -83,4 +83,5 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell: !include-raw ../../build/teardown
+            - build-steps:
+                - shell: !include-raw ../../build/teardown

--- a/ceph-container-prs/config/definitions/ceph-container-prs.yml
+++ b/ceph-container-prs/config/definitions/ceph-container-prs.yml
@@ -31,11 +31,11 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph-container
-    logrotate:
-      daysToKeep: 15
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
 
     parameters:
       - string:

--- a/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
+++ b/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
@@ -9,13 +9,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-deploy
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -39,13 +39,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-deploy/
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-deploy-tag/config/definitions/ceph-tag.yml
+++ b/ceph-deploy-tag/config/definitions/ceph-tag.yml
@@ -14,14 +14,14 @@
     description: "This job clones ceph-deploy and sets the right version from the tag, pushing back to ceph-deploy.git"
     display-name: 'ceph-deploy-tag'
     node: 'trusty&&small'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-deploy
 

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -91,12 +91,13 @@
           script-only-if-failed: True
           script-only-if-succeeded: False
           builders:
-            - inject:
-                properties-file: ${WORKSPACE}/build_info
-            - shell:
-                !include-raw:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/failure
+            - build-steps:
+                - inject:
+                    properties-file: ${WORKSPACE}/build_info
+                - shell:
+                    !include-raw:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/failure
 
     wrappers:
       - inject-passwords:

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -91,12 +91,13 @@
           script-only-if-failed: True
           script-only-if-succeeded: False
           builders:
-            - inject:
-                properties-file: ${WORKSPACE}/build_info
-            - shell:
-                !include-raw:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/failure
+            - build-steps:
+                - inject:
+                    properties-file: ${WORKSPACE}/build_info
+                - shell:
+                    !include-raw:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/failure
 
     wrappers:
       - inject-passwords:

--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -48,10 +48,11 @@
           script-only-if-failed: True
           script-only-if-succeeded: False
           builders:
-            - shell:
-                !include-raw:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/failure
+            - build-steps:
+                - shell:
+                    !include-raw:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/failure
 
     wrappers:
       - inject-passwords:

--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -5,15 +5,15 @@
     # FIXME: unpin when this gets ported over
     node: huge && trusty && x86_64
     display-name: 'ceph-dev-new-setup'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
     block-downstream: false
     block-upstream: false
     concurrent: true
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-ci
 

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -7,14 +7,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-ci
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -6,14 +6,14 @@
     defaults: global
     concurrent: true
     display-name: 'ceph-dev-new'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: 25
-      artifactNumToKeep: 25
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: 25
+          artifact-num-to-keep: 25
       - github:
           url: https://github.com/ceph/ceph-ci
 

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -48,10 +48,11 @@
           script-only-if-failed: True
           script-only-if-succeeded: False
           builders:
-            - shell:
-                !include-raw:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/failure
+            - build-steps:
+                - shell:
+                    !include-raw:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/failure
 
     wrappers:
       - inject-passwords:

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -5,15 +5,15 @@
     # FIXME: unpin when this gets ported over
     node: huge && trusty && x86_64
     display-name: 'ceph-dev-setup'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
     block-downstream: false
     block-upstream: false
     concurrent: true
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph
 
@@ -46,7 +46,7 @@
 
       - postbuildscript:
           script-only-if-failed: True
-          script-only-if-succeeded: False 
+          script-only-if-succeeded: False
           builders:
             - shell:
                 !include-raw:

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -7,14 +7,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -6,14 +6,14 @@
     defaults: global
     concurrent: true
     display-name: 'ceph-dev'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: 25
-      artifactNumToKeep: 25
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: 25
+          artifact-num-to-keep: 25
       - github:
           url: https://github.com/ceph/ceph
 

--- a/ceph-docs/config/definitions/ceph-docs.yml
+++ b/ceph-docs/config/definitions/ceph-docs.yml
@@ -7,14 +7,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-iscsi-cli-trigger/config/definitions/ceph-iscsi-cli-trigger.yml
+++ b/ceph-iscsi-cli-trigger/config/definitions/ceph-iscsi-cli-trigger.yml
@@ -7,14 +7,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-iscsi-cli
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-iscsi-config-trigger/config/definitions/ceph-iscsi-config-trigger.yml
+++ b/ceph-iscsi-config-trigger/config/definitions/ceph-iscsi-config-trigger.yml
@@ -7,14 +7,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-iscsi-config
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-iscsi-tools-trigger/config/definitions/ceph-iscsi-tools-trigger.yml
+++ b/ceph-iscsi-tools-trigger/config/definitions/ceph-iscsi-tools-trigger.yml
@@ -7,14 +7,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-iscsi-tools
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-medic-docs/config/definitions/ceph-medic-docs.yml
+++ b/ceph-medic-docs/config/definitions/ceph-medic-docs.yml
@@ -9,13 +9,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-medic
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-medic-pull-requests/config/definitions/ceph-medic-pull-requests.yml
+++ b/ceph-medic-pull-requests/config/definitions/ceph-medic-pull-requests.yml
@@ -1,5 +1,5 @@
 - scm:
-    name: ceph-medic 
+    name: ceph-medic
     scm:
       - git:
           url: https://github.com/ceph/ceph-medic
@@ -25,13 +25,13 @@
     quiet-period: 5
     retry-count: 3
 
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: 15
-      artifactNumToKeep: 15
 
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: 15
+          artifact-num-to-keep: 15
       - github:
           url: https://github.com/ceph/ceph-medic/
 

--- a/ceph-medic-rpm/config/definitions/ceph-medic-rpm.yml
+++ b/ceph-medic-rpm/config/definitions/ceph-medic-rpm.yml
@@ -12,14 +12,14 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-medic
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/ceph-medic-tests/config/definitions/ceph-medic-tests.yml
+++ b/ceph-medic-tests/config/definitions/ceph-medic-tests.yml
@@ -7,7 +7,7 @@
 
 - job-template:
     name: 'ceph-medic-tests-{scenario}'
-    node: vagrant && libvirt 
+    node: vagrant && libvirt
     project-type: freestyle
     defaults: global
     display-name: 'ceph-medic: Tests [{scenario}]'
@@ -18,11 +18,11 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph-medic
-    logrotate:
-      daysToKeep: -1
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
 
     parameters:
       - string:
@@ -42,7 +42,7 @@
       - git:
           url: https://github.com/ceph/ceph-medic.git
           branches:
-            - $CEPH_MEDIC_BRANCH 
+            - $CEPH_MEDIC_BRANCH
           browser: auto
           timeout: 20
 

--- a/ceph-pr-arm-trigger/config/definitions/ceph-pr-arm-trigger.yml
+++ b/ceph-pr-arm-trigger/config/definitions/ceph-pr-arm-trigger.yml
@@ -10,14 +10,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github-pull-request:

--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -38,13 +38,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph/
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -11,9 +11,10 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph
+      - build-discarder:
+          days-to-keep: 14
+
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 14
 
     triggers:
       - github-pull-request:

--- a/ceph-pr-render-docs/config/definitions/ceph-pr-render-docs.yml
+++ b/ceph-pr-render-docs/config/definitions/ceph-pr-render-docs.yml
@@ -10,9 +10,9 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph
+      - build-discarder:
+          days-to-keep: 14
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 14
 
     triggers:
       - github-pull-request:

--- a/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
@@ -10,13 +10,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph/
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -10,13 +10,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 300
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph/
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 300
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -58,4 +58,5 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell: "sudo reboot"
+            - build-steps:
+                - shell: "sudo reboot"

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -10,13 +10,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-qa-suite/
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -48,10 +48,11 @@
           script-only-if-failed: True
           script-only-if-succeeded: False
           builders:
-            - shell:
-                !include-raw:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/failure
+            - build-steps:
+                - shell:
+                    !include-raw:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/failure
 
     wrappers:
       - inject-passwords:

--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -5,15 +5,15 @@
     # FIXME: unpin when this gets ported over
     node: huge && trusty && x86_64
     display-name: 'ceph-setup'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
     block-downstream: false
     block-upstream: false
     concurrent: true
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph
 

--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -16,14 +16,14 @@
     node: trusty
     description: "This job clones from upstream Ceph, sets the right version from the tag and pushes changes to ceph-releases"
     display-name: 'ceph-tag'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph
 

--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -121,10 +121,11 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell:
-                !include-raw-escape:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/teardown
+            - build-steps:
+                - shell:
+                    !include-raw-escape:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown
 
       - archive:
           artifacts: 'logs/**'

--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -47,9 +47,9 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph
+      - build-discarder:
+          days-to-keep: 30
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 30
 
     parameters:
       - string:

--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -53,9 +53,9 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph
+      - build-discarder:
+          days-to-keep: 30
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 30
 
     triggers:
       - timed: '@daily'

--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -93,10 +93,11 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell:
-                !include-raw-escape:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/teardown
+            - build-steps:
+                - shell:
+                    !include-raw-escape:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown
 
       - archive:
           artifacts: 'logs/**'

--- a/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
@@ -76,7 +76,8 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell:
-                !include-raw-escape:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/teardown
+            - build-steps:
+                - shell:
+                    !include-raw-escape:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown

--- a/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
@@ -10,9 +10,9 @@
     properties:
       - github:
           url: https://github.com/ceph/ceph
+      - build-discarder:
+          days-to-keep: 14
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 14
 
     parameters:
       - string:

--- a/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
+++ b/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
@@ -61,10 +61,11 @@
           script-only-if-succeeded: False
           script-only-if-failed: True
           builders:
-            - shell:
-                !include-raw:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/teardown
+            - build-steps:
+                - shell:
+                    !include-raw:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown
 
       - archive:
           artifacts: 'logs/**'

--- a/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
+++ b/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
@@ -10,17 +10,17 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:
-          name: SUBCOMMAND 
+          name: SUBCOMMAND
           description: "The subcommand in ceph-volume we are testing. (lvm or simple)"
           default: "lvm"
       - string:

--- a/ceph-volume-test/config/definitions/ceph-volume-test.yml
+++ b/ceph-volume-test/config/definitions/ceph-volume-test.yml
@@ -1,18 +1,18 @@
 - job:
-    name: "ceph-volume-test" 
+    name: "ceph-volume-test"
     description: 'This job will trigger all ceph-volume functional tests given a branch and sha1.'
     project-type: multijob
     defaults: global
     display-name: 'ceph-volume functional test suite'
-    logrotate:
-      daysToKeep: 90
-      numToKeep: 25
-      artifactDaysToKeep: 25
-      artifactNumToKeep: 25
     block-downstream: false
     block-upstream: false
     concurrent: true
     properties:
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: 25
+          artifact-days-to-keep: 25
+          artifact-num-to-keep: 25
       - github:
           url: https://github.com/ceph/ceph
 

--- a/ceph/config/definitions/ceph.yml
+++ b/ceph/config/definitions/ceph.yml
@@ -4,15 +4,15 @@
     project-type: multijob
     defaults: global
     display-name: 'ceph'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: 25
-      artifactNumToKeep: 25
     block-downstream: false
     block-upstream: false
     concurrent: true
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: 25
+          artifact-num-to-keep: 25
       - github:
           url: https://github.com/ceph/ceph
 

--- a/cephmetrics-pull-requests/config/definitions/cephmetrics-pull-requests.yml
+++ b/cephmetrics-pull-requests/config/definitions/cephmetrics-pull-requests.yml
@@ -10,13 +10,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/cephmetrics/
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/chacra-pull-requests/config/definitions/chacra-pull-requests.yml
+++ b/chacra-pull-requests/config/definitions/chacra-pull-requests.yml
@@ -38,13 +38,13 @@
     quiet-period: 5
     retry-count: 3
 
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: 15
-      artifactNumToKeep: 15
 
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: 15
+          artifact-num-to-keep: 15
       - github:
           url: https://github.com/ceph/chacra/
 

--- a/diamond-setup/config/definitions/diamond-setup.yml
+++ b/diamond-setup/config/definitions/diamond-setup.yml
@@ -5,15 +5,15 @@
     # FIXME: unpin when this gets ported over
     node: small && trusty
     display-name: 'diamond-setup'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
     block-downstream: false
     block-upstream: false
     concurrent: true
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/Diamond
 

--- a/diamond/config/definitions/diamond.yml
+++ b/diamond/config/definitions/diamond.yml
@@ -5,14 +5,14 @@
     defaults: global
     concurrent: true
     display-name: 'diamond'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: 25
-      artifactNumToKeep: 25
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: 25
+          artifact-num-to-keep: 25
       - github:
           url: https://github.com/ceph/Diamond
 

--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -47,6 +47,7 @@ If this is checked, JJB will wipe out its cache and force each job to align with
     publishers:
       - postbuildscript:
           builders:
-            - shell: 'rm $HOME/.jenkins_jobs.*.ini'
+            - build-steps:
+                - shell: 'rm $HOME/.jenkins_jobs.*.ini'
         script-only-if-succeeded: false
         script-only-if-failed: false

--- a/kernel-trigger/config/definitions/kernel-trigger.yml
+++ b/kernel-trigger/config/definitions/kernel-trigger.yml
@@ -7,14 +7,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-client
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/lab-cop/config/definitions/lab-cop.yml
+++ b/lab-cop/config/definitions/lab-cop.yml
@@ -3,11 +3,12 @@
     node: small && xenial
     defaults: global
     display-name: 'lab-cop'
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
 
     builders:
       - shell:

--- a/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
+++ b/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
@@ -8,13 +8,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/alfredodeza/merfi/
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/mita-deploy/config/definitions/mita-deploy.yml
+++ b/mita-deploy/config/definitions/mita-deploy.yml
@@ -15,14 +15,14 @@
     node: master
     description: "This job clones mita and deploys it to its production server based on the BRANCH value"
     display-name: 'mita-deploy'
-    logrotate:
-      daysToKeep: -1
-      numToKeep: 25
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/mita
 

--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -169,14 +169,15 @@ If this is checked, then the binaries will be built and pushed to chacra even if
     publishers:
       - postbuildscript:
           script-only-if-failed: True
-          script-only-if-succeeded: False 
+          script-only-if-succeeded: False
           builders:
-            - inject:
-                properties-file: ${WORKSPACE}/build_info
-            - shell:
-                !include-raw:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/failure
+            - build-steps:
+                - inject:
+                    properties-file: ${WORKSPACE}/build_info
+                - shell:
+                    !include-raw:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/failure
 
     wrappers:
       - inject-passwords:

--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -145,14 +145,16 @@ If this is checked, then the binaries will be built and pushed to chacra even if
     publishers:
       - postbuildscript:
           script-only-if-failed: True
-          script-only-if-succeeded: False 
+          script-only-if-succeeded: False
           builders:
-            - inject:
-                properties-file: ${WORKSPACE}/build_info
-            - shell:
-                !include-raw:
-                  - ../../../scripts/build_utils.sh
-                  - ../../build/failure
+            - build-steps:
+                - inject:
+                    properties-file: ${WORKSPACE}/build_info
+
+                - shell:
+                    !include-raw:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/failure
 
     wrappers:
       - inject-passwords:

--- a/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
+++ b/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
@@ -38,13 +38,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/radosgw-agent
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:

--- a/rtslib-fb-trigger/config/definitions/rtslib-fb-trigger.yml
+++ b/rtslib-fb-trigger/config/definitions/rtslib-fb-trigger.yml
@@ -7,14 +7,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/rtslib-fb
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/samba-trigger/config/definitions/samba-trigger.yml
+++ b/samba-trigger/config/definitions/samba-trigger.yml
@@ -7,14 +7,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/samba
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/samba/config/definitions/samba.yml
+++ b/samba/config/definitions/samba.yml
@@ -116,4 +116,5 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           script-only-if-succeeded: False
           script-only-if-failed: False
           builders:
-            - shell: "sudo rm -f /etc/apt/sources.list.d/shaman.list /etc/yum.repos.d/shaman.repo"
+            - build-steps:
+                - shell: "sudo rm -f /etc/apt/sources.list.d/shaman.list /etc/yum.repos.d/shaman.repo"

--- a/sepia-fog-images/config/definitions/sepia-fog-images.yml
+++ b/sepia-fog-images/config/definitions/sepia-fog-images.yml
@@ -8,11 +8,12 @@
     quiet-period: 0
     block-downstream: false
     block-upstream: false
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
 
     parameters:
       - string:

--- a/sepia-fog-images/config/definitions/sepia-fog-images.yml
+++ b/sepia-fog-images/config/definitions/sepia-fog-images.yml
@@ -35,9 +35,10 @@
           script-only-if-failed: True
           script-only-if-succeeded: False
           builders:
-            - shell:
-                !include-raw:
-                  - ../../build/failure
+            - build-steps:
+                - shell:
+                    !include-raw:
+                      - ../../build/failure
 
     wrappers:
       - mask-passwords:

--- a/shaman-pull-requests/config/definitions/shaman-pull-requests.yml
+++ b/shaman-pull-requests/config/definitions/shaman-pull-requests.yml
@@ -1,5 +1,5 @@
 - scm:
-    name: shaman 
+    name: shaman
     scm:
       - git:
           url: https://github.com/ceph/shaman
@@ -38,13 +38,13 @@
     quiet-period: 5
     retry-count: 3
 
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: 15
-      artifactNumToKeep: 15
 
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: 15
+          artifact-num-to-keep: 15
       - github:
           url: https://github.com/ceph/shaman/
 
@@ -68,7 +68,7 @@
           auto-close-on-fail: false
 
     scm:
-      - shaman 
+      - shaman
       - ceph-build
 
     builders:

--- a/tcmu-runner-trigger/config/definitions/tcmu-runner-trigger.yml
+++ b/tcmu-runner-trigger/config/definitions/tcmu-runner-trigger.yml
@@ -7,14 +7,14 @@
     block-downstream: false
     block-upstream: false
     properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/tcmu-runner
     discard-old-builds: true
-    logrotate:
-      daysToKeep: 1
-      numToKeep: 10
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/teuthology-docs/config/definitions/teuthology-docs.yml
+++ b/teuthology-docs/config/definitions/teuthology-docs.yml
@@ -9,13 +9,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/teuthology
-    logrotate:
-      daysToKeep: -1
-      numToKeep: -1
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     triggers:
       - github

--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -10,13 +10,13 @@
     block-upstream: false
     retry-count: 3
     properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/teuthology/
-    logrotate:
-      daysToKeep: 15
-      numToKeep: 30
-      artifactDaysToKeep: -1
-      artifactNumToKeep: -1
 
     parameters:
       - string:


### PR DESCRIPTION
build-discarder has been deprecated for a while and it is pervasive in
all jobs. Jenkins will stop supporting this as well as Jenkins Job
Builder

Job description that notes deprecation: https://docs.openstack.org/infra/jenkins-job-builder/definition.html#job

build-discarder documentation: https://docs.openstack.org/infra/jenkins-job-builder/properties.html#properties.build-discarder