### PR TITLE
build_utils: import ubuntu-toolchain-r's key without keyserver

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -531,10 +531,6 @@ echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu $DIST main" >>
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
 echo "deb http://ports.ubuntu.com/ubuntu-ports $DIST-updates main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
-# import PPA's signing key into APT's keyring
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F
-apt-get update -y -o Acquire::Languages=none -o Acquire::Translation=none || true
-apt-get install -y g++-7
 EOF
     elif [ "$ARCH" = "x86_64" ]; then
         cat > $hookdir/D05install-gcc-7 <<EOF
@@ -546,15 +542,32 @@ echo "deb [arch=amd64] http://mirror.cs.uchicago.edu/ubuntu-toolchain-r $DIST ma
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
 echo "deb [arch=amd64,i386] http://mirror.yandex.ru/mirrors/launchpad/ubuntu-toolchain-r $DIST main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
-# import PPA's signing key into APT's keyring
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F
-apt-get -y update -o Acquire::Languages=none -o Acquire::Translation=none || true
-apt-get install -y g++-7
 EOF
     else
         echo "unsupported arch: $ARCH"
         exit 1
     fi
+cat >> $hookdir/D05install-gcc-7 <<EOF
+cat << ENDOFKEY | sudo apt-key add -
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: SKS 1.1.6
+Comment: Hostname: keyserver.ubuntu.com
+
+mI0ESuBvRwEEAMi4cDba7xlKaaoXjO1n1HX8RKrkW+HEIl79nSOSJyvzysajs7zUow/OzCQp
+9NswqrDmNuH1+lPTTRNAGtK8r2ouq2rnXT1mTl23dpgHZ9spseR73s4ZBGw/ag4bpU5dNUSt
+vfmHhIjVCuiSpNn7cyy1JSSvSs3N2mxteKjXLBf7ABEBAAG0GkxhdW5jaHBhZCBUb29sY2hh
+aW4gYnVpbGRziLYEEwECACAFAkrgb0cCGwMGCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAKCRAe
+k3eiup7yfzGKA/4xzUqNACSlB+k+DxFFHqkwKa/ziFiAlkLQyyhm+iqz80htRZr7Ls/ZRYZl
+0aSU56/hLe0V+TviJ1s8qdN2lamkKdXIAFfavA04nOnTzyIBJ82EAUT3Nh45skMxo4z4iZMN
+msyaQpNl/m/lNtOLhR64v5ZybofB2EWkMxUzX8D/FQ==
+=LcUQ
+-----END PGP PUBLIC KEY BLOCK-----
+ENDOFKEY
+# import PPA's signing key into APT's keyring
+env DEBIAN_FRONTEND=noninteractive apt-get update -y -o Acquire::Languages=none -o Acquire::Translation=none || true
+env DEBIAN_FRONTEND=noninteractive apt-get install -y g++-7
+EOF
+
     chmod +x $hookdir/D05install-gcc-7
 
     setup_gcc_hook 7 > $hookdir/D10update-gcc-alternatives


### PR DESCRIPTION
we are running into following error recently

gpg: requesting key BA9EF27F from hkp server keyserver.ubuntu.com
gpgkeys: key 1E9377A2BA9EF27F can't be retrieved
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
gpg: keyserver communications error: keyserver helper general error
gpg: keyserver communications error: unknown pubkey algorithm
gpg: keyserver receive failed: unknown pubkey algorithm

so use the local copy of the pubkey instead

Signed-off-by: Kefu Chai <kchai@redhat.com>