### PR TITLE
ceph-pull-requests-arm64: set jobs number according to free memory

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -74,16 +74,17 @@ echo deb vers $bpvers
 echo building debs for $DIST
 
 CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS $(extra_cmake_args)"
+DEB_BUILD_OPTIONS="parallel=$(get_nr_build_jobs)"
 
 # pass only those env vars specifically noted
 sudo \
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS" \
     CEPH_EXTRA_CONFIGURE_ARGS="$CEPH_EXTRA_CONFIGURE_ARGS" \
+    DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS" \
     pbuilder build \
     --distribution $DIST \
     --basetgz $pbuilddir/$DIST.tgz \
     --buildresult $releasedir/$cephver \
-    --debbuildopts "-j`grep -c processor /proc/cpuinfo`" \
     $releasedir/$cephver/ceph_$bpvers.dsc
 
 # do lintian checks

--- a/ceph-dev-build/build/build_deb
+++ b/ceph-dev-build/build/build_deb
@@ -74,16 +74,17 @@ echo deb vers $bpvers
 echo building debs for $DIST
 
 CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS $(extra_cmake_args)"
+DEB_BUILD_OPTIONS="parallel=$(get_nr_build_jobs)"
 
 # pass only those env vars specifically noted
 sudo \
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS" \
     CEPH_EXTRA_CONFIGURE_ARGS="$CEPH_EXTRA_CONFIGURE_ARGS" \
+    DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS" \
     pbuilder build \
     --distribution $DIST \
     --basetgz $pbuilddir/$DIST.tgz \
     --buildresult $releasedir/$cephver \
-    --debbuildopts "-j`grep -c processor /proc/cpuinfo`" \
     $releasedir/$cephver/ceph_$bpvers.dsc
 
 # do lintian checks

--- a/ceph-dev-new-build/build/build_deb
+++ b/ceph-dev-new-build/build/build_deb
@@ -74,16 +74,17 @@ echo deb vers $bpvers
 echo building debs for $DIST
 
 CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS $(extra_cmake_args)"
+DEB_BUILD_OPTIONS="parallel=$(get_nr_build_jobs)"
 
 # pass only those env vars specifically noted
 sudo \
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS" \
     CEPH_EXTRA_CONFIGURE_ARGS="$CEPH_EXTRA_CONFIGURE_ARGS" \
+    DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS" \
     pbuilder build \
     --distribution $DIST \
     --basetgz $pbuilddir/$DIST.tgz \
     --buildresult $releasedir/$cephver \
-    --debbuildopts "-j`grep -c processor /proc/cpuinfo`" \
     $releasedir/$cephver/ceph_$bpvers.dsc
 
 # do lintian checks

--- a/ceph-pull-requests-arm64/build/build
+++ b/ceph-pull-requests-arm64/build/build
@@ -1,8 +1,8 @@
 #!/bin/bash -ex
-NPROC=$(nproc)
-testnproc=$(($NPROC / 4))
-export CHECK_MAKEOPTS="-j${testnproc}"
-export BUILD_MAKEOPTS="-j${NPROC}"
+n_build_jobs=$(get_nr_build_jobs)
+n_test_jobs=$(($(nproc) / 4))
+export CHECK_MAKEOPTS="-j${n_test_jobs}"
+export BUILD_MAKEOPTS="-j${n_build_jobs}"
 timeout 3h ./run-make-check.sh
 sleep 5
 ps -ef | grep ceph || true

--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -4,7 +4,8 @@
     builders:
     - shell:
         !include-raw:
-        - ../../build/build
+          - ../../../scripts/build_utils.sh
+          - ../../build/build
     concurrent: true
     disabled: false
     name: ceph-pull-requests-arm64

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -830,3 +830,21 @@ teardown_vagrant_tests() {
         sudo virsh net-undefine $network || true
     done
 }
+
+get_nr_build_jobs() {
+    # assume each compiling job takes 1800 MiB memory on average
+    local nproc=$(nproc)
+    local max_build_jobs=$(vmstat --stats --unit m | \
+                               grep 'free memory' | \
+                               awk '{print int($1/1800)}')
+    if [[ $max_build_jobs -eq 0 ]]; then
+        # probably the system is under high load, use a safe number
+        max_build_jobs=16
+    fi
+    if [[ $nproc -ge $max_build_jobs ]]; then
+        n_build_jobs=$max_build_jobs
+    else
+        n_build_jobs=$nproc
+    fi
+    echo $n_build_jobs
+}


### PR DESCRIPTION
guess we are using more compile-time optimizations now, to compile
ceph source requires more memory. sometimes, a single cc1plus takes
more than 3GB memeory. that's why we are seeing more and more OOM
in our arm64 builders. following is a sample from omani09 -- a
arm64 builder compiling a ceph/ceph PR targeting master:
```
30474 jenkins+  20   0 2573092 2.388g  16220 R 100.0  3.8   9:11.04 cc1plus
34339 jenkins+  20   0 3279768 3.005g  16296 R 100.0  4.8   5:07.63 cc1plus
36382 jenkins+  20   0  322276 278932  12740 R 100.0  0.4   0:09.78 cc1plus
...
```
also, the performance of over-all compiling is also impacted by the I/O
subsystem. so lower the number of job could actually reduce the time
of the compiling processes to completing for the I/O queue of local
device. so we can use an conservative number for calc an upper bound of
job number for "make" instead using $(nproc). in this change,
$(free_memory_in_mega / 1800) is used as the upper limit of n_jobs.

Signed-off-by: Kefu Chai <kchai@redhat.com>