### PR TITLE
add new ceph-container-build-ceph-base-push-imgs job

### DIFF
--- a/ceph-container-build-ceph-base-push-imgs/build/build
+++ b/ceph-container-build-ceph-base-push-imgs/build/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+
+cd "$WORKSPACE"/ceph-container/ || exit
+bash -x contrib/build-ceph-base.sh

--- a/ceph-container-build-ceph-base-push-imgs/config/JENKINS_URL
+++ b/ceph-container-build-ceph-base-push-imgs/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-container-build-ceph-base-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-ceph-base-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
@@ -1,0 +1,46 @@
+- job:
+    name: ceph-container-build-ceph-base-push-imgs
+    node: huge && trusty && x86_64
+    project-type: freestyle
+    defaults: global
+    display-name: 'ceph-container: build and push ceph base container images to Docker Hub'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 1
+          artifact-days-to-keep: 1
+          artifact-num-to-keep: 1
+      - github:
+          url: https://github.com/ceph/ceph-container
+
+    triggers:
+      - timed: '@daily'
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-container.git
+          branches:
+            - master
+          browser: auto
+          basedir: "ceph-container"
+          timeout: 20
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: docker-hub-leseb
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD


### PR DESCRIPTION
This job runs on a daily basis and is responsible for building ceph/base
versionned images.

Signed-off-by: Sébastien Han <seb@redhat.com>