### PR TITLE
ceph-ansible-pr-syntax-check: do not check for removed lines

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -59,7 +59,7 @@ function test_sign_off {
 
 function test_capital_letter {
   for commit in $(git log --no-merges --pretty=format:"%h" origin/"${ghprbTargetBranch}"..HEAD); do
-    if git show "$commit" | grep -E "\\- name:" | grep '[[:upper:]]'; then
+    if git show "$commit" | grep -E '^[<>+].*- name:' | grep '[[:upper:]]'; then
       echo "'- name:' statement must not contain any capital letters!"
       echo "Remove any capital letters from task's name."
       return 1


### PR DESCRIPTION
The git show was returning - and + lines, we only want to check for
lines that were added not removed.

Signed-off-by: Sébastien Han <seb@redhat.com>