### PR TITLE
ceph-ansible: install expected ansible version

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -4,7 +4,11 @@ set -e
 
 # the following two methods exist in scripts/build_utils.sh
 # shellcheck disable=SC2034
-pkgs=( "ansible" "ansible-lint" )
+pkgs=( "ansible-lint" )
+# force virtualenv to be created earlier for this occurence, so we are not stuck because of ansible-lint dependencie,
+# which would enforce latest ansible version to be installed.
+virtualenv $TEMPVENV
+"$VENV"/bin/pip install -r <(grep ansible "$WORKSPACE"/tests/requirements.txt)
 install_python_packages "pkgs[@]"
 
 


### PR DESCRIPTION
install the ansible version corresponding to its respective ceph-ansible
ansible.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>