### PR TITLE
ceph-ansible-syntax: fix path to pip

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -8,7 +8,7 @@ pkgs=( "ansible-lint" )
 # force virtualenv to be created earlier for this occurence, so we are not stuck because of ansible-lint dependencie,
 # which would enforce latest ansible version to be installed.
 virtualenv $TEMPVENV
-"$VENV"/bin/pip install -r <(grep ansible "$WORKSPACE"/tests/requirements.txt)
+"$VENV"/pip install -r <(grep ansible "$WORKSPACE"/tests/requirements.txt)
 install_python_packages "pkgs[@]"
 
 


### PR DESCRIPTION
`$VENV` contains already '/bin/' pattern.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>