### PR TITLE
ceph-ansible-syntax: display matched files in group_vars_check

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -35,14 +35,14 @@ function ansible_lint {
 }
 
 function group_vars_check {
-  # we use || true so we still count and don't fail if we don't find anything
+  match_file "/defaults/main.yml"
   nb=$(match_file "/defaults/main.yml" | wc -l)
   if [[ "$nb" -eq 0 ]]; then
     echo "group_vars has not been touched."
     return 0
   fi
 
-  # we use || true so we still count and don't fail if we don't find anything
+  match_file "group_vars/"
   nb_group_vars=$(match_file "group_vars/" | wc -l)
   if [[ "$nb" -gt "$nb_group_vars" ]]; then
     echo "One or more files containing default variables has/have been modified."


### PR DESCRIPTION
it can be useful to see which files have matched in `group_vars_check()`
function.
I'm currently facing an issue where the CI complains on that check while
it doesn't on an other environment when trying to reproduce the issue.

on the CI:

```
+ group_vars_check
++ match_file /defaults/main.yml
++ git_diff_to_head
++ wc -l
++ git diff origin/master..HEAD -- . ':(exclude)roles/*/meta/*'
++ sed -n 's|^+++.*\(/defaults/main.yml.*\)|\1|p'
+ nb=1
+ [[ 1 -eq 0 ]]
++ match_file group_vars/
++ wc -l
++ git_diff_to_head
++ git diff origin/master..HEAD -- . ':(exclude)roles/*/meta/*'
++ sed -n 's|^+++.*\(group_vars/.*\)|\1|p'
+ nb_group_vars=0
+ [[ 1 -gt 0 ]]
+ echo 'One or more files containing default variables has/have been modified.'
One or more files containing default variables has/have been modified.
+ echo 'You must run '\''generate_group_vars_sample.sh'\'' to generate the group_vars template files.'
You must run 'generate_group_vars_sample.sh' to generate the group_vars template files.
+ return 1
```

local env:

```
+ group_vars_check
++ match_file /defaults/main.yml
++ wc -l
++ git_diff_to_head
++ sed -n 's|^+++.*\(/defaults/main.yml.*\)|\1|p'
++ git diff origin/master..HEAD -- . ':(exclude)roles/*/meta/*'
+ nb=0
+ [[ 0 -eq 0 ]]
+ echo 'group_vars has not been touched.'
group_vars has not been touched.
+ return 0
```