### PR TITLE
ceph-ansible: Stop hardcoding ansible version in scenarios

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -2,8 +2,6 @@
     name: ceph-ansible-nightly-jewel-stable3.0
     release:
       - jewel
-    ansible_version:
-      - ansible2.4
     scenario:
       - centos7_cluster
       - xenial_cluster
@@ -26,14 +24,12 @@
     ceph_ansible_branch:
       - stable-3.0
     jobs:
-      - 'ceph-ansible-nightly-{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}'
+      - 'ceph-ansible-nightly-{release}-{ceph_ansible_branch}-{scenario}'
 
 - project:
     name: ceph-ansible-nightly-luminous-master
     release:
       - luminous
-    ansible_version:
-      - ansible2.4
     scenario:
       - centos7_cluster
       - xenial_cluster
@@ -62,15 +58,12 @@
     ceph_ansible_branch:
       - master
     jobs:
-        - 'ceph-ansible-nightly-{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}'
+        - 'ceph-ansible-nightly-{release}-{ceph_ansible_branch}-{scenario}'
 
 - project:
     name: ceph-ansible-nightly-luminous-stable3.1
     release:
       - luminous
-    ansible_version:
-      - ansible2.4
-      - ansible2.5
     scenario:
       - centos7_cluster
       - xenial_cluster
@@ -99,14 +92,12 @@
     ceph_ansible_branch:
       - stable-3.1
     jobs:
-        - 'ceph-ansible-nightly-{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}'
+        - 'ceph-ansible-nightly-{release}-{ceph_ansible_branch}-{scenario}'
 
 - project:
     name: ceph-ansible-nightly-luminous-stable3.0
     release:
       - luminous
-    ansible_version:
-      - ansible2.4
     scenario:
       - centos7_cluster
       - xenial_cluster
@@ -133,14 +124,14 @@
     ceph_ansible_branch:
       - stable-3.0
     jobs:
-        - 'ceph-ansible-nightly-{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}'
+        - 'ceph-ansible-nightly-{release}-{ceph_ansible_branch}-{scenario}'
 
 - job-template:
-    name: 'ceph-ansible-nightly-{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}'
+    name: 'ceph-ansible-nightly-{release}-{ceph_ansible_branch}-{scenario}'
     node: vagrant&&libvirt&&centos7
     concurrent: true
     defaults: global
-    display-name: 'ceph-ansible: Nightly [{release}-{ansible_version}-{ceph_ansible_branch}-{scenario}]'
+    display-name: 'ceph-ansible: Nightly [{release}-{ceph_ansible_branch}-{scenario}]'
     quiet-period: 5
     block-downstream: false
     block-upstream: false
@@ -178,7 +169,6 @@
           properties-content: |
             SCENARIO={scenario}
             RELEASE={release}
-            ANSIBLE_VERSION={ansible_version}
             CEPH_ANSIBLE_BRANCH={ceph_ansible_branch}
       - shell:
           !include-raw-escape:

--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -74,15 +74,15 @@
                       condition: SUCCESSFUL
                       execution-type: PARALLEL
                       projects:
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_bluestore_osds_non_container'
+                        - name: 'ceph-ansible-prs-luminous-purge_bluestore_osds_non_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_cluster_container'
+                        - name: 'ceph-ansible-prs-luminous-purge_cluster_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_cluster_non_container'
+                        - name: 'ceph-ansible-prs-luminous-purge_cluster_non_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_filestore_osds_container'
+                        - name: 'ceph-ansible-prs-luminous-purge_filestore_osds_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_filestore_osds_non_container'
+                        - name: 'ceph-ansible-prs-luminous-purge_filestore_osds_non_container'
                           current-parameters: true
             # If PR is NOT merging into stable-3.0 branch HEAD, run all scenarios
             - conditional-step:
