### PR TITLE
ceph-dashboard-pull-requests: switch to https for Chrome URLs

### DIFF
--- a/ceph-dashboard-pull-requests/setup/setup
+++ b/ceph-dashboard-pull-requests/setup/setup
@@ -2,7 +2,7 @@
 set -ex
 
 if grep -q  debian /etc/*-release; then
-    sudo bash -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list'
+    sudo bash -c 'echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list'
     wget https://dl.google.com/linux/linux_signing_key.pub
     sudo apt-key add linux_signing_key.pub
     sudo apt-get update
@@ -12,7 +12,7 @@ elif grep -q rhel /etc/*-release; then
     sudo cat <<-EOF > /etc/yum.repos.d/google-chrome.repo
 		[google-chrome]
 		name=google-chrome
-		baseurl=http://dl.google.com/linux/chrome/rpm/stable/x86_64
+		baseurl=https://dl.google.com/linux/chrome/rpm/stable/x86_64
 		enabled=1
 		gpgcheck=1
 		gpgkey=https://dl.google.com/linux/linux_signing_key.pub


### PR DESCRIPTION
Note: this needs to be tested by triggering the Jenkins job (seems to work for the deb repository though), if it does not work I have to revert this change.
Signed-off-by: Laura Paduano <lpaduano@suse.com>