### PR TITLE
build_utils.sh: do not try to check non-existent file's size

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -404,7 +404,7 @@ setup_pbuilder() {
     # again
     pbuild_tar="$basedir/$DIST.tgz"
     is_not_tar=`python -c "exec 'try: import tarfile;print int(not int(tarfile.is_tarfile(\"$pbuild_tar\")))\nexcept IOError: print 1'"`
-    file_size_kb=`du -k "$pbuild_tar" | cut -f1`
+    file_size_kb=`test -f $pbuild_tar && du -k "$pbuild_tar" | cut -f1 || echo 0`
 
     if [ "$is_not_tar" = "1" ]; then
         sudo rm -f "$pbuild_tar"


### PR DESCRIPTION
it's distracting to read the red alert in jenkins' log like

du: cannot access '/srv/debian-base/xenial.tgz': No such file or
directory

Signed-off-by: Kefu Chai <kchai@redhat.com>