### PR TITLE
add ceph-container-build-push-imgs-arm64

### DIFF
--- a/ceph-container-build-push-imgs-arm64/build/build
+++ b/ceph-container-build-push-imgs-arm64/build/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+
+cd "$WORKSPACE"/ceph-container/ || exit
+bash -x contrib/build-push-ceph-container-imgs.sh

--- a/ceph-container-build-push-imgs-arm64/config/JENKINS_URL
+++ b/ceph-container-build-push-imgs-arm64/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-container-build-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs-arm64.yml
+++ b/ceph-container-build-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs-arm64.yml
@@ -1,0 +1,46 @@
+- job:
+    name: ceph-container-build-push-imgs-arm64
+    node: arm64
+    project-type: freestyle
+    defaults: global
+    display-name: 'ceph-container: build and push container images to Docker Hub on arm64'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+      - github:
+          url: https://github.com/ceph/ceph-container
+
+    triggers:
+      - github
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-container.git
+          branches:
+            - master
+          browser: auto
+          basedir: "ceph-container"
+          timeout: 20
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: docker-hub-leseb
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD


### PR DESCRIPTION
We need to build container images on arm64.

Signed-off-by: Sébastien Han <seb@redhat.com>