### PR TITLE
mgr/dashboard: Removes extra attributes from Cobertura plugin

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -64,17 +64,13 @@
                 - shell: "sudo reboot"
       - cobertura:
           report-file: "src/pybind/mgr/dashboard/frontend/coverage/cobertura-coverage.xml"
-          only-stable: "true"
-          health-auto-update: "false"
-          stability-auto-update: "false"
           zoom-coverage-chart: "true"
-          source-encoding: "Big5"
           targets:
             - files:
                 healthy: 10
-                unhealthy: 20
-                failing: 30
+                unhealthy: 10
+                failing: 10
             - method:
                 healthy: 10
-                unhealthy: 20
-                failing: 30
+                unhealthy: 10
+                failing: 10


### PR DESCRIPTION
Due to some build failures, this PR removes attributes for Cobertura that are not required right now.
Signed-off-by: Kanika Murarka <kmurarka@redhat.com>