### PR TITLE
ceph-pull-requests-arm64: Normalize name to appease JJB

### DIFF
--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -7,7 +7,7 @@
         - ../../build/build
     concurrent: true
     disabled: false
-    name: !!python/unicode 'ceph-pull-requests-arm64'
+    name: ceph-pull-requests-arm64
     node: arm64
     parameters:
     - string:


### PR DESCRIPTION
Not sure why `!!python/unicode` was there originally but the current
version of JJB doesn't like it.

Signed-off-by: David Galloway <dgallowa@redhat.com>