### PR TITLE
ceph-ansible-pr-syntax-check: group_vars operator

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -40,7 +40,7 @@ function group_vars_check {
 
   # we use || true so we still count and don't fail if we don't find anything
   nb_group_vars=$(match_file "group_vars/" | wc -l)
-  if [[ "$nb" -ne "$nb_group_vars" ]]; then
+  if [[ "$nb" -gt "$nb_group_vars" ]]; then
     echo "One or more files containing default variables has/have been modified."
     echo "You must run 'generate_group_vars_sample.sh' to generate the group_vars template files."
     return 1


### PR DESCRIPTION
When defaults/main.yml is touched we will generate 2 group_vars files,
one for all.yml.sample and one for rhcs.yml.sample, this is making the
conditional never pass since there is one more value in the count.

Basically if defaults/main.yml and osd/defaults/main.yml are touched
this will result in 3 group_vars file but the count for
defaults/main.yml is 2.

In the end we want to fail if the number of defaults/main.yml is
greather than the number of group_vars files.

Signed-off-by: Sébastien Han <seb@redhat.com>