### PR TITLE
ceph-ansible-pipeline: remove one step

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -164,11 +164,6 @@
                     current-parameters: true
                   - name: 'ceph-ansible-prs-luminous-docker_cluster'
                     current-parameters: true
-            - multijob:
-                name: 'ceph-ansible advanced cluster testing phase'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
                   - name: 'ceph-ansible-prs-luminous-bluestore_lvm_osds'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-luminous-bluestore_osds_container'


### PR DESCRIPTION
save some times by removing one step, let's run everything in one step.

Otherwise, it's ~4h of CI testing for 1 PR, removing this step will make
amount of time divided per 2.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>