### PR TITLE
ceph-dashboard-pull-requests: switch node type from trusty to xenial

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && (centos7 || trusty) && rebootable
+    node: huge && (centos7 || xenial) && rebootable
     display-name: 'ceph: dashboard Pull Requests'
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
Since there are currently issues with the dashboard job and its dependencies (python-jwt)
when the test node is based on trusty (and Nautilus has dropped the support for trusty)
it makes sense to switch to a more recent Ubuntu version

Signed-off-by: Laura Paduano <lpaduano@suse.com>