### PR TITLE
ceph-volume-nightly: remove bionic

### DIFF
--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -1,7 +1,6 @@
 - project:
     name: ceph-volume-nightly-lvm
     distro:
-      - bionic
       - xenial
       - centos7
     objectstore:
@@ -22,7 +21,6 @@
 - project:
     name: ceph-volume-nightly-simple
     distro:
-      - bionic
       - xenial
       - centos7
     objectstore:


### PR DESCRIPTION
ceph-volume doesn't have a 'bionic' factor in tox, so there aren't any
functional scenarios to support this. At the moment, there aren't any
ceph packages to test against either. Disabling this for now.

Signed-off-by: Alfredo Deza <adeza@redhat.com>