### PR TITLE
ceph-container: Don't test Ubuntu

### DIFF
--- a/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
+++ b/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
@@ -2,7 +2,6 @@
     name: ceph-container-nightly
     os:
       - centos7
-      - xenial
     ceph-version:
       - jewel
       - luminous

--- a/ceph-container-prs/config/definitions/ceph-container-prs.yml
+++ b/ceph-container-prs/config/definitions/ceph-container-prs.yml
@@ -12,19 +12,6 @@
     jobs:
         - 'ceph-container-prs-auto'
 
-- project:
-    name: ceph-container-prs-trigger
-    os:
-      - xenial
-    ceph-version:
-      - jewel
-    test:
-      - cluster
-      - filestore_osds_container
-      - docker_cluster_collocation
-    jobs:
-        - 'ceph-container-prs-trigger'
-
 - job-template:
     name: 'ceph-container-prs-ceph_ansible-{ceph-version}-{os}-{test}'
     id: 'ceph-container-prs-auto'


### PR DESCRIPTION
No longer tested on Ubuntu: https://github.com/ceph/ceph-container/pull/1167