### PR TITLE
ceph-ansible-ci: do not run osd twice

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -237,6 +237,8 @@
               echo "Infra playbooks modified.  Not testing remaining scenarios."
               exit 1
             fi
+            # do not run if roles/ceph-osd has been touched since the task above play osds already
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-osd' && exit 1
           on-evaluation-failure: dont-run
           steps:
             - multijob:


### PR DESCRIPTION
Do not play twice osds if they have been ack by the first task of the
pipeline.

Signed-off-by: Sébastien Han <seb@redhat.com>