### PR TITLE
ceph-container-build-push-imgs: use a bigger machine to build images

### DIFF
--- a/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-container-build-push-imgs
-    node: small && trusty
+    node: huge && trusty && x86_64
     project-type: freestyle
     defaults: global
     display-name: 'ceph-container: build and push container images to Docker Hub'


### PR DESCRIPTION
We want to parallelise the build image process. Currently it takes 40min
to build 8 images, we hope to reduce this by 8 with this new flavor.

Signed-off-by: Sébastien Han <seb@redhat.com>