### PR TITLE
ceph-ansible-pr-syntax-check: remove merge commit from count

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -50,7 +50,7 @@ function group_vars_check {
 function test_sign_off {
   git fetch
   # shellcheck disable=SC2154
-  test "$(git log --oneline origin/"${ghprbTargetBranch}"..HEAD | wc -l)" -ne "$(git log origin/"${ghprbTargetBranch}"..HEAD | grep -c Signed-off-by)" && echo "One or more commits is/are missing a Signed-off-by. Add it with 'git commit -s'."
+  test "$(git log --oneline --no-merges origin/"${ghprbTargetBranch}"..HEAD | wc -l)" -ne "$(git log --no-merges origin/"${ghprbTargetBranch}"..HEAD | grep -c Signed-off-by)" && echo "One or more commits is/are missing a Signed-off-by. Add it with 'git commit -s'."
   return 1
 }
 


### PR DESCRIPTION
When counting the number of commit you must remove the merge commit so
we get the right number of commits.

Signed-off-by: Sébastien Han <seb@redhat.com>