### PR TITLE
ceph-container-build-push-imgs-arm64: Fixing scripts

### DIFF
--- a/ceph-container-build-push-imgs-arm64/build/build
+++ b/ceph-container-build-push-imgs-arm64/build/build
@@ -3,4 +3,4 @@ set -e
 
 
 cd "$WORKSPACE"/ceph-container/ || exit
-bash -x contrib/build-push-ceph-container-imgs.sh
+bash -x contrib/build-push-ceph-container-imgs-arm64.sh


### PR DESCRIPTION
As ceph-container needs a particular build script for arm64, let's fix
the script name.