### PR TITLE
ceph-{ansible,container}-prs: Fix skip-build-phrase regex

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -124,7 +124,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          skip-build-phrase: '^jenkins do not test.*|.*\[skip\W+ci\].*'
+          skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
           trigger-phrase: '^jenkins test oldstable {release}-{ansible_version}-{scenario}|jenkins test oldstable.*'
           only-trigger-phrase: true
           github-hooks: true
@@ -206,7 +206,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          skip-build-phrase: '^jenkins do not test.*|.*\[skip\W+ci\].*'
+          skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
           trigger-phrase: '^jenkins test {release}-{ansible_version}-{scenario}|jenkins test all.*'
           only-trigger-phrase: false
           github-hooks: true
@@ -288,7 +288,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          skip-build-phrase: '^jenkins do not test.*|.*\[skip\W+ci\].*'
+          skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
           trigger-phrase: '^jenkins test {release}-{ansible_version}-{scenario}|jenkins test all.*'
           only-trigger-phrase: true
           github-hooks: true

--- a/ceph-container-prs/config/definitions/ceph-container-prs.yml
+++ b/ceph-container-prs/config/definitions/ceph-container-prs.yml
@@ -48,7 +48,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          skip-build-phrase: '^jenkins do not test.*|.*\[skip\W+ci\].*'
+          skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
           trigger-phrase: 'jenkins test ceph_ansible-{ceph-version}-{os}-{test}'
           only-trigger-phrase: false
           github-hooks: true


### PR DESCRIPTION
JJB converts the string to lowercase so the \W was getting converted to
\w so the actual phrase wasn't being detected.  We can just use a space
instead of trying to match any character.

https://git.openstack.org/cgit/openstack-infra/jenkins-job-builder/tree/jenkins_jobs/modules/triggers.py#n1027

Signed-off-by: David Galloway <dgallowa@redhat.com>