### PR TITLE
ceph-ansible: update the testing matrix

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -1,5 +1,5 @@
 - project:
-    name: ceph-ansible-nightly-jewel-stable3.0
+    name: ceph-ansible-nightly-jewel
     release:
       - jewel
     scenario:
@@ -23,11 +23,12 @@
       - ooo_collocation
     ceph_ansible_branch:
       - stable-3.0
+      - stable-3.1
     jobs:
       - 'ceph-ansible-nightly-{release}-{ceph_ansible_branch}-{scenario}'
 
 - project:
-    name: ceph-ansible-nightly-luminous-master
+    name: ceph-ansible-nightly-stable3.0
     release:
       - luminous
     scenario:
@@ -35,8 +36,6 @@
       - xenial_cluster
       - docker_cluster
       - update_cluster
-      - lvm_osds
-      - purge_lvm_osds
       - docker_cluster_collocation
       - update_docker_cluster
       - switch_to_containers
@@ -56,14 +55,15 @@
       - purge_bluestore_osds_non_container
       - ooo_collocation
     ceph_ansible_branch:
-      - master
+      - stable-3.0
     jobs:
         - 'ceph-ansible-nightly-{release}-{ceph_ansible_branch}-{scenario}'
 
 - project:
-    name: ceph-ansible-nightly-luminous-stable3.1
+    name: ceph-ansible-nightly-stable3.1
     release:
       - luminous
+      - mimic
     scenario:
       - centos7_cluster
       - xenial_cluster
@@ -95,14 +95,16 @@
         - 'ceph-ansible-nightly-{release}-{ceph_ansible_branch}-{scenario}'
 
 - project:
-    name: ceph-ansible-nightly-luminous-stable3.0
+    name: ceph-ansible-nightly-master
     release:
-      - luminous
+      - dev
     scenario:
       - centos7_cluster
       - xenial_cluster
       - docker_cluster
       - update_cluster
+      - lvm_osds
+      - purge_lvm_osds
       - docker_cluster_collocation
       - update_docker_cluster
       - switch_to_containers
@@ -122,7 +124,7 @@
       - purge_bluestore_osds_non_container
       - ooo_collocation
     ceph_ansible_branch:
-      - stable-3.0
+      - master
     jobs:
         - 'ceph-ansible-nightly-{release}-{ceph_ansible_branch}-{scenario}'
 

--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -185,8 +185,6 @@
                     current-parameters: true
                   - name: 'ceph-ansible-prs-luminous-ooo_collocation'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-xenial_cluster'
-                    current-parameters: true
 
     scm:
       - git:

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -9,7 +9,6 @@
       - luminous
     scenario:
       - centos7_cluster
-      - xenial_cluster
       - docker_cluster
       - docker_cluster_collocation
       - bluestore_osds_container
@@ -25,7 +24,6 @@
       - jewel
     scenario:
       - centos7_cluster
-      - xenial_cluster
       - docker_cluster
       - ooo_collocation
     jobs:


### PR DESCRIPTION
stable-3.0 => jewel,luminous
stable-3.1 => jewel,luminous,mimic
master     => dev (last sha1 on master)

This also removes `xenial_cluster` scenario on PRs and leave it played in nightly.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>