### PR TITLE
ceph-volume-nightly: look for the ssh config file to avoid using the root dir

### DIFF
--- a/ceph-volume-nightly/build/teardown
+++ b/ceph-volume-nightly/build/teardown
@@ -5,7 +5,7 @@
 
 cd $WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
 
-scenarios=$(find . | grep Vagrantfile | xargs dirname)
+scenarios=$(find . | grep vagrant_ssh_config | xargs dirname)
 
 for scenario in $scenarios; do
     cd $scenario


### PR DESCRIPTION
Otherwise it was looking at Vagrantfile which exists at the root, but it is not a valid vagrant dir with boxes running