### PR TITLE
ceph-ansible-pr-syntax-check: use latest ansible version

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -4,7 +4,7 @@ set -e
 
 # the following two methods exist in scripts/build_utils.sh
 # shellcheck disable=SC2034
-pkgs=( "ansible==2.3.1" "ansible-lint" )
+pkgs=( "ansible" "ansible-lint" )
 install_python_packages "pkgs[@]"
 
 


### PR DESCRIPTION
There is no reason to pin to an old ansible version. Since this is doing
syntax checking we should have the latest Ansible version to compare
against our latest ceph-ansible code.

Signed-off-by: Sébastien Han <seb@redhat.com>