### PR TITLE
ceph-ansible: add "add_osds" scenarios to pipeline

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -57,6 +57,23 @@
           condition-command: |
             #!/bin/bash
             set -x
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/add-osd'
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible purge playbook testing'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-luminous-add_osds'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-luminous-add_osds_container'
+                    current-parameters: true
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            set -x
             # if the current branch is master then we don't run these tests
             if [[ "$ghprbTargetBranch" == "master" ]]; then
               exit 1


### PR DESCRIPTION
adding `add_osds` and `add_osds_container` to the ceph-ansible pipeline

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>