### PR TITLE
scripts/build_utils.sh: increase mem per job to 2.2GB

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -832,11 +832,11 @@ teardown_vagrant_tests() {
 }
 
 get_nr_build_jobs() {
-    # assume each compiling job takes 1800 MiB memory on average
+    # assume each compiling job takes 2200 MiB memory on average
     local nproc=$(nproc)
     local max_build_jobs=$(vmstat --stats --unit m | \
                                grep 'total memory' | \
-                               awk '{print int($1/1800)}')
+                               awk '{print int($1/2200)}')
     if [[ $max_build_jobs -eq 0 ]]; then
         # probably the system is under high load, use a safe number
         max_build_jobs=16


### PR DESCRIPTION
it's observed that on our arm64 build host, using the existing
$total_mem/1600, n_build_jobs=37 . but we still have following error
when compiling Ceph:

virtual memory exhausted: Cannot allocate memory
make[3]: *** [src/mds/CMakeFiles/mds.dir/SnapClient.cc.o] Error 1

so increase the denominator to 2200 .

Signed-off-by: Kefu Chai <kchai@redhat.com>