### PR TITLE
ceph-dashboard-pull-requests: fix another permission denied issue

### DIFF
--- a/ceph-dashboard-pull-requests/setup/setup
+++ b/ceph-dashboard-pull-requests/setup/setup
@@ -4,7 +4,7 @@ set -ex
 if grep -q  debian /etc/*-release; then
     sudo bash -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list'
     wget https://dl.google.com/linux/linux_signing_key.pub
-    apt-key add linux_signing_key.pub
+    sudo apt-key add linux_signing_key.pub
     sudo apt-get update
     sudo apt-get install -y google-chrome-stable
 


### PR DESCRIPTION
Jenkins job failure:
``+ apt-key add linux_signing_key.pub
ERROR: This command can only be used by root.``

see: https://jenkins.ceph.com/job/ceph-dashboard-pull-requests/2/console

Signed-off-by: Laura Paduano <lpaduano@suse.com>