### PR TITLE
ceph-container: Add staging test

### DIFF
--- a/ceph-container-stage-test/build/build
+++ b/ceph-container-stage-test/build/build
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set -x
+
+cd "$WORKSPACE"/ceph-container/ || exit
+make test.staging

--- a/ceph-container-stage-test/config/JENKINS_URL
+++ b/ceph-container-stage-test/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-container-stage-test/config/definitions/ceph-container-stage-test.yml
+++ b/ceph-container-stage-test/config/definitions/ceph-container-stage-test.yml
@@ -1,0 +1,59 @@
+- scm:
+    name: ceph-container
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-container.git
+          branches:
+            - ${sha1}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: false
+          basedir: "ceph-container"
+
+- job:
+    name: ceph-container-stage-test
+    node: small && centos7
+    defaults: global
+    display-name: 'ceph-container-stage-test'
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 30
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+      - github:
+          url: https://github.com/ceph/ceph-container/
+
+    parameters:
+      - string:
+          name: sha1
+          description: "A pull request ID, like 'origin/pr/72/head'"
+
+    triggers:
+      - github-pull-request:
+          admin-list:
+            - alfredodeza
+            - ktdreyer
+            - gmeno
+            - zcerza
+          org-list:
+            - ceph
+          trigger-phrase: 'jenkins test.staging'
+          only-trigger-phrase: false
+          github-hooks: true
+          permit-all: true
+          auto-close-on-fail: false
+          status-context: "Testing: image staging integration test"
+          started-status: "Running: make test.staging"
+          success-status: "OK - nice work"
+          failure-status: "FAIL - Staging is broken. Images may not build as expected."
+
+    scm:
+      - ceph-container
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../build/build


### PR DESCRIPTION
Staging is an important part of the build process, and if the staging
integration test fails, it is very possible that some/all images may not
build as expected. Therefore, add the integration test to the PR
pre-flight tests.

I haven't submitted a Jenkins job before. I want to make sure that the build at least keeps the `stage.log` from the test. Do I need to configure this somewhere? Or does the `-1` entry make it keep all artifacts?

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>