### PR TITLE
build_utils.sh: add ubuntu-ports repo for arm64 build

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -510,8 +510,8 @@ update-alternatives \
 update-alternatives --auto gcc
 
 # cmake uses the latter by default
-ln -nsf /usr/bin/gcc /usr/bin/x86_64-linux-gnu-gcc
-ln -nsf /usr/bin/g++ /usr/bin/x86_64-linux-gnu-g++
+ln -nsf /usr/bin/gcc /usr/bin/\$(arch)-linux-gnu-gcc
+ln -nsf /usr/bin/g++ /usr/bin/\$(arch)-linux-gnu-g++
 EOF
 }
 


### PR DESCRIPTION
as it offers updated binutils which does not exist in the default repo.
and the updated binutils is depended by gcc-7. this change address
following failure like:

The following packages have unmet dependencies:
 gcc-7 : Depends: binutils (>= 2.26.1) but 2.26-8ubuntu2 is to be
installed

when installing g++-7.

Signed-off-by: Kefu Chai <kchai@redhat.com>