### PR TITLE
ceph-build/cobertura: set *auto-update to false

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -65,8 +65,8 @@
       - cobertura:
           report-file: "src/pybind/mgr/dashboard/frontend/coverage/cobertura-coverage.xml"
           only-stable: "true"
-          health-auto-update: "true"
-          stability-auto-update: "true"
+          health-auto-update: "false"
+          stability-auto-update: "false"
           zoom-coverage-chart: "true"
           source-encoding: "Big5"
           targets:


### PR DESCRIPTION
Set `health-auto-update` and `stability-auto-update` to false, as the build failed.

Signed-off-by: Jos Collin <jcollin@redhat.com>