### PR TITLE
ceph-container-build-ceph-base-push-imgs: install jq

### DIFF
--- a/ceph-container-build-ceph-base-push-imgs-arm64/build/build
+++ b/ceph-container-build-ceph-base-push-imgs-arm64/build/build
@@ -2,6 +2,8 @@
 set -e
 
 
+sudo apt-get install jq -y
+
 cd "$WORKSPACE"/ceph-container/ || exit
 ARCH=aarch64 bash -x contrib/build-ceph-base.sh
 

--- a/ceph-container-build-ceph-base-push-imgs/build/build
+++ b/ceph-container-build-ceph-base-push-imgs/build/build
@@ -2,6 +2,8 @@
 set -e
 
 
+sudo apt-get install jq -y
+
 cd "$WORKSPACE"/ceph-container/ || exit
 ARCH=x86_64 bash -x contrib/build-ceph-base.sh
 


### PR DESCRIPTION
We need jq to read json.

Signed-off-by: Sébastien Han <seb@redhat.com>