### PR TITLE
ceph-ansible: fix teardown issue

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -716,6 +716,7 @@ write_collect_logs_playbook() {
     - name: find ceph logs
       command: find /var/log/ceph -name "{{ cluster|default('ceph') }}*.log"
       register: ceph_logs
+      failed_when: false
 
     - name: collect ceph logs
       fetch:


### PR DESCRIPTION
At the moment, the teardown isn't fully executed because of `collect-logs.yml`
playbook.

it is expected the following task can fail according to the context of the main failure:

```
TASK [find ceph logs] **********************************************************
task path: /home/jenkins-build/build/workspace/ceph-ansible-scenario/collect-logs.yml:4
fatal: [ceph-nfs0]: FAILED! => {
    "changed": true,
    "cmd": [
        "find",
        "/var/log/ceph",
        "-name",
        "test*.log"
    ],
    "delta": "0:00:00.003363",
    "end": "2018-05-23 16:45:22.845782",
    "rc": 1,
    "start": "2018-05-23 16:45:22.842419"
}

STDERR:

find: ‘/var/log/ceph’: No such file or directory

MSG:

non-zero return code
```

therefore, `teardown_vagrant_tests()` doesn't return `0` and causes the
teardown to stop because of `set -e`

```
PLAY RECAP *********************************************************************
ceph-client0               : ok=1    changed=0    unreachable=0    failed=1
ceph-client1               : ok=1    changed=0    unreachable=0    failed=1
ceph-iscsi-gw0             : ok=1    changed=0    unreachable=0    failed=1
ceph-mds0                  : ok=1    changed=0    unreachable=0    failed=1
ceph-mgr0                  : ok=1    changed=0    unreachable=0    failed=1
ceph-mon0                  : ok=3    changed=2    unreachable=0    failed=0
ceph-mon1                  : ok=3    changed=2    unreachable=0    failed=0
ceph-mon2                  : ok=3    changed=2    unreachable=0    failed=0
ceph-nfs0                  : ok=1    changed=0    unreachable=0    failed=1
ceph-osd0                  : ok=1    changed=0    unreachable=0    failed=1
ceph-rbd-mirror0           : ok=1    changed=0    unreachable=0    failed=1
ceph-rgw0                  : ok=1    changed=0    unreachable=0    failed=1

Build step 'Execute Scripts' marked build as failure
Archiving artifacts
Finished: FAILURE
```

adding a `failed_when: false` on this task should avoid this bug.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>