### PR TITLE
ceph-dashboard-pull-requests: add new python-jwt dependency

### DIFF
--- a/ceph-dashboard-pull-requests/setup/setup
+++ b/ceph-dashboard-pull-requests/setup/setup
@@ -7,7 +7,7 @@ if grep -q  debian /etc/*-release; then
     sudo apt-key add linux_signing_key.pub
     sudo apt-get update
     sudo apt-get install -y google-chrome-stable
-    sudo apt-get install -y python-requests python-openssl python-jinja2
+    sudo apt-get install -y python-requests python-openssl python-jinja2 python-jwt
 
 elif grep -q rhel /etc/*-release; then
     sudo dd of=/etc/yum.repos.d/google-chrome.repo status=none <<EOF
@@ -19,5 +19,5 @@ gpgcheck=1
 gpgkey=https://dl.google.com/linux/linux_signing_key.pub
 EOF
     sudo yum install -y google-chrome-stable
-    sudo yum install -y python-requests pyOpenSSL python-jinja2
+    sudo yum install -y python-requests pyOpenSSL python-jinja2 python-jwt
 fi


### PR DESCRIPTION
Since the JWT PR [#22833](https://github.com/ceph/ceph/pull/22833) has been merged  a new dependency has been introduced which is now missing for the dashboard Jenkins job.
This PR adds the python-jwt dependency.

Signed-off-by: Laura Paduano <lpaduano@suse.com>