### PR TITLE
ceph-container-build-ceph-base-push-imgs-arm64: run manifest script

### DIFF
--- a/ceph-container-build-ceph-base-push-imgs-arm64/build/build
+++ b/ceph-container-build-ceph-base-push-imgs-arm64/build/build
@@ -4,3 +4,6 @@ set -e
 
 cd "$WORKSPACE"/ceph-container/ || exit
 ARCH=aarch64 bash -x contrib/build-ceph-base.sh
+
+echo "Now running manifest script"
+BUILD_SERVER_GOARCH=arm64 bash -x contrib/make-ceph-base-manifests.sh


### PR DESCRIPTION
Run manifest script after the arm64 build is complete.

Signed-off-by: Sébastien Han <seb@redhat.com>