### PR TITLE
sepia-fog-images: Don't hardcode distros

### DIFF
--- a/sepia-fog-images/build/build
+++ b/sepia-fog-images/build/build
@@ -10,27 +10,17 @@ set -ex
 
 # Converts distro friendly names into Cobbler/FOG image names
 funSetProfiles () {
-  if [ "$1" == "trusty" ]; then
-    cobblerprofile="Ubuntu-14.04-server-x86_64"
-    fogprofile="ubuntu_14.04"
-  elif [ "$1" == "xenial" ]; then
-    cobblerprofile="Ubuntu-16.04-server-x86_64"
-    fogprofile="ubuntu_16.04"
-  elif [ "$1" == "bionic" ]; then
-    cobblerprofile="Ubuntu-18.04-server-x86_64"
-    fogprofile="ubuntu_18.04"
-  elif [ "$1" == "centos74" ]; then
-    cobblerprofile="CentOS-7.4-x86_64"
-    fogprofile="centos_7.4"
-  elif [ "$1" == "centos75" ]; then
-    cobblerprofile="CentOS-7.5-x86_64"
-    fogprofile="centos_7.5"
-  elif [ "$1" == "rhel74" ]; then
-    cobblerprofile="RHEL-7.4-Server-x86_64"
-    fogprofile="rhel_7.4"
-  elif [ "$1" == "rhel75" ]; then
-    cobblerprofile="RHEL-7.5-Server-x86_64"
-    fogprofile="rhel_7.5"
+  splitdistro=$(echo $1 | cut -d '_' -f1)
+  distroversion=$(echo $1 | cut -d '_' -f2)
+  if [ "$splitdistro" == "ubuntu" ]; then
+    cobblerprofile="Ubuntu-$distroversion-server-x86_64"
+    fogprofile="ubuntu_$distroversion"
+  elif [ "$splitdistro" == "rhel" ]; then
+    cobblerprofile="RHEL-$distroversion-Server-x86_64"
+    fogprofile="rhel_$distroversion"
+  elif [ "$splitdistro" == "centos" ]; then
+    cobblerprofile="CentOS-$distroversion-x86_64"
+    fogprofile="centos_$distroversion"
   else
     echo "Unknown profile $1"
     exit 1

--- a/sepia-fog-images/config/definitions/sepia-fog-images.yml
+++ b/sepia-fog-images/config/definitions/sepia-fog-images.yml
@@ -18,8 +18,8 @@
     parameters:
       - string:
           name: DISTROS
-          default: "trusty xenial bionic centos74 rhel75"
-          description: "Distro to capture images for: (e.g., 'trusty', 'xenial', 'centos74' or 'trusty xenial' for multiple distros)"
+          default: "ubuntu_14.04 ubuntu_16.04 centos_7.5 rhel_7.5"
+          description: "Distro to capture images for: (e.g., 'ubuntu_16.04', 'centos_7.5' or 'ubuntu_16.04 rhel_7.5' for multiple distros)"
       - string:
           name: MACHINETYPES
           default: "smithi mira"


### PR DESCRIPTION
This change ensures I don't have to add or remove if statements in
funSetProfiles function any time there's a new distro version released.