### PR TITLE
ceph-dashboard-pull-requests: add further python packages

### DIFF
--- a/ceph-dashboard-pull-requests/setup/setup
+++ b/ceph-dashboard-pull-requests/setup/setup
@@ -7,7 +7,7 @@ if grep -q  debian /etc/*-release; then
     sudo apt-key add linux_signing_key.pub
     sudo apt-get update
     sudo apt-get install -y google-chrome-stable
-    sudo apt-get install -y python3-werkzeug python3-bcrypt python3-routes python3-requests
+    sudo apt-get install -y python3-werkzeug python3-bcrypt python3-routes python3-requests python3-openssl python2-requests python-openssl
 
 elif grep -q rhel /etc/*-release; then
     sudo dd of=/etc/yum.repos.d/google-chrome.repo status=none <<EOF
@@ -19,5 +19,5 @@ gpgcheck=1
 gpgkey=https://dl.google.com/linux/linux_signing_key.pub
 EOF
     sudo yum install -y google-chrome-stable
-    sudo yum install -y python3-werkzeug python3-bcrypt python3-routes python3-requests
+    sudo yum install -y python3-werkzeug python3-bcrypt python3-routes python3-requests python3-pyOpenSSL python2-requests python2-pyOpenSSL
 fi


### PR DESCRIPTION
which might help to get rid of the vstart 'invalid command' error

Signed-off-by: Laura Paduano <lpaduano@suse.com>