### PR TITLE
ceph-container: add a nightly flag

### DIFF
--- a/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
+++ b/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
@@ -56,6 +56,7 @@
       - inject:
           properties-content: |
             SCENARIO=ceph_ansible-{ceph-version}-{os}-{test}
+            NIGHTLY=TRUE
       - shell:
           !include-raw-escape:
             - ../../../scripts/build_utils.sh


### PR DESCRIPTION
In addition to ceph/ceph-container#1112

Adding this environment variable allows tests/tox.sh in ceph/ceph-container to
know whether we are running in a nightly job.

This is needed because ceph-container project checks if some code has
been changed, if no, test is not run.
Since in nightlies job will always enter this condition we must have a
way to be aware if we are running a nightly so we can skip this test.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>