### PR TITLE
ceph-build: use BRANCH instead of non-existing GIT_BRANCH

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -55,12 +55,12 @@
           condition-operands:
             - condition-kind: regex-match
               regex: (jewel|kraken|luminous)
-              label: '${GIT_BRANCH}'
+              label: '${BRANCH}'
             - condition-kind: and
               condition-operands:
                 - condition-kind: regex-match
                   regex: (mimic|nautilus)
-                  label: '${GIT_BRANCH}'
+                  label: '${BRANCH}'
                 - condition-kind: regex-match
                   regex: (xenial|bionic|centos7|centos8|buster|bullseye)
                   label: '${DIST}'


### PR DESCRIPTION
`GIT_BRANCH` didn't exist, so it wouldn't match and the build would be skipped for everything/anything.