### PR TITLE
ceph-pull-requests: Improving ccache efficiency

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -51,7 +51,7 @@
           wipe-workspace: true
 
     builders:
-      - shell: "export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
+      - shell: "export SOURCE_DATE_EPOCH=$(date +%D |date -f- +%s); export NPROC=$(nproc); timeout 7200 ./run-make-check.sh -D ENABLE_GIT_VERSION=OFF"
 
     publishers:
       - postbuildscript:


### PR DESCRIPTION
As of today, ccache is installed by run-make-check but the statistics
reports almost no cache it (<1%) and even worse, this is slowing down
the whole process. The needed time to setup the cache isn't compensated
by the reuse of the cache as every build is rebuilding the cache. This
is leading to a 10% loss of the compilation time.

So the question, is why does two consecutives builds doesn't reuse the
cache. Its usually a matter of variables introduces on each builds like
a sha1 or a __DATE__ or __TIME__ in a header.

As per
https://wiki.debian.org/ReproducibleBuilds/TimestampsProposal, several
tools from the tool chain (like compilers or make tools) are able to use
theses variables to enforce a particular timestamp at build time.

This commit also add a "-D ENABLE_GIT_VERSION=OFF" to avoid having the
commit id in the ceph_ver.h header. Not having the git versioning inside
the CI job is not a by deal as the binaries will be destroyed after the
build procedure.

These changes avoid introducing small variations in the source code
which breaks the build cache (ccache). The expected result is to get a
80 or 90% cache hit between two very close builds.

Signed-off-by: Erwan Velu <erwan@redhat.com>