### PR TITLE
ceph-ansible-prs: run 'auto' scenarios on smithi or ovh

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,7 +1,7 @@
-# tests that will auto start for every PR created and run on smithi
+# tests that will auto start for every PR created and run on smithi or ovh
 - project:
     name: ceph-ansible-prs-auto
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && (smithi || centos7)'
     release:
       - luminous
     ansible_version:


### PR DESCRIPTION
This is slowing down CI testing because we can't run more than 1 or 2
PRs at a time. Since I'm not sure if it's still worth to limit these
scenarios to be run only on smithi node, let's try to temporary remove
this limitation.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>