### PR TITLE
ceph-volume-scenario: configurable ceph repo url

### DIFF
--- a/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
+++ b/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
@@ -38,10 +38,14 @@
           name: CEPH_ANSIBLE_BRANCH
           description: "The ceph-ansible branch to test against"
           default: "master"
+      - string:
+          name: CEPH_REPO_URL
+          description: "The full https url to clone from"
+          default: "https://github.com/ceph/ceph.git"
 
     scm:
       - git:
-          url: https://github.com/ceph/ceph.git
+          url: $CEPH_REPO_URL
           branches:
             - $CEPH_BRANCH
           refspec: +refs/pull/*:refs/remotes/origin/pr/*


### PR DESCRIPTION
So that we can alternatively use ceph-ci.git