### PR TITLE
ceph-ansible-pipeline: fix wrong condition

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -239,11 +239,10 @@
             fi
             # do not run if roles/ceph-osd has been touched since the task above play osds already
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-osd'
-            if [ $? -eq 1 ]; then
+            if [ $? -eq 0 ]; then
               echo "ceph-osd role modified, nothing to test, the ceph-osd role test is handled by another pipeline job."
               exit 1
             fi
-            exit 0
           on-evaluation-failure: dont-run
           steps:
             - multijob:


### PR DESCRIPTION
if grep report 0 ceph-osd was modified thus we exit

Signed-off-by: Sébastien Han <seb@redhat.com>