### PR TITLE
ceph-dashboard-pull-requests: fix permission denied error

### DIFF
--- a/ceph-dashboard-pull-requests/setup/setup
+++ b/ceph-dashboard-pull-requests/setup/setup
@@ -9,13 +9,13 @@ if grep -q  debian /etc/*-release; then
     sudo apt-get install -y google-chrome-stable
 
 elif grep -q rhel /etc/*-release; then
-    sudo cat <<-EOF > /etc/yum.repos.d/google-chrome.repo
-		[google-chrome]
-		name=google-chrome
-		baseurl=https://dl.google.com/linux/chrome/rpm/stable/x86_64
-		enabled=1
-		gpgcheck=1
-		gpgkey=https://dl.google.com/linux/linux_signing_key.pub
-	EOF
+    sudo dd of=/etc/yum.repos.d/google-chrome.repo status=none <<EOF
+[google-chrome]
+name=google-chrome
+baseurl=https://dl.google.com/linux/chrome/rpm/stable/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=https://dl.google.com/linux/linux_signing_key.pub
+EOF
     sudo yum install -y google-chrome-stable
 fi


### PR DESCRIPTION
as stdout redirect is performed by the shell, and shell is launched by
the "jenkins" user, so permission denied is expected when we are trying
to create a file under /etc/yum.repos.d/. in that case, we'll have
following failure:

/tmp/jenkins8899238112048417478.sh: line 14:
/etc/yum.repos.d/google-chrome.repo: Permission denied
Build step 'Execute shell' marked build as failure

Signed-off-by: Kefu Chai <kchai@redhat.com>