### PR TITLE
ceph-ansible-syntax: disable syntax coloration in `git_diff_to_head()`

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -54,7 +54,7 @@ function group_vars_check {
 function git_diff_to_head {
   # shellcheck disable=SC2154
   # ghprbTargetBranch variable comes from jenkins's injectedEnvVars
-  git diff origin/"${ghprbTargetBranch}"..HEAD
+  git diff --no-color origin/"${ghprbTargetBranch}"..HEAD
 }
 
 function match_file {


### PR DESCRIPTION
when running this code locally for debugging purposes, the sed in
`match_file()` won't match the pattern because of the ANSI codes inserted by
the git diff (colored) output.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>