### PR TITLE
ceph-ansible: move bluestore_osds_container in ceph-ansible-prs-auto

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -14,6 +14,7 @@
       - xenial_cluster
       - docker_cluster
       - docker_cluster_collocation
+      - bluestore_osds_container
       - purge_bluestore_osds_non_container
       - ooo_collocation
     jobs:
@@ -65,7 +66,6 @@
       - ansible2.4
     scenario:
       - bluestore_osds_non_container
-      - bluestore_osds_container
       - filestore_osds_non_container
       - filestore_osds_container
       - shrink_mon


### PR DESCRIPTION
we are seeing this scenario failing because of the race condition,
moving it to a project which requires smithi nodes should help.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>