### PR TITLE
ceph-ansible: fix collect ceph config task

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -786,10 +786,14 @@ write_collect_logs_playbook() {
 
     - name: collect ceph configuration file
       fetch:
-        src: "{{ ceph_conf_key_directory }}/{{ cluster }}.conf"
+        src: "{{ item }}"
         dest: "{{ archive_path }}/{{ inventory_hostname }}/"
         fail_on_missing: no
         flat: yes
+      with_items:
+        - "/etc/ceph/ceph.conf"
+        - "/etc/ceph/test.conf"
+        - "/etc/ceph/mycluster.conf"
 EOF
 }
 


### PR DESCRIPTION
`ceph_conf_key_directory` doesn't exist in this playbook.
All our testing is done with '/etc/ceph', let's hardcode it here.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>