### PR TITLE
ceph-container-build-ceph-base-push-imgs: try to build manifest on am…

### DIFF
--- a/ceph-container-build-ceph-base-push-imgs/build/build
+++ b/ceph-container-build-ceph-base-push-imgs/build/build
@@ -4,3 +4,6 @@ set -e
 
 cd "$WORKSPACE"/ceph-container/ || exit
 ARCH=x86_64 bash -x contrib/build-ceph-base.sh
+
+echo "Now running manifest script"
+BUILD_SERVER_GOARCH=amd64 bash -x contrib/make-ceph-base-manifests.sh


### PR DESCRIPTION
…d64 too

They are days where arm64 runs before amd64 and the other way around so
let's try to build the manifest also on amd64. This can't not do any
harm.

Signed-off-by: Sébastien Han <seb@redhat.com>