### PR TITLE
ceph-dashboard-pull-requests: Need to cd to the dashboard dir

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -57,4 +57,4 @@
       - shell:
           !include-raw:
             - ../../setup/setup
-      - shell: "timeout 7200  ./src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh"
+      - shell: "cd src/pybind/mgr/dashboard; timeout 7200 ./run-frontend-e2e-tests.sh"


### PR DESCRIPTION
..before executing the e2e script

Otherwise it fails with the following error:
``./src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh: line 39: cd: ../../../../build: No such file or directory``

Signed-off-by: Laura Paduano <lpaduano@suse.com>