### PR TITLE
ceph-container-build-push-imgs-arm64: update node label

### DIFF
--- a/ceph-container-build-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs-arm64.yml
+++ b/ceph-container-build-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs-arm64.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-container-build-push-imgs-arm64
-    node: arm64
+    node: arm64 xenial
     project-type: freestyle
     defaults: global
     display-name: 'ceph-container: build and push container images to Docker Hub on arm64'


### PR DESCRIPTION
The arm64 nodes have a 'arm64 xenial' label.

Signed-off-by: Sébastien Han <seb@redhat.com>