### PR TITLE
Use ansible 2.5 with master and 2.4 with stable-3.x

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -93,23 +93,66 @@
                   git show-branch ${sha1} | grep -v $(git ls-remote https://github.com/ceph/ceph-ansible.git stable-3.0 | awk '{ print $1 }')
                 on-evaluation-failure: run
                 steps:
-                  - multijob:
-                      name: 'ceph-ansible purge playbook testing'
-                      condition: SUCCESSFUL
-                      execution-type: PARALLEL
-                      projects:
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_bluestore_osds_non_container'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_cluster_container'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_cluster_non_container'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_filestore_osds_container'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_filestore_osds_non_container'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_lvm_osds'
-                          current-parameters: true
+                  - conditional-step:
+                      condition-kind: shell
+                      condition-command: |
+                        #!/bin/bash
+                        set -x
+                        if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                          ANSIBLE_VERSION="ansible2.4"
+                        else
+                          ANSIBLE_VERSION="ansible2.5"
+                        fi
+                        test "$ANSIBLE_VERSION" == "ansible2.4"
+                      on-evaluation-failure: dont-run
+                      steps:
+                        - multijob:
+                            name: 'ceph-ansible purge playbook testing (ansible 2.4)'
+                            condition: SUCCESSFUL
+                            execution-type: PARALLEL
+                            projects:
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_bluestore_osds_non_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_cluster_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_cluster_non_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_filestore_osds_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_filestore_osds_non_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_lvm_osds'
+                                current-parameters: true
+                  - conditional-step:
+                      condition-kind: shell
+                      condition-command: |
+                        #!/bin/bash
+                        set -x
+                        if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                          ANSIBLE_VERSION="ansible2.4"
+                        else
+                          ANSIBLE_VERSION="ansible2.5"
+                        fi
+                        test "$ANSIBLE_VERSION" == "ansible2.5"
+                      on-evaluation-failure: dont-run
+                      steps:
+                        - multijob:
+                            name: 'ceph-ansible purge playbook testing (ansible 2.5)'
+                            condition: SUCCESSFUL
+                            execution-type: PARALLEL
+                            projects:
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-purge_bluestore_osds_non_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-purge_cluster_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-purge_cluster_non_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-purge_filestore_osds_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-purge_filestore_osds_non_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-purge_lvm_osds'
+                                current-parameters: true
       - conditional-step:
           condition-kind: shell
           condition-command: |
@@ -118,15 +161,50 @@
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/rolling_update'
           on-evaluation-failure: dont-run
           steps:
-            - multijob:
-                name: 'ceph-ansible rolling_update playbook testing'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-update_cluster'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-update_docker_cluster'
-                    current-parameters: true
+            - conditional-step:
+                condition-kind: shell
+                condition-command: |
+                  #!/bin/bash
+                  set -x
+                  if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                    ANSIBLE_VERSION="ansible2.4"
+                  else
+                    ANSIBLE_VERSION="ansible2.5"
+                  fi
+                  test "$ANSIBLE_VERSION" == "ansible2.4"
+                on-evaluation-failure: dont-run
+                steps:
+                  - multijob:
+                      name: 'ceph-ansible rolling_update playbook testing (ansible 2.4)'
+                      condition: SUCCESSFUL
+                      execution-type: PARALLEL
+                      projects:
+                        - name: 'ceph-ansible-prs-luminous-ansible2.4-update_cluster'
+                          current-parameters: true
+                        - name: 'ceph-ansible-prs-luminous-ansible2.4-update_docker_cluster'
+                          current-parameters: true
+            - conditional-step:
+                condition-kind: shell
+                condition-command: |
+                  #!/bin/bash
+                  set -x
+                  if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                    ANSIBLE_VERSION="ansible2.4"
+                  else
+                    ANSIBLE_VERSION="ansible2.5"
+                  fi
+                  test "$ANSIBLE_VERSION" == "ansible2.5"
+                on-evaluation-failure: dont-run
+                steps:
+                  - multijob:
+                      name: 'ceph-ansible rolling_update playbook testing (ansible 2.5)'
+                      condition: SUCCESSFUL
+                      execution-type: PARALLEL
+                      projects:
+                        - name: 'ceph-ansible-prs-luminous-ansible2.5-update_cluster'
+                          current-parameters: true
+                        - name: 'ceph-ansible-prs-luminous-ansible2.5-update_docker_cluster'
+                          current-parameters: true
       - conditional-step:
           condition-kind: shell
           condition-command: |
@@ -135,15 +213,50 @@
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/shrink-mon'
           on-evaluation-failure: dont-run
           steps:
-            - multijob:
-                name: 'ceph-ansible shrink_mon playbook testing'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_mon'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_mon_container'
-                    current-parameters: true
+            - conditional-step:
+                condition-kind: shell
+                condition-command: |
+                  #!/bin/bash
+                  set -x
+                  if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                    ANSIBLE_VERSION="ansible2.4"
+                  else
+                    ANSIBLE_VERSION="ansible2.5"
+                  fi
+                  test "$ANSIBLE_VERSION" == "ansible2.4"
+                on-evaluation-failure: dont-run
+                steps:
+                  - multijob:
+                      name: 'ceph-ansible shrink_mon playbook testing (ansible 2.4)'
+                      condition: SUCCESSFUL
+                      execution-type: PARALLEL
+                      projects:
+                        - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_mon'
+                          current-parameters: true
+                        - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_mon_container'
+                          current-parameters: true
+            - conditional-step:
+                condition-kind: shell
+                condition-command: |
+                  #!/bin/bash
+                  set -x
+                  if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                    ANSIBLE_VERSION="ansible2.4"
+                  else
+                    ANSIBLE_VERSION="ansible2.5"
+                  fi
+                  test "$ANSIBLE_VERSION" == "ansible2.5"
+                on-evaluation-failure: dont-run
+                steps:
+                  - multijob:
+                      name: 'ceph-ansible shrink_mon playbook testing (ansible 2.5)'
+                      condition: SUCCESSFUL
+                      execution-type: PARALLEL
+                      projects:
+                        - name: 'ceph-ansible-prs-luminous-ansible2.5-shrink_mon'
+                          current-parameters: true
+                        - name: 'ceph-ansible-prs-luminous-ansible2.5-shrink_mon_container'
+                          current-parameters: true
       - conditional-step:
           condition-kind: shell
           condition-command: |
@@ -152,15 +265,50 @@
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/shrink-osd'
           on-evaluation-failure: dont-run
           steps:
-            - multijob:
-                name: 'ceph-ansible shrink_osd playbook testing'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_osd'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_osd_container'
-                    current-parameters: true
+            - conditional-step:
+                condition-kind: shell
+                condition-command: |
+                  #!/bin/bash
+                  set -x
+                  if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                    ANSIBLE_VERSION="ansible2.4"
+                  else
+                    ANSIBLE_VERSION="ansible2.5"
+                  fi
+                  test "$ANSIBLE_VERSION" == "ansible2.4"
+                on-evaluation-failure: dont-run
+                steps:
+                  - multijob:
+                      name: 'ceph-ansible shrink_osd playbook testing (ansible 2.4)'
+                      condition: SUCCESSFUL
+                      execution-type: PARALLEL
+                      projects:
+                        - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_osd'
+                          current-parameters: true
+                        - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_osd_container'
+                          current-parameters: true
+            - conditional-step:
+                condition-kind: shell
+                condition-command: |
+                  #!/bin/bash
+                  set -x
+                  if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                    ANSIBLE_VERSION="ansible2.4"
+                  else
+                    ANSIBLE_VERSION="ansible2.5"
+                  fi
+                  test "$ANSIBLE_VERSION" == "ansible2.5"
+                on-evaluation-failure: dont-run
+                steps:
+                  - multijob:
+                      name: 'ceph-ansible shrink_osd playbook testing (ansible 2.5)'
+                      condition: SUCCESSFUL
+                      execution-type: PARALLEL
+                      projects:
+                        - name: 'ceph-ansible-prs-luminous-ansible2.5-shrink_osd'
+                          current-parameters: true
+                        - name: 'ceph-ansible-prs-luminous-ansible2.5-shrink_osd_container'
+                          current-parameters: true
       - conditional-step:
           condition-kind: shell
           condition-command: |
@@ -169,13 +317,46 @@
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons'
           on-evaluation-failure: dont-run
           steps:
-            - multijob:
-                name: 'ceph-ansible switch_to_containers playbook testing'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-switch_to_containers'
-                    current-parameters: true
+            - conditional-step:
+                condition-kind: shell
+                condition-command: |
+                  #!/bin/bash
+                  set -x
+                  if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                    ANSIBLE_VERSION="ansible2.4"
+                  else
+                    ANSIBLE_VERSION="ansible2.5"
+                  fi
+                  test "$ANSIBLE_VERSION" == "ansible2.4"
+                on-evaluation-failure: dont-run
+                steps:
+                  - multijob:
+                      name: 'ceph-ansible switch_to_containers playbook testing (ansible 2.4)'
+                      condition: SUCCESSFUL
+                      execution-type: PARALLEL
+                      projects:
+                        - name: 'ceph-ansible-prs-luminous-ansible2.4-switch_to_containers'
+                          current-parameters: true
+            - conditional-step:
+                condition-kind: shell
+                condition-command: |
+                  #!/bin/bash
+                  set -x
+                  if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                    ANSIBLE_VERSION="ansible2.4"
+                  else
+                    ANSIBLE_VERSION="ansible2.5"
+                  fi
+                  test "$ANSIBLE_VERSION" == "ansible2.5"
+                on-evaluation-failure: dont-run
+                steps:
+                  - multijob:
+                      name: 'ceph-ansible switch_to_containers playbook testing (ansible 2.5)'
+                      condition: SUCCESSFUL
+                      execution-type: PARALLEL
+                      projects:
+                        - name: 'ceph-ansible-prs-luminous-ansible2.5-switch_to_containers'
+                          current-parameters: true
       - conditional-step:
           condition-kind: shell
           condition-command: |
@@ -188,15 +369,50 @@
             fi
           on-evaluation-failure: dont-run
           steps:
-            - multijob:
-                name: 'ceph-ansible basic cluster testing phase'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-centos7_cluster'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-docker_cluster'
-                    current-parameters: true
+            - conditional-step:
+                condition-kind: shell
+                condition-command: |
+                  #!/bin/bash
+                  set -x
+                  if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                    ANSIBLE_VERSION="ansible2.4"
+                  else
+                    ANSIBLE_VERSION="ansible2.5"
+                  fi
+                  test "$ANSIBLE_VERSION" == "ansible2.4"
+                on-evaluation-failure: dont-run
+                steps:
+                  - multijob:
+                      name: 'ceph-ansible basic cluster testing phase (ansible 2.4)'
+                      condition: SUCCESSFUL
+                      execution-type: PARALLEL
+                      projects:
+                        - name: 'ceph-ansible-prs-luminous-ansible2.4-centos7_cluster'
+                          current-parameters: true
+                        - name: 'ceph-ansible-prs-luminous-ansible2.4-docker_cluster'
+                          current-parameters: true
+            - conditional-step:
+                condition-kind: shell
+                condition-command: |
+                  #!/bin/bash
+                  set -x
+                  if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                    ANSIBLE_VERSION="ansible2.4"
+                  else
+                    ANSIBLE_VERSION="ansible2.5"
+                  fi
+                  test "$ANSIBLE_VERSION" == "ansible2.5"
+                on-evaluation-failure: dont-run
+                steps:
+                  - multijob:
+                      name: 'ceph-ansible basic cluster testing phase (ansible 2.5)'
+                      condition: SUCCESSFUL
+                      execution-type: PARALLEL
+                      projects:
+                        - name: 'ceph-ansible-prs-luminous-ansible2.5-centos7_cluster'
+                          current-parameters: true
+                        - name: 'ceph-ansible-prs-luminous-ansible2.5-docker_cluster'
+                          current-parameters: true
             # If PR is merging into stable-3.0 branch HEAD, run all but LVM scenarios
             - conditional-step:
                 condition-kind: shell
@@ -234,29 +450,78 @@
                   git show-branch ${sha1} | grep -v $(git ls-remote https://github.com/ceph/ceph-ansible.git stable-3.0 | awk '{ print $1 }')
                 on-evaluation-failure: run
                 steps:
-                  - multijob:
-                      name: 'ceph-ansible advanced cluster testing phase'
-                      condition: SUCCESSFUL
-                      execution-type: PARALLEL
-                      projects:
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_lvm_osds'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_osds_container'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_osds_non_container'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-docker_cluster_collocation'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-filestore_osds_container'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-filestore_osds_non_container'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-lvm_osds'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-ooo_collocation'
-                          current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-xenial_cluster'
-                          current-parameters: true
+                  - conditional-step:
+                      condition-kind: shell
+                      condition-command: |
+                        #!/bin/bash
+                        set -x
+                        if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                          ANSIBLE_VERSION="ansible2.4"
+                        else
+                          ANSIBLE_VERSION="ansible2.5"
+                        fi
+                        test "$ANSIBLE_VERSION" == "ansible2.4"
+                      on-evaluation-failure: dont-run
+                      steps:
+                        - multijob:
+                            name: 'ceph-ansible advanced cluster testing phase (ansible 2.4)'
+                            condition: SUCCESSFUL
+                            execution-type: PARALLEL
+                            projects:
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_lvm_osds'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_osds_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_osds_non_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-docker_cluster_collocation'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-filestore_osds_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-filestore_osds_non_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-lvm_osds'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-ooo_collocation'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.4-xenial_cluster'
+                                current-parameters: true
+                  - conditional-step:
+                      condition-kind: shell
+                      condition-command: |
+                        #!/bin/bash
+                        set -x
+                        if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
+                          ANSIBLE_VERSION="ansible2.4"
+                        else
+                          ANSIBLE_VERSION="ansible2.5"
+                        fi
+                        test "$ANSIBLE_VERSION" == "ansible2.5"
+                      on-evaluation-failure: dont-run
+                      steps:
+                        - multijob:
+                            name: 'ceph-ansible advanced cluster testing phase (ansible 2.5)'
+                            condition: SUCCESSFUL
+                            execution-type: PARALLEL
+                            projects:
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-bluestore_lvm_osds'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-bluestore_osds_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-bluestore_osds_non_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-docker_cluster_collocation'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-filestore_osds_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-filestore_osds_non_container'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-lvm_osds'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-ooo_collocation'
+                                current-parameters: true
+                              - name: 'ceph-ansible-prs-luminous-ansible2.5-xenial_cluster'
+                                current-parameters: true
 
     scm:
       - git:

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -9,6 +9,7 @@
       - luminous
     ansible_version:
       - ansible2.4
+      - ansible2.5
     scenario:
       - centos7_cluster
       - xenial_cluster
@@ -44,6 +45,7 @@
       - luminous
     ansible_version:
       - ansible2.4
+      - ansible2.5
     scenario:
       - purge_cluster_container
       - purge_cluster_non_container
@@ -64,6 +66,7 @@
       - luminous
     ansible_version:
       - ansible2.4
+      - ansible2.5
     scenario:
       - bluestore_osds_non_container
       - filestore_osds_non_container


### PR DESCRIPTION
Again, surely there's a more elegant way to do this but this works and doesn't rely on any additional plugins.

I tried setting the job names like `ceph-ansible-prs-luminous-$ANSIBLE_VERSION-purge_bluestore_osds_non_container` so I wouldn't have to duplicate code but `$ANSIBLE_VERSION` doesn't get set globally if I run it during a step in the first `multijob`.

The new conditionals could be boiled down to `test [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]` and `on-evaluation-failure` set accordingly but I think since this job yaml is already confusing, the larger functions make it somewhat clearer.