### PR TITLE
ceph-pr-commits/build: Fix Sign your work url

### DIFF
--- a/ceph-pr-commits/build/test_commits.py
+++ b/ceph-pr-commits/build/test_commits.py
@@ -54,7 +54,7 @@ class TestSignedOffByCommits(object):
                 msg = (
                     "\nFollowing commit is not signed, please make sure all commits",
                     "\nare signed following the 'Submitting Patches' guide:",
-                    "\nhttps://github.com/ceph/ceph/blob/master/SubmittingPatches#L61",
+                    "\nhttps://github.com/ceph/ceph/blob/master/SubmittingPatches.rst#1-sign-your-work",
                     "\n",
                     commit)
                 raise AssertionError, ' '.join(msg)


### PR DESCRIPTION
Fixes:
```
E               Following commit is not signed, please make sure all commits 
E               are signed following the 'Submitting Patches' guide: 
E               https://github.com/ceph/ceph/blob/master/SubmittingPatches#L61 
```
Signed-off-by: Jos Collin <jcollin@redhat.com>