### PR TITLE
ceph-container-build-ceph-base-push-imgs: build with arg

### DIFF
--- a/ceph-container-build-ceph-base-push-imgs/build/build
+++ b/ceph-container-build-ceph-base-push-imgs/build/build
@@ -3,4 +3,4 @@ set -e
 
 
 cd "$WORKSPACE"/ceph-container/ || exit
-bash -x contrib/build-ceph-base.sh
+ARCH=x86_64 bash -x contrib/build-ceph-base.sh


### PR DESCRIPTION
We need to pass the ARCH so the build can successfully run.

Signed-off-by: Sébastien Han <seb@redhat.com>