### PR TITLE
ceph-pull-requests: Automatically rebuild w/o asking params

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -17,6 +17,8 @@
           artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph/
+      - rebuild:
+          auto-rebuild: true
 
     parameters:
       - string:


### PR DESCRIPTION
Just tested and clicking 'Rebuild' does carry over the `sha1` variable.

Signed-off-by: David Galloway <dgallowa@redhat.com>