### PR TITLE
ceph-volume-pr: add the TargetBranch param for manually triggering it

### DIFF
--- a/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
@@ -25,6 +25,9 @@
           name: ghprbSourceBranch
           description: "When manually triggered, and the remote PR isn't a branch in the ceph.git repo This can be specified to determine the actual branch."
       - string:
+          name: ghprbTargetBranch
+          description: 'Required when manually triggered,  the targeted branch needs to be set (e.g. "luminous" or "master")'
+      - string:
           name: GITHUB_SHA
           description: "The tip (last commit) in the PR, a sha1 like 7d787849556788961155534039886aedfcdb2a88 (if set, will report status to Github)"
 


### PR DESCRIPTION
So that tox tests can be triggered manually (or via de CLI). Already working nicely for ceph-volume PRs
