### PR TITLE
ceph-volume-ansible-prs: use underscores for scenarios

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -42,8 +42,8 @@
       - bluestore
       - filestore
     scenario:
-      - single-type
-      - single-type-dmcrypt
+      - single_type
+      - single_type_dmcrypt
     subcommand:
       - batch
 


### PR DESCRIPTION
This was causing issues in tox, where '-' is used as a delimiter, and it is now being updated on the PR that introduces batch tests ( https://github.com/ceph/ceph/pull/23532 )