### PR TITLE
scripts/build_utils.sh: add lang=none option to sources.list

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -534,20 +534,20 @@ setup_pbuilder_for_new_gcc() {
     # in test repo.
     if [ "$ARCH" = "arm64" ]; then
         cat > $hookdir/D05install-gcc-7 <<EOF
-echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu $DIST main" >> \
+echo "deb [lang=none] http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu $DIST main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
-echo "deb http://ports.ubuntu.com/ubuntu-ports $DIST-updates main" >> \
+echo "deb [lang=none] http://ports.ubuntu.com/ubuntu-ports $DIST-updates main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
 EOF
     elif [ "$ARCH" = "x86_64" ]; then
         cat > $hookdir/D05install-gcc-7 <<EOF
-echo "deb http://security.ubuntu.com/ubuntu $DIST-security main" >> \
+echo "deb [lang=none] http://security.ubuntu.com/ubuntu $DIST-security main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
-echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu $DIST main" >> \
+echo "deb [lang=none] http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu $DIST main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
-echo "deb [arch=amd64] http://mirror.cs.uchicago.edu/ubuntu-toolchain-r $DIST main" >> \
+echo "deb [arch=amd64 lang=none] http://mirror.cs.uchicago.edu/ubuntu-toolchain-r $DIST main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
-echo "deb [arch=amd64,i386] http://mirror.yandex.ru/mirrors/launchpad/ubuntu-toolchain-r $DIST main" >> \
+echo "deb [arch=amd64,i386 lang=none] http://mirror.yandex.ru/mirrors/launchpad/ubuntu-toolchain-r $DIST main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
 EOF
     else


### PR DESCRIPTION
some mirrors do not contains the package description translations. when
apt tries to download the packages descriptions, it fails like:

E: Failed to fetch
http://mirror.yandex.ru/mirrors/launchpad/ubuntu-toolchain-r/dists/xenial/main/i18n/Translation-en
404  Not Found [IP: 213.180.204.183 80]
E: Some index files failed to download. They have been ignored, or old
ones used instead.

for more info, see sources.list(5) and apt.conf(5). the default value
of "lang" is set by Acquire::Languages, which is in turn "en" and
"environment" by default. we need to override them with "none".

Fixes #1136
Signed-off-by: Kefu Chai <kchai@redhat.com>