### PR TITLE
build: fix unkown option

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -30,7 +30,7 @@ pip_download() {
     if ! $VENV/pip download $options --dest="$PIP_SDIST_INDEX" $package; then
         # pip <8.0.0 does not have "download" command
         $VENV/pip install $options \
-                  --upgrade --exists-action=i --download="$PIP_SDIST_INDEX" \
+                  --upgrade --exists-action=i --cache-dir="$PIP_SDIST_INDEX" \
                   $package
     fi
 }


### PR DESCRIPTION
Newer version of pip does not support --download anymore, the option has
been replaced by --cache-dir.
This fixes errors like:

+ /tmp/venv.ufvIkiZl8v/bin/pip download
--dest=/home/jenkins-build/.cache/pip pip
ERROR: unknown command "download"

Signed-off-by: Sébastien Han <seb@redhat.com>