### PR TITLE
ceph-ansible: update nightlies definition

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -1,31 +1,4 @@
 - project:
-    name: ceph-ansible-nightly-jewel-stable2.2
-    release:
-      - jewel
-    ansible_version:
-      - ansible2.2
-      - ansible2.4
-    scenario:
-      - centos7_cluster
-      - xenial_cluster
-      - docker_cluster
-      - journal_collocation
-      - dmcrypt_journal
-      - dmcrypt_journal_collocation
-      - purge_cluster
-      - purge_dmcrypt
-      - docker_dedicated_journal
-      - docker_dmcrypt_journal_collocation
-      - update_dmcrypt
-      - update_cluster
-      - cluster
-      - purge_docker_cluster
-    ceph_ansible_branch:
-      - stable-2.2
-    jobs:
-      - 'ceph-ansible-nightly-{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}'
-
-- project:
     name: ceph-ansible-nightly-jewel-stable3.0
     release:
       - jewel
@@ -56,7 +29,7 @@
       - 'ceph-ansible-nightly-{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}'
 
 - project:
-    name: ceph-ansible-nightly-luminous
+    name: ceph-ansible-nightly-luminous-master
     release:
       - luminous
     ansible_version:
@@ -87,8 +60,78 @@
       - purge_bluestore_osds_non_container
       - ooo_collocation
     ceph_ansible_branch:
-      - stable-3.0
       - master
+    jobs:
+        - 'ceph-ansible-nightly-{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}'
+
+- project:
+    name: ceph-ansible-nightly-luminous-stable3.1
+    release:
+      - luminous
+    ansible_version:
+      - ansible2.4
+      - ansible2.5
+    scenario:
+      - centos7_cluster
+      - xenial_cluster
+      - docker_cluster
+      - update_cluster
+      - lvm_osds
+      - purge_lvm_osds
+      - docker_cluster_collocation
+      - update_docker_cluster
+      - switch_to_containers
+      - shrink_mon
+      - shrink_mon_container
+      - shrink_osd
+      - shrink_osd_container
+      - bluestore_osds_non_container
+      - bluestore_osds_container
+      - filestore_osds_non_container
+      - filestore_osds_container
+      - purge_cluster_container
+      - purge_cluster_non_container
+      - purge_filestore_osds_container
+      - purge_filestore_osds_non_container
+      - purge_bluestore_osds_container
+      - purge_bluestore_osds_non_container
+      - ooo_collocation
+    ceph_ansible_branch:
+      - stable-3.1
+    jobs:
+        - 'ceph-ansible-nightly-{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}'
+
+- project:
+    name: ceph-ansible-nightly-luminous-stable3.0
+    release:
+      - luminous
+    ansible_version:
+      - ansible2.4
+    scenario:
+      - centos7_cluster
+      - xenial_cluster
+      - docker_cluster
+      - update_cluster
+      - docker_cluster_collocation
+      - update_docker_cluster
+      - switch_to_containers
+      - shrink_mon
+      - shrink_mon_container
+      - shrink_osd
+      - shrink_osd_container
+      - bluestore_osds_non_container
+      - bluestore_osds_container
+      - filestore_osds_non_container
+      - filestore_osds_container
+      - purge_cluster_container
+      - purge_cluster_non_container
+      - purge_filestore_osds_container
+      - purge_filestore_osds_non_container
+      - purge_bluestore_osds_container
+      - purge_bluestore_osds_non_container
+      - ooo_collocation
+    ceph_ansible_branch:
+      - stable-3.0
     jobs:
         - 'ceph-ansible-nightly-{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}'
 


### PR DESCRIPTION
- remove testing of stable-2.2 against ceph jewel
- add testing of stable-3.1 against luminous
- update testing of stable-3.0 against luminous:
  - remove lvm scenarios

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>