### PR TITLE
ceph-ansible: don't check for capital letter in meta directories

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -50,7 +50,7 @@ function group_vars_check {
 function git_diff_to_head {
   # shellcheck disable=SC2154
   # ghprbTargetBranch variable comes from jenkins's injectedEnvVars
-  git diff origin/"${ghprbTargetBranch}"..HEAD
+  git diff origin/"${ghprbTargetBranch}"..HEAD -- . ':(exclude)roles/*/meta/*'
 }
 
 function match_file {


### PR DESCRIPTION
it's expected to have capital letters in roles/*/meta/main.yml so let's
exclude this path in git_diff_to_head function.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>