### PR TITLE
ceph-{ansible,container}-prs: Fix skip-build-phrase

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -124,7 +124,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          skip-build-phrase: '^jenkins do not test.*'
+          skip-build-phrase: '^jenkins do not test.*|.*\[skip\W+ci\].*'
           trigger-phrase: '^jenkins test oldstable {release}-{ansible_version}-{scenario}|jenkins test oldstable.*'
           only-trigger-phrase: true
           github-hooks: true
@@ -206,7 +206,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          skip-build-phrase: '^jenkins do not test.*'
+          skip-build-phrase: '^jenkins do not test.*|.*\[skip\W+ci\].*'
           trigger-phrase: '^jenkins test {release}-{ansible_version}-{scenario}|jenkins test all.*'
           only-trigger-phrase: false
           github-hooks: true
@@ -288,7 +288,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          skip-build-phrase: '^jenkins do not test.*'
+          skip-build-phrase: '^jenkins do not test.*|.*\[skip\W+ci\].*'
           trigger-phrase: '^jenkins test {release}-{ansible_version}-{scenario}|jenkins test all.*'
           only-trigger-phrase: true
           github-hooks: true

--- a/ceph-container-prs/config/definitions/ceph-container-prs.yml
+++ b/ceph-container-prs/config/definitions/ceph-container-prs.yml
@@ -48,6 +48,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
+          skip-build-phrase: '^jenkins do not test.*|.*\[skip\W+ci\].*'
           trigger-phrase: 'jenkins test ceph_ansible-{ceph-version}-{os}-{test}'
           only-trigger-phrase: false
           github-hooks: true


### PR DESCRIPTION
I think JJB was previously not sending 'jenkins do not test' as the skip
build phrase so the plugin default 'skip ci' was being used and
working.  Since we recently updated JJB, I'm guessing 'jenkins do not
test' *is* being configured so 'skip ci' is no longer working.  This
commit should allow either phrase to be used.

Signed-off-by: David Galloway <dgallowa@redhat.com>