### PR TITLE
jenkins-job-builder: Unpin JJB version

### DIFF
--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -9,7 +9,7 @@
 set -ex
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "jenkins-job-builder==2.0.0.0b2" )
+pkgs=( "jenkins-job-builder==2.0.3" )
 install_python_packages "pkgs[@]"
 
 # Wipe out JJB's cache if $FORCE is set.


### PR DESCRIPTION
It was pinned to a beta release in https://github.com/ceph/ceph-build/commit/4f10012571b120e01854fae49be4d43f382787f1 so we could take advantage of an option that wasn't available in the stable version.

It's now in the stable version so we can pin to latest stable.

Signed-off-by: David Galloway <dgallowa@redhat.com>