### PR TITLE
ceph-volume-ansible-prs: ensure correct path is used for teardown

### DIFF
--- a/ceph-volume-ansible-prs/build/teardown
+++ b/ceph-volume-ansible-prs/build/teardown
@@ -8,7 +8,7 @@ install_python_packages "pkgs[@]"
 
 GITHUB_STATUS_STATE="failure" $VENV/github-status create
 
-cd $WORKSPACE/src/ceph-volume/tests/functional
+cd $WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
 
 # the method exists in scripts/build_utils.sh
 teardown_vagrant_tests


### PR DESCRIPTION
Build was failing to teardown with:

    + cd /home/jenkins-build/build/workspace/ceph-volume-prs-lvm-centos7-bluestore-create/src/ceph-volume/tests/functional
    /tmp/jenkins8179485046699215972.sh: line 771: cd: /home/jenkins-build/build/workspace/ceph-volume-prs-lvm-centos7-bluestore-create/src/ceph-volume/tests/functional: No such file or directory