### PR TITLE
ceph-container-build-ceph-base-push-imgs: add build manifest

### DIFF
--- a/ceph-container-build-ceph-base-push-imgs/build/build
+++ b/ceph-container-build-ceph-base-push-imgs/build/build
@@ -4,3 +4,5 @@ set -e
 
 cd "$WORKSPACE"/ceph-container/ || exit
 ARCH=x86_64 bash -x contrib/build-ceph-base.sh
+
+bash -x contrib/make-ceph-base-manifests.sh


### PR DESCRIPTION
We need to build a manifest on the docker hub so that you can simply
pull ceph/ceph

Signed-off-by: Sébastien Han <seb@redhat.com>