### PR TITLE
scripts: collect all logs in /var/log/ceph on ansible failures

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -751,7 +751,7 @@ write_collect_logs_playbook() {
       when: ansible_distribution == 'CentOS'
 
     - name: find ceph logs
-      command: find /var/log/ceph -name "{{ cluster|default('ceph') }}*.log"
+      command: find /var/log/ceph -name "*.log"
       register: ceph_logs
       failed_when: false
 


### PR DESCRIPTION
On the jobs that use ceph-ansible to test ceph logs are collected from
the vms on failure. However, if the cluster name was not ceph the find
command would fail to collect any ceph-volume logs.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>