### PR TITLE
ceph-ansible-prs: fix a typo

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -29,4 +29,4 @@ popd
 # stable-3.0 doesn't have ceph-volume and therefore doesn't support LVM scenarios.
 # Rather than running a bunch of conditional steps in the pipeline to check if
 # a PR is merging into the stable-3.0 branch, we'll just pass LVM jobs.
-[[ "$ghprbTargetBranch" == "stable-3.0" && "$scenario" == *"lvm"* ]] || start_tox
+[[ "$ghprbTargetBranch" == "stable-3.0" && "$SCENARIO" == *"lvm"* ]] || start_tox


### PR DESCRIPTION
`$scenario` gets set by the last iteration in the loop above.
The actual value we want is `$SCENARIO`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>