### PR TITLE
ceph-dashboard-pull-requests: Jenkins job for ceph dashboard frontend (e2e) tests

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -1,0 +1,60 @@
+- job:
+    name: ceph-dashboard-pull-requests
+    project-type: freestyle
+    defaults: global
+    concurrent: true
+    node: huge && (centos7 || trusty) && rebootable
+    display-name: 'ceph: dashboard Pull Requests'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 300
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+      - github:
+          url: https://github.com/ceph/ceph/
+      - rebuild:
+          auto-rebuild: true
+
+    parameters:
+      - string:
+          name: sha1
+          description: "A pull request ID, like 'origin/pr/72/head'"
+
+    triggers:
+      - github-pull-request:
+          allow-whitelist-orgs-as-admins: true
+          org-list:
+            - ceph
+          trigger-phrase: 'jenkins test dashboard'
+          skip-build-phrase: '^jenkins do not test.*'
+          only-trigger-phrase: true
+          github-hooks: true
+          permit-all: true
+          auto-close-on-fail: false
+          status-context: "ceph dashboard tests"
+          started-status: "running ceph dashboard tests"
+          success-status: "ceph dashboard tests succeeded"
+          failure-status: "ceph dashboard tests failed"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph.git
+          branches:
+            - ${sha1}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+
+    builders:
+      - shell: "export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
+      - shell:
+          !include-raw:
+            - ../../setup/setup
+      - shell: "timeout 7200  ./src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh"

--- a/ceph-dashboard-pull-requests/setup/setup
+++ b/ceph-dashboard-pull-requests/setup/setup
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+if grep -q  debian /etc/*-release; then
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+    wget https://dl.google.com/linux/linux_signing_key.pub
+    apt-key add linux_signing_key.pub
+    sudo apt-get update
+    sudo apt-get install -y google-chrome-stable
+
+elif grep -q rhel /etc/*-release; then
+    cat <<-EOF > /etc/yum.repos.d/google-chrome.repo
+		[google-chrome]
+		name=google-chrome
+		baseurl=http://dl.google.com/linux/chrome/rpm/stable/x86_64
+		enabled=1
+		gpgcheck=1
+		gpgkey=https://dl.google.com/linux/linux_signing_key.pub
+	EOF
+    yum install -y google-chrome-stable
+fi


### PR DESCRIPTION
This Jenkins job should be triggered for pull-requests labeled with "dashboard" and should execute the frontend (e2e) tests.
To be able to execute the tests it's required to have a browser installed (in this case Google Chrome).

The "[ceph-dashboard-pull-requests.yml](https://github.com/ceph/ceph-build/blob/master/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)" is based on the ceph-pull-requests.yml file with some modifications.

``Signed-off-by: Laura Paduano lpaduano@suse.com``