### PR TITLE
ceph-dashboard-pull-requests: install python3 packages

### DIFF
--- a/ceph-dashboard-pull-requests/setup/setup
+++ b/ceph-dashboard-pull-requests/setup/setup
@@ -7,6 +7,7 @@ if grep -q  debian /etc/*-release; then
     sudo apt-key add linux_signing_key.pub
     sudo apt-get update
     sudo apt-get install -y google-chrome-stable
+    sudo apt-get install -y python3-werkzeug python3-bcrypt python3-routes python3-requests
 
 elif grep -q rhel /etc/*-release; then
     sudo dd of=/etc/yum.repos.d/google-chrome.repo status=none <<EOF
@@ -18,4 +19,5 @@ gpgcheck=1
 gpgkey=https://dl.google.com/linux/linux_signing_key.pub
 EOF
     sudo yum install -y google-chrome-stable
+    sudo yum install -y python3-werkzeug python3-bcrypt python3-routes python3-requests
 fi


### PR DESCRIPTION
Testing a fix which worked for my local environment when running vstart (was able to reproduce the same error which is currently occurring in the Jenkins job, see e.g. https://jenkins.ceph.com/job/ceph-dashboard-pull-requests/21/consoleFull, tested different PRs and it always failed with the same error):

``/home/jenkins-build/build/workspace/ceph-dashboard-pull-requests/build/bin/ceph-mgr -i y -c /home/jenkins-build/build/workspace/ceph-dashboard-pull-requests/build/ceph.conf 
/home/jenkins-build/build/workspace/ceph-dashboard-pull-requests/build/bin/ceph -c /home/jenkins-build/build/workspace/ceph-dashboard-pull-requests/build/ceph.conf -k /home/jenkins-build/build/workspace/ceph-dashboard-pull-requests/build/keyring tell mgr dashboard ac-user-create admin admin administrator``

``no valid command found; 10 closest matches:
osd status {<bucket>}
hello {<person_name>}
diskprediction status
diskprediction self-test
device predict-life-expectancy <dev_id>
device debug smart-forced
device debug prediction-forced
device debug metrics-forced
device get-predicted-status <dev_id>
influx config-show
Error EINVAL: invalid command``

Signed-off-by: Laura Paduano <lpaduano@suse.com>