### PR TITLE
ceph-volume: deploy the target branch, not the source branch

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -24,6 +24,6 @@ update_vagrant_boxes
 
 cd src/ceph-volume/ceph_volume/tests/functional/$SUBCOMMAND
 
-CEPH_DEV_BRANCH=$BRANCH CEPH_DEV_SHA1=$SHA $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt
+CEPH_DEV_BRANCH=$ghprbTargetBranch $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt
 
 GITHUB_STATUS_STATE="success" $VENV/github-status create

--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -1,8 +1,11 @@
+# disabling centos7 for now as we're having infrastructure issues
+# with OVH and the centos7 vm kernel panics after booting
+
 - project:
     name: ceph-volume-ansible-prs-lvm
     distro:
       - xenial
-      - centos7
+#     - centos7
     objectstore:
       - bluestore
       - filestore
@@ -19,7 +22,7 @@
     name: ceph-volume-ansible-prs-simple
     distro:
       - xenial
-      - centos7
+#     - centos7
     objectstore:
       - bluestore
       - filestore
@@ -37,7 +40,7 @@
     name: ceph-volume-ansible-prs-batch
     distro:
       - xenial
-      - centos7
+#     - centos7
     objectstore:
       - bluestore
       - filestore


### PR DESCRIPTION
In https://github.com/ceph/ceph/pull/23697 we've made a change so that we can rsync the ceph-volume code to the testing vms instead of waiting for a repo to be built. The ceph-volume tests rarely need a build, so this allows us to test faster and avoid waiting for a repo to be built for each change we make to a ceph-volume PR.

This also disables the centos7 tests because we're having infrastructure issues. When those have been resolved we'll enable them again.