### PR TITLE
ceph-volume-ansible-prs use credentials binding plugin instead of global passwords

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -148,9 +148,11 @@
             - ../../build/build
 
     wrappers:
-      - inject-passwords:
-          global: true
-          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: ceph-jenkins
+              username: GITHUB_USERNAME
+              password: GITHUB_OAUTH_TOKEN
 
     publishers:
       - postbuildscript:


### PR DESCRIPTION
This might make it a bit more secure. I'm sure it will cause breakage, would love to see some other eyes on it.