### PR TITLE
ceph-volume-ansible-prs: enable tests on centos 7

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -1,11 +1,9 @@
-# disabling centos7 for now as we're having infrastructure issues
-# with OVH and the centos7 vm kernel panics after booting
 
 - project:
     name: ceph-volume-ansible-prs-lvm
     distro:
       - xenial
-#     - centos7
+      - centos7
     objectstore:
       - bluestore
       - filestore
@@ -22,7 +20,7 @@
     name: ceph-volume-ansible-prs-simple
     distro:
       - xenial
-#     - centos7
+      - centos7
     objectstore:
       - bluestore
       - filestore
@@ -40,7 +38,7 @@
     name: ceph-volume-ansible-prs-batch
     distro:
       - xenial
-#     - centos7
+      - centos7
     objectstore:
       - bluestore
       - filestore


### PR DESCRIPTION
Running the tests on Centos 7.4 hosts allows the vagrant vms
to boot properly.

See:
https://github.com/ceph/mita/pull/126/commits/35d53b13e177831306b0b401b0b5d0fafecf4b78

Signed-off-by: Andrew Schoen <aschoen@redhat.com>