### PR TITLE
ceph-ansible-pr-syntax-check: use master instead of HEAD

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -47,7 +47,7 @@ function group_vars_check {
 }
 
 function test_sign_off {
-  test "$(git log --oneline origin/HEAD..HEAD | wc -l)" -ne "$(git log origin/HEAD..HEAD | grep -c Signed-off-by)" && echo "One or more commits is/are missing a Signed-off-by. Add it with 'git commit -s'."
+  test "$(git log --oneline origin/master..HEAD | wc -l)" -ne "$(git log origin/master..HEAD | grep -c Signed-off-by)" && echo "One or more commits is/are missing a Signed-off-by. Add it with 'git commit -s'."
   return 1
 }
 


### PR DESCRIPTION
origin/HEAD does not exist so let's use origin/master instead. This
prevents the following error:

bad revision 'origin/HEAD'

Signed-off-by: Sébastien Han <seb@redhat.com>