### PR TITLE
ceph-ansible: add some tasks for debugging purpose

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -729,6 +729,18 @@ write_collect_logs_playbook() {
 - hosts: all
   become: yes
   tasks:
+    - name: get yum repoinfo result
+      command: yum repoinfo
+      failed_when: false
+
+    - name: get date result
+      command: date
+      failed_when: false
+
+    - name: get yum check-update result
+      command: yum check-update
+      failed_when: false
+
     - name: find ceph logs
       command: find /var/log/ceph -name "{{ cluster|default('ceph') }}*.log"
       register: ceph_logs


### PR DESCRIPTION
related to ceph/ceph-ansible/pull/2665 and ceph/ceph-ansible/pull/2652

We are seeing too many failures related to yum.
These additional tasks will help us to have more information when a yum
failure occurs.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>