@@ -98,17 +98,17 @@
                       condition: SUCCESSFUL
                       execution-type: PARALLEL
                       projects:
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_bluestore_osds_non_container'
+                        - name: 'ceph-ansible-prs-luminous-purge_bluestore_osds_non_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_cluster_container'
+                        - name: 'ceph-ansible-prs-luminous-purge_cluster_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_cluster_non_container'
+                        - name: 'ceph-ansible-prs-luminous-purge_cluster_non_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_filestore_osds_container'
+                        - name: 'ceph-ansible-prs-luminous-purge_filestore_osds_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_filestore_osds_non_container'
+                        - name: 'ceph-ansible-prs-luminous-purge_filestore_osds_non_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-purge_lvm_osds'
+                        - name: 'ceph-ansible-prs-luminous-purge_lvm_osds'
                           current-parameters: true
       - conditional-step:
           condition-kind: shell
@@ -123,9 +123,9 @@
                 condition: SUCCESSFUL
                 execution-type: PARALLEL
                 projects:
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-update_cluster'
+                  - name: 'ceph-ansible-prs-luminous-update_cluster'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-update_docker_cluster'
+                  - name: 'ceph-ansible-prs-luminous-update_docker_cluster'
                     current-parameters: true
       - conditional-step:
           condition-kind: shell
@@ -140,9 +140,9 @@
                 condition: SUCCESSFUL
                 execution-type: PARALLEL
                 projects:
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_mon'
+                  - name: 'ceph-ansible-prs-luminous-shrink_mon'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_mon_container'
+                  - name: 'ceph-ansible-prs-luminous-shrink_mon_container'
                     current-parameters: true
       - conditional-step:
           condition-kind: shell
@@ -157,9 +157,9 @@
                 condition: SUCCESSFUL
                 execution-type: PARALLEL
                 projects:
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_osd'
+                  - name: 'ceph-ansible-prs-luminous-shrink_osd'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-shrink_osd_container'
+                  - name: 'ceph-ansible-prs-luminous-shrink_osd_container'
                     current-parameters: true
       - conditional-step:
           condition-kind: shell
@@ -174,7 +174,7 @@
                 condition: SUCCESSFUL
                 execution-type: PARALLEL
                 projects:
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-switch_to_containers'
+                  - name: 'ceph-ansible-prs-luminous-switch_to_containers'
                     current-parameters: true
       - conditional-step:
           condition-kind: shell
@@ -193,9 +193,9 @@
                 condition: SUCCESSFUL
                 execution-type: PARALLEL
                 projects:
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-centos7_cluster'
+                  - name: 'ceph-ansible-prs-luminous-centos7_cluster'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-ansible2.4-docker_cluster'
+                  - name: 'ceph-ansible-prs-luminous-docker_cluster'
                     current-parameters: true
             # If PR is merging into stable-3.0 branch HEAD, run all but LVM scenarios
             - conditional-step:
@@ -211,19 +211,19 @@
                       condition: SUCCESSFUL
                       execution-type: PARALLEL
                       projects:
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_osds_container'
+                        - name: 'ceph-ansible-prs-luminous-bluestore_osds_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_osds_non_container'
+                        - name: 'ceph-ansible-prs-luminous-bluestore_osds_non_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-docker_cluster_collocation'
+                        - name: 'ceph-ansible-prs-luminous-docker_cluster_collocation'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-filestore_osds_container'
+                        - name: 'ceph-ansible-prs-luminous-filestore_osds_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-filestore_osds_non_container'
+                        - name: 'ceph-ansible-prs-luminous-filestore_osds_non_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-ooo_collocation'
+                        - name: 'ceph-ansible-prs-luminous-ooo_collocation'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-xenial_cluster'
+                        - name: 'ceph-ansible-prs-luminous-xenial_cluster'
                           current-parameters: true
             # If PR is NOT merging into stable-3.0 branch HEAD, run all scenarios
             - conditional-step:
@@ -239,23 +239,23 @@
                       condition: SUCCESSFUL
                       execution-type: PARALLEL
                       projects:
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_lvm_osds'
+                        - name: 'ceph-ansible-prs-luminous-bluestore_lvm_osds'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_osds_container'
+                        - name: 'ceph-ansible-prs-luminous-bluestore_osds_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-bluestore_osds_non_container'
+                        - name: 'ceph-ansible-prs-luminous-bluestore_osds_non_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-docker_cluster_collocation'
+                        - name: 'ceph-ansible-prs-luminous-docker_cluster_collocation'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-filestore_osds_container'
+                        - name: 'ceph-ansible-prs-luminous-filestore_osds_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-filestore_osds_non_container'
+                        - name: 'ceph-ansible-prs-luminous-filestore_osds_non_container'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-lvm_osds'
+                        - name: 'ceph-ansible-prs-luminous-lvm_osds'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-ooo_collocation'
+                        - name: 'ceph-ansible-prs-luminous-ooo_collocation'
                           current-parameters: true
-                        - name: 'ceph-ansible-prs-luminous-ansible2.4-xenial_cluster'
+                        - name: 'ceph-ansible-prs-luminous-xenial_cluster'
                           current-parameters: true
 
     scm:

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -7,8 +7,6 @@
     slave_labels: 'vagrant && libvirt && smithi'
     release:
       - luminous
-    ansible_version:
-      - ansible2.4
     scenario:
       - centos7_cluster
       - xenial_cluster
@@ -25,8 +23,6 @@
     slave_labels: 'vagrant && libvirt && smithi'
     release:
       - jewel
-    ansible_version:
-      - ansible2.4
     scenario:
       - centos7_cluster
       - xenial_cluster
@@ -42,8 +38,6 @@
     slave_labels: 'vagrant && libvirt && smithi'
     release:
       - luminous
-    ansible_version:
-      - ansible2.4
     scenario:
       - purge_cluster_container
       - purge_cluster_non_container
@@ -62,8 +56,6 @@
     slave_labels: 'vagrant && libvirt && !smithi && centos7'
     release:
       - luminous
-    ansible_version:
-      - ansible2.4
     scenario:
       - bluestore_osds_non_container
       - filestore_osds_non_container
@@ -86,8 +78,6 @@
     slave_labels: 'vagrant && libvirt && !smithi && centos7'
     release:
       - dev
-    ansible_version:
-      - ansible2.4
     scenario:
       - centos7_cluster
       - lvm_osds
@@ -97,12 +87,12 @@
       - 'ceph-ansible-prs-trigger'
 
 - job-template:
-    name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
+    name: 'ceph-ansible-prs-{release}-{scenario}'
     id: 'ceph-ansible-prs-oldstable-trigger'
     node: '{slave_labels}'
     concurrent: true
     defaults: global
-    display-name: 'ceph-ansible: Pull Requests [{release}-{ansible_version}-{scenario}]'
+    display-name: 'ceph-ansible: Pull Requests [{release}-{scenario}]'
     quiet-period: 5
     block-downstream: false
     block-upstream: false
@@ -128,15 +118,15 @@
           org-list:
             - ceph
           skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
-          trigger-phrase: '^jenkins test oldstable {release}-{ansible_version}-{scenario}|jenkins test oldstable.*'
+          trigger-phrase: '^jenkins test oldstable {release}-{scenario}|jenkins test oldstable.*'
           only-trigger-phrase: true
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false
-          status-context: "Testing: {release}-{ansible_version}-{scenario}"
-          started-status: "Running: {release}-{ansible_version}-{scenario}"
-          success-status: "OK - {release}-{ansible_version}-{scenario}"
-          failure-status: "FAIL - {release}-{ansible_version}-{scenario}"
+          status-context: "Testing: {release}-{scenario}"
+          started-status: "Running: {release}-{scenario}"
+          success-status: "OK - {release}-{scenario}"
+          failure-status: "FAIL - {release}-{scenario}"
 
     scm:
       - git:
@@ -154,7 +144,6 @@
           properties-content: |
             SCENARIO={scenario}
             RELEASE={release}
-            ANSIBLE_VERSION={ansible_version}
       - shell:
           !include-raw-escape:
             - ../../../scripts/build_utils.sh
@@ -179,12 +168,12 @@
           latest-only: false
 
 - job-template:
-    name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
+    name: 'ceph-ansible-prs-{release}-{scenario}'
     id: 'ceph-ansible-prs-auto'
     node: '{slave_labels}'
     concurrent: true
     defaults: global
-    display-name: 'ceph-ansible: Pull Requests [{release}-{ansible_version}-{scenario}]'
+    display-name: 'ceph-ansible: Pull Requests [{release}-{scenario}]'
     quiet-period: 5
     block-downstream: false
     block-upstream: false
@@ -210,15 +199,15 @@
           org-list:
             - ceph
           skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
-          trigger-phrase: '^jenkins test {release}-{ansible_version}-{scenario}|jenkins test all.*'
+          trigger-phrase: '^jenkins test {release}-{scenario}|jenkins test all.*'
           only-trigger-phrase: true
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false
-          status-context: "Testing: {release}-{ansible_version}-{scenario}"
-          started-status: "Running: {release}-{ansible_version}-{scenario}"
-          success-status: "OK - {release}-{ansible_version}-{scenario}"
-          failure-status: "FAIL - {release}-{ansible_version}-{scenario}"
+          status-context: "Testing: {release}-{scenario}"
+          started-status: "Running: {release}-{scenario}"
+          success-status: "OK - {release}-{scenario}"
+          failure-status: "FAIL - {release}-{scenario}"
 
     scm:
       - git:
@@ -236,7 +225,6 @@
           properties-content: |
             SCENARIO={scenario}
             RELEASE={release}
-            ANSIBLE_VERSION={ansible_version}
       - conditional-step:
           condition-kind: shell
           condition-command: |
@@ -274,12 +262,12 @@
           latest-only: false
 
 - job-template:
-    name: 'ceph-ansible-prs-{release}-{ansible_version}-{scenario}'
+    name: 'ceph-ansible-prs-{release}-{scenario}'
     id: 'ceph-ansible-prs-trigger'
     node: '{slave_labels}'
     concurrent: true
     defaults: global
-    display-name: 'ceph-ansible: Pull Requests [{release}-{ansible_version}-{scenario}]'
+    display-name: 'ceph-ansible: Pull Requests [{release}-{scenario}]'
     quiet-period: 5
     block-downstream: false
     block-upstream: false
@@ -305,15 +293,15 @@
           org-list:
             - ceph
           skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
-          trigger-phrase: '^jenkins test {release}-{ansible_version}-{scenario}|jenkins test all.*'
+          trigger-phrase: '^jenkins test {release}-{scenario}|jenkins test all.*'
           only-trigger-phrase: true
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false
-          status-context: "Testing: {release}-{ansible_version}-{scenario}"
-          started-status: "Running: {release}-{ansible_version}-{scenario}"
-          success-status: "OK - {release}-{ansible_version}-{scenario}"
-          failure-status: "FAIL - {release}-{ansible_version}-{scenario}"
+          status-context: "Testing: {release}-{scenario}"
+          started-status: "Running: {release}-{scenario}"
+          success-status: "OK - {release}-{scenario}"
+          failure-status: "FAIL - {release}-{scenario}"
 
     scm:
       - git:
@@ -331,7 +319,6 @@
           properties-content: |
             SCENARIO={scenario}
             RELEASE={release}
-            ANSIBLE_VERSION={ansible_version}
       - shell:
           !include-raw-escape:
             - ../../../scripts/build_utils.sh

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -698,7 +698,7 @@ else
   TOX_RUN_ENV=("CEPH_STABLE_RELEASE=$RELEASE" "${TOX_RUN_ENV[@]}")
 fi
 # shellcheck disable=SC2116
-if ! eval "$(echo "${TOX_RUN_ENV[@]}")" "$VENV"/tox -rv -e="$RELEASE"-"$ANSIBLE_VERSION"-"$SCENARIO" --workdir="$WORKDIR" -- --provider=libvirt; then echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
+if ! eval "$(echo "${TOX_RUN_ENV[@]}")" "$VENV"/tox -rv -e="$RELEASE"-"$SCENARIO" --workdir="$WORKDIR" -- --provider=libvirt; then echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
   exit 1
 fi
 }


### PR DESCRIPTION
We'll set the ansible version in each ceph-ansible branch's respective
requirements.txt.

For example, master will use ansible2.5 and stable-3.{1,2} will use ansible2.4.

The only reason the ansible version was in each scenario name was so it
could get passed to tox.

Signed-off-by: David Galloway <dgallowa@redhat.com>