### PR TITLE
scripts: upgrade pip with easy_install before actual pinning

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -61,7 +61,11 @@ install_python_packages_no_binary () {
     echo "Ensuring latest pip is installed"
     # XXX This means we are now pinning to 10.0.0, to prevent issues on pip
     # mismtaching versions, but also that we need to revisit this when newer
-    # options are needed
+    # options are needed. ``easy_install`` is a must on systems with ancient
+    # versions of pip that break with newer versions of pkg_resources that come
+    # with the virtualenv. Doing an initial upgrade with easy_install
+    # circumvents the problem
+    $VENV/easy_install --upgrade pip
     $VENV/pip install "pip==10.0.0"
     $VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index pip
 
@@ -98,7 +102,11 @@ install_python_packages () {
     echo "Ensuring latest pip is installed"
     # XXX This means we are now pinning to 10.0.0, to prevent issues on pip
     # mismtaching versions, but also that we need to revisit this when newer
-    # options are needed
+    # options are needed. ``easy_install`` is a must on systems with ancient
+    # versions of pip that break with newer versions of pkg_resources that come
+    # with the virtualenv. Doing an initial upgrade with easy_install
+    # circumvents the problem
+    $VENV/easy_install --upgrade pip
     $VENV/pip install "pip==10.0.0"
     $VENV/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index pip
 


### PR DESCRIPTION
Fixes this problem:

    Traceback (most recent call last):
      File "/tmp/venv.PiUT4JO97l/bin/pip", line 9, in <module>
        load_entry_point('pip==1.4.1', 'console_scripts', 'pip')()
      File "/tmp/venv.PiUT4JO97l/lib/python2.7/site-packages/pkg_resources.py", line 378, in load_entry_point
        return get_distribution(dist).load_entry_point(group, name)
      File "/tmp/venv.PiUT4JO97l/lib/python2.7/site-packages/pkg_resources.py", line 2566, in load_entry_point
        return ep.load()
      File "/tmp/venv.PiUT4JO97l/lib/python2.7/site-packages/pkg_resources.py", line 2265, in load
        raise ImportError("%r has no %r attribute" % (entry,attr))
    ImportError: <module 'pip' from '/tmp/venv.PiUT4JO97l/lib/python2.7/site-packages/pip/__init__.pyc'> has no 'main' attribute