### PR TITLE
container: add docker hub credential binding

### DIFF
--- a/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
@@ -39,3 +39,8 @@
       - inject-passwords:
           global: true
           mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: docker-hub-leseb
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD


### PR DESCRIPTION
docker-hub-leseb is defined as a credential on 2.jenkins.ceph.com