### PR TITLE
ceph-dashboard-pull-requests: added 'white-list-labels'

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -30,9 +30,9 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
+          white-list-labels: "dashboard"
           trigger-phrase: 'jenkins test dashboard'
           skip-build-phrase: '^jenkins do not test.*'
-          only-trigger-phrase: true
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false


### PR DESCRIPTION
and changed 'only-trigger-phrase' to be able to automatically
start this Job for all dashboard PRs

https://docs.openstack.org/infra/jenkins-job-builder/triggers.html#triggers.github-pull-request

Signed-off-by: Laura Paduano <lpaduano@suse.com>