### PR TITLE
ceph-medic-tests: disable all child jobs from template

### DIFF
--- a/ceph-medic-tests/config/definitions/ceph-medic-tests.yml
+++ b/ceph-medic-tests/config/definitions/ceph-medic-tests.yml
@@ -13,6 +13,7 @@
     node: vagrant && libvirt
     project-type: freestyle
     defaults: global
+    disabled: true
     display-name: 'ceph-medic: Tests [{scenario}]'
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
I guess these needed to be disabled as well. ceph-medic is not under development anymore