### PR TITLE
ceph-volume ansible jobs need python-netaddr installed in the controlling node

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -8,8 +8,13 @@ WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 # if this project was started manually
 github_status_setup
 
-# TODO: at this point a `curl` to shaman is needed to verify that the repo is
-# ready to be consumed
+# ceph-ansible now requires a dependency on the control node (this machine) in
+# order to work properly
+if test -f /etc/redhat-release ; then
+    sudo yum install python-netaddr
+else
+    sudo apt-get install python-netaddr
+fi
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" "github-status>0.0.3" )

--- a/ceph-volume-nightly/build/build
+++ b/ceph-volume-nightly/build/build
@@ -2,10 +2,17 @@
 set -ex
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
+# ceph-ansible now requires a dependency on the control node (this machine) in
+# order to work properly
+if test -f /etc/redhat-release ; then
+    sudo yum install python-netaddr
+else
+    sudo apt-get install python-netaddr
+fi
+
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
 install_python_packages "pkgs[@]"
-
 
 delete_libvirt_vms
 clear_libvirt_networks

--- a/ceph-volume-scenario/build/build
+++ b/ceph-volume-scenario/build/build
@@ -2,6 +2,14 @@
 set -ex
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
+# ceph-ansible now requires a dependency on the control node (this machine) in
+# order to work properly
+if test -f /etc/redhat-release ; then
+    sudo yum install python-netaddr
+else
+    sudo apt-get install python-netaddr
+fi
+
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
 install_python_packages "pkgs[@]"


### PR DESCRIPTION
This should allow ceph-volume tests to work. PR https://github.com/ceph/ceph-ansible/pull/3199 made it so that any/all tests should have `python-netaddr` installed