### PR TITLE
ceph-dashboard-pull-requests: disable trigger

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -30,11 +30,9 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          white-list-labels: 
-            - dashboard
           trigger-phrase: 'jenkins test dashboard'
           skip-build-phrase: '^jenkins do not test.*'
-          only-trigger-phrase: false
+          only-trigger-phrase: true
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false


### PR DESCRIPTION
Disable the automated trigger for the dashboard
Jenkins job (runtime crashes) in order to save resources

Signed-off-by: Laura Paduano <lpaduano@suse.com>