### PR TITLE
ceph-ansible-pr-syntax-check: add cbheck for coding convention

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -57,6 +57,17 @@ function test_sign_off {
   echo "Sign-off ok!" && return 0
 }
 
+function test_capital_letter {
+  for commit in $(git log --no-merges --pretty=format:"%h" origin/"${ghprbTargetBranch}"..HEAD); do
+    if git show "$commit" | grep -E "\\- name:" | grep '[[:upper:]]'; then
+      echo "'- name:' statement must not contain any capital letters!"
+      echo "Remove any capital letters from task's name."
+      return 1
+    fi
+  done
+  echo "No capital letters found in task's name!" && return 0
+}
+
 
 ########
 # MAIN #
@@ -66,3 +77,4 @@ syntax_check
 #ansible_lint
 group_vars_check
 test_sign_off
+test_capital_letter


### PR DESCRIPTION
One of our convention in ceph-ansible is to not use capital letters in
task's name. So let's hardcode it in the initial phase of the pipeline.
ALso, this will let user discover what's wrong without us doing the
review and finding the problem.

Signed-off-by: Sébastien Han <seb@redhat.com>