### PR TITLE
ceph-medic-tests: disable nightly tests

### DIFF
--- a/ceph-medic-tests/config/definitions/ceph-medic-tests.yml
+++ b/ceph-medic-tests/config/definitions/ceph-medic-tests.yml
@@ -1,5 +1,8 @@
 - project:
     name: ceph-medic-tests
+    # disabled because it is broken with current ceph-ansible master and there
+    # is no active development going on
+    disabled: true
     scenario:
       - ansible2.3-nightly_centos7
     jobs:


### PR DESCRIPTION
There is currently no active development on the project and the nightly tests are thoroughly broken from changes in ceph-ansible.
