### PR TITLE
ceph-container-flake8: Using project's tox.ini

### DIFF
--- a/ceph-container-flake8/build/build
+++ b/ceph-container-flake8/build/build
@@ -21,7 +21,7 @@ function check(){
     while read -r filename; do
         pushd "$(dirname "$filename")"
         file=$(basename "$filename")
-        sudo docker run --rm -v "$(pwd)"/"$file":/"$file" eeacms/flake8 /"$file"
+        sudo docker run --rm -v "$(pwd)"/tox.ini:/tox.ini -v "$(pwd)"/"$file":/"$file" eeacms/flake8 /"$file"
         popd
     done
     return $?


### PR DESCRIPTION
When running the flake8, it's really important to reuse project's
tox.ini to insure the CI is testing the code with the same configuration
unless that brings to a situation where a local flake pass and the CI
fails.