### PR TITLE
build_utils: when running dev-* scenarios set release to nautilus

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -3,7 +3,9 @@
 set -e
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "ansible" "jenkins-job-builder" "urllib3" "pyopenssl" "ndg-httpsclient" "pyasn1" )
+# must pin urllib3 to 1.22 because 1.23 is incompatible with requests, which
+# is used by jenkins-job-builder
+pkgs=( "ansible" "jenkins-job-builder" "urllib3==1.22" "pyopenssl" "ndg-httpsclient" "pyasn1" )
 install_python_packages "pkgs[@]"
 
 

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -662,6 +662,12 @@ while true; do
       ;;
   esac
 done
+if [ "$release" = "dev" ]; then
+    # dev runs will need to be set to the release
+    # that matches what the current ceph master
+    # branch is at
+    local release="nautilus"
+fi
 TOX_RUN_ENV=("timeout 3h")
 if [ -n "$ceph_docker_image_tag" ]; then
   TOX_RUN_ENV=("CEPH_DOCKER_IMAGE_TAG=$ceph_docker_image_tag" "${TOX_RUN_ENV[@]}")


### PR DESCRIPTION
When running dev-* tests for ceph-ansible PRs we were setting
CEPH_STABLE_RELEASE to 'dev' which is not an actual release and our
functional tests break because of that.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>