### PR TITLE
ceph-ansible-prs: disable purge_bluestore_osds_container

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -11,7 +11,6 @@
       - xenial_cluster
       - docker_cluster
       - docker_cluster_collocation
-      - purge_bluestore_osds_container
       - purge_bluestore_osds_non_container
       - ooo_collocation
     jobs:


### PR DESCRIPTION
This scenario is failing for every PRs because of a race condition.
A PR has been opened https://github.com/ceph/ceph/pull/21415 but until
it doesn't get merged we better to disable this scenario.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>