### PR TITLE
Added Jenkins job definition and setup for ceph dashboard frontend (e2e tests)

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -54,9 +54,9 @@
 
     builders:
       - shell: "export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
-      - shell:
-          !include-raw:
-            - ../../setup/setup
+      #- shell:
+      #    !include-raw:
+      #      - ../../setup/setup
       #- shell: "timeout 7200  ./src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh"
 
     publishers:

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -1,0 +1,68 @@
+- job:
+    name: ceph-dashboard-pull-requests
+    project-type: freestyle
+    defaults: global
+    concurrent: true
+    node: huge && (centos7 || trusty) && rebootable
+    display-name: 'ceph: dashboard Pull Requests'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 300
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+      - github:
+          url: https://github.com/ceph/ceph/
+
+    parameters:
+      - string:
+          name: sha1
+          description: "A pull request ID, like 'origin/pr/72/head'"
+
+    triggers:
+      - github-pull-request:
+          allow-whitelist-orgs-as-admins: true
+          org-list:
+            - ceph
+          white-list-labels:
+            - dashboard
+          trigger-phrase: 'jenkins test make check'
+          skip-build-phrase: '^jenkins do not test.*'
+          only-trigger-phrase: false
+          github-hooks: true
+          permit-all: true
+          auto-close-on-fail: false
+          status-context: "make check"
+          started-status: "running make check"
+          success-status: "make check succeeded"
+          failure-status: "make check failed"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph.git
+          branches:
+            - ${sha1}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+
+    builders:
+      - shell: "export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
+      - shell: !include-raw ../../setup/setup
+      - shell: "timeout 7200  ./src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh"
+
+    publishers:
+      - postbuildscript:
+          builders:
+            - role: SLAVE
+              build-on:
+                - FAILURE
+                - ABORTED
+              build-steps:
+- shell: "sudo reboot"

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -54,8 +54,10 @@
 
     builders:
       - shell: "export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
-      - shell: !include-raw ../../setup/setup
-      - shell: "timeout 7200  ./src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh"
+      - shell:
+          !include-raw:
+            - ../../setup/setup
+      #- shell: "timeout 7200  ./src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh"
 
     publishers:
       - postbuildscript:

--- a/ceph-dashboard-pull-requests/setup/setup
+++ b/ceph-dashboard-pull-requests/setup/setup
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+
+if grep -q  debian /etc/*-release; then        
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+    wget https://dl.google.com/linux/linux_signing_key.pub
+    apt-key add linux_signing_key.pub
+    sudo apt-get update
+    sudo apt-get install -y google-chrome-stable
+
+
+elif grep -q rhel /etc/*-release; then
+    cat << EOF > /etc/yum.repos.d/google-chrome.repo
+        [google-chrome]
+        name=google-chrome
+        baseurl=http://dl.google.com/linux/chrome/rpm/stable/x86_64
+        enabled=1
+        gpgcheck=1
+        gpgkey=https://dl.google.com/linux/linux_signing_key.pub
+EOF
+    yum install -y google-chrome-stable
+fi


### PR DESCRIPTION
This Jenkins job should be triggered for pull-requests labeled with "dashboard" and should execute the frontend (e2e) tests.
To be able to execute the tests it's required to have a browser installed (in this case Google Chrome).

The "ceph-dashboard-pull-requests.yml" is based on the ceph-pull-requests.yml file with some modifications.

Signed-off-by: Laura Paduano <lpaduano@suse.com>