### PR TITLE
ceph-dashboard-pull-requests: re-add 'only-trigger-phrase'

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -33,6 +33,7 @@
           white-list-labels: "dashboard"
           trigger-phrase: 'jenkins test dashboard'
           skip-build-phrase: '^jenkins do not test.*'
+          only-trigger-phrase: false
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false


### PR DESCRIPTION
Currently the manual trigger "jenkins test dashboard" does not trigger a new job anymore.
Not sure if this is related to removing the ``only-trigger-phrase`` line or if it's related to the ``white-list-label`` line I've recently added. This PR is just a test to see if it makes a difference when the ``only-trigger-phrase`` line is still present.

Signed-off-by: Laura Paduano <lpaduano@suse.com>