### PR TITLE
ceph-ansible fix job typo in pipeline

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -215,7 +215,7 @@
                 projects:
                   - name: 'ceph-ansible-prs-luminous-lvm_osds'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-lvm_osds_containers'
+                  - name: 'ceph-ansible-prs-luminous-lvm_osds_container'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-luminous-bluestore_lvm_osds'
                     current-parameters: true


### PR DESCRIPTION
The job name is ceph-ansible-prs-luminous-lvm_osds_container

Signed-off-by: Sébastien Han <seb@redhat.com>