### PR TITLE
ceph-ansible-pr-syntax-check: return 1 only on failure

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -50,8 +50,8 @@ function group_vars_check {
 function test_sign_off {
   git fetch
   # shellcheck disable=SC2154
-  test "$(git log --oneline --no-merges origin/"${ghprbTargetBranch}"..HEAD | wc -l)" -ne "$(git log --no-merges origin/"${ghprbTargetBranch}"..HEAD | grep -c Signed-off-by)" && echo "One or more commits is/are missing a Signed-off-by. Add it with 'git commit -s'."
-  return 1
+  # ghprbTargetBranch variable comes from jenkins's injectedEnvVars
+  test "$(git log --oneline --no-merges origin/"${ghprbTargetBranch}"..HEAD | wc -l)" -ne "$(git log --no-merges origin/"${ghprbTargetBranch}"..HEAD | grep -c Signed-off-by)" && echo "One or more commits is/are missing a Signed-off-by. Add it with 'git commit -s'." && return 1
 }
 
 


### PR DESCRIPTION
This was a leftover from an initial attempt with if combinaison. We now
return 1 only if the test line fails.

Signed-off-by: Sébastien Han <seb@redhat.com>