### PR TITLE
mgr/dashboard: Adds unit test coverage report

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -62,3 +62,19 @@
                   - ABORTED
               build-steps:
                 - shell: "sudo reboot"
+      - cobertura:
+          report-file: "src/pybind/mgr/dashboard/frontend/coverage/cobertura-coverage.xml"
+          only-stable: "true"
+          health-auto-update: "true"
+          stability-auto-update: "true"
+          zoom-coverage-chart: "true"
+          source-encoding: "Big5"
+          targets:
+            - files:
+                healthy: 10
+                unhealthy: 20
+                failing: 30
+            - method:
+                healthy: 10
+                unhealthy: 20
+                failing: 30


### PR DESCRIPTION
Enable plugin 'Cobertura' to generate code coverage report, for every PR for ceph-dashboard frontend unit test. Cobertura jenkins plugin: https://wiki.jenkins.io/display/JENKINS/Cobertura+Plugin

Fixes: http://tracker.ceph.com/issues/24377
Signed-off-by: Kanika Murarka <kmurarka@redhat.com>