### PR TITLE
ceph-volume-scenario: lock tests to smithi nodes

### DIFF
--- a/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
+++ b/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
@@ -1,7 +1,7 @@
 
 - job:
     name: 'ceph-volume-scenario'
-    node: vagrant&&libvirt
+    node: vagrant&&libvirt&&smithi
     concurrent: true
     defaults: global
     display-name: 'ceph-volume: individual scenario testing'


### PR DESCRIPTION
We are currently having troubles running test on our OVH nodes. This
locks these tests to smithi nodes for now so we can do some testing for
12.2.9.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>