### PR TITLE
Change build discard options for ceph and ceph-volume jobs

### DIFF
--- a/ceph-pr-arm-trigger/config/definitions/ceph-pr-arm-trigger.yml
+++ b/ceph-pr-arm-trigger/config/definitions/ceph-pr-arm-trigger.yml
@@ -11,8 +11,7 @@
     block-upstream: false
     properties:
       - build-discarder:
-          days-to-keep: 1
-          num-to-keep: 10
+          days-to-keep: 15
           artifact-days-to-keep: -1
           artifact-num-to-keep: -1
       - github:

--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -40,9 +40,7 @@
     properties:
       - build-discarder:
           days-to-keep: 15
-          num-to-keep: 30
-          artifact-days-to-keep: -1
-          artifact-num-to-keep: -1
+          artifact-days-to-keep: 15
       - github:
           url: https://github.com/ceph/ceph/
 

--- a/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
@@ -12,7 +12,6 @@
     properties:
       - build-discarder:
           days-to-keep: 15
-          num-to-keep: 30
           artifact-days-to-keep: -1
           artifact-num-to-keep: -1
       - github:

--- a/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
+++ b/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
@@ -12,9 +12,7 @@
     properties:
       - build-discarder:
           days-to-keep: 15
-          num-to-keep: 30
-          artifact-days-to-keep: -1
-          artifact-num-to-keep: -1
+          artifact-days-to-keep: 15
       - github:
           url: https://github.com/ceph/ceph
 

--- a/ceph-volume-test/config/definitions/ceph-volume-test.yml
+++ b/ceph-volume-test/config/definitions/ceph-volume-test.yml
@@ -9,10 +9,8 @@
     concurrent: true
     properties:
       - build-discarder:
-          days-to-keep: 90
-          num-to-keep: 25
-          artifact-days-to-keep: 25
-          artifact-num-to-keep: 25
+          days-to-keep: 20
+          artifact-num-to-keep: 20
       - github:
           url: https://github.com/ceph/ceph
 


### PR DESCRIPTION
So that it isn't limited by the number, it is limited by days only. This
will allow builds to avoid 404'ing when the limit is reached, which is
unexpected if there are too many builds and not long enough time between
them (like 100 builds in one day, but limit is 20 before discarding)

Signed-off-by: Alfredo Deza <adeza@redhat.com>