### PR TITLE
ceph-ansible-pr-syntax-check: add group_vars check

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -6,19 +6,49 @@ set -e
 pkgs=( "ansible==2.3.1" "ansible-lint" )
 install_python_packages "pkgs[@]"
 
-cd $WORKSPACE/ceph-ansible
 
-$VENV/ansible-playbook -i '127.0.0.1,' site.yml.sample --syntax-check --list-tasks -vv
-$VENV/ansible-playbook -i '127.0.0.1,' site-docker.yml.sample --syntax-check --list-tasks -vv
+#############
+# FUNCTIONS #
+#############
+function syntax_check {
+  "$VENV"/ansible-playbook -i '127.0.0.1,' site.yml.sample --syntax-check --list-tasks -vv
+  "$VENV"/ansible-playbook -i '127.0.0.1,' site-docker.yml.sample --syntax-check --list-tasks -vv
 
-# move roles and group_vars into the
-# infrastructure-playbooks directory for easier syntax checking
-cp -r roles infrastructure-playbooks/
-cp -r group_vars infrastructure-playbooks/
-mv infrastructure-playbooks/group_vars/all.yml.sample infrastructure-playbooks/group_vars/all.yml
-export ANSIBLE_LIBRARY=$WORKSPACE/ceph-ansible/library
+  # move roles and group_vars into the
+  # infrastructure-playbooks directory for easier syntax checking
+  cp -r roles infrastructure-playbooks/
+  cp -r group_vars infrastructure-playbooks/
+  mv infrastructure-playbooks/group_vars/all.yml.sample infrastructure-playbooks/group_vars/all.yml
+  export ANSIBLE_LIBRARY=$WORKSPACE/ceph-ansible/library
 
-$VENV/ansible-playbook -i '127.0.0.1,' infrastructure-playbooks/*.yml --syntax-check --list-tasks -vv
+  "$VENV"/ansible-playbook -i '127.0.0.1,' infrastructure-playbooks/*.yml --syntax-check --list-tasks -vv
+}
 
-#$VENV/ansible-lint site.yml.sample
-#$VENV/ansible-lint site-docker.yml.sample
+function ansible_lint {
+  "$VENV"/ansible-lint site.yml.sample
+  "$VENV"/ansible-lint site-docker.yml.sample
+}
+
+function group_vars_check {
+  nb="$(git show HEAD --name-only --pretty="" | grep -c '/defaults/main.yml')"
+  if [[ "$nb" -eq 0 ]]; then
+    echo "group_vars has not been touched."
+    return 0
+  fi
+
+  nb_group_vars="$(git show HEAD --name-only --pretty="" | grep -c 'group_var/*')"
+  if [[ "$nb" -ne "$nb_group_vars" ]]; then
+    echo "One or more files containing default variables has/have been modified."
+    echo "You must run 'generate_group_vars_sample.sh' to generate the group_vars template files."
+    return 1
+  fi
+}
+
+
+########
+# MAIN #
+########
+cd "$WORKSPACE"/ceph-ansible
+syntax_check
+#ansible_lint
+group_vars_check


### PR DESCRIPTION
This commit does 2 things:

* split the structure of the script to use functions
* add a function to test if group_vars weren't generated

Signed-off-by: Sébastien Han <seb@redhat.com>