### PR TITLE
nfs-ganesha: fix debian stable build

### DIFF
--- a/nfs-ganesha-stable/build/build_deb
+++ b/nfs-ganesha-stable/build/build_deb
@@ -61,6 +61,9 @@ sudo chown -R jenkins-build:jenkins-build $WORKSPACE/dist/ntirpc/deb
 cd $WORKSPACE/dist/ntirpc/deb
 apt-ftparchive packages . > Packages
 
+# for debugging
+cat Packages
+
 cd $WORKSPACE
 
 REPO_URL="https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/$CEPH_SHA1/$DISTRO/$DIST/repo"
@@ -135,7 +138,7 @@ DEB_ARCH=$(dpkg-architecture -qDEB_BUILD_ARCH)
 
 ## Prepare the debian files
 # Bump the changelog
-dch -v "$VERSION-1${DIST}" "$VERSION for Shaman"
+dch -v "$VERSION-1${DIST}" "$VERSION for download.ceph.com"
 
 # Create .dsc and source tarball, we don't care about signing changes or source package
 sudo dpkg-buildpackage -S -us -uc -d
@@ -147,18 +150,36 @@ sudo pbuilder --clean \
     --distribution $DIST \
     --basetgz $PBUILDDIR/$DIST.tgz
 
-
 mkdir -p $WORKSPACE/dist/deb
 
 # add missing packages and components to pbuilder
 sudo pbuilder update \
     --distribution $DIST \
     --basetgz $PBUILDDIR/$DIST.tgz \
-    --extrapackages "apt-transport-https apt-utils ca-certificates librados-dev libcephfs-dev librgw-dev libntirpc-dev debhelper python-all" \
+    --extrapackages "apt-transport-https apt-utils ca-certificates debhelper python-all liblttng-ust0 liblttng-ust-dev liblttng-ctl-dev pkgconf quilt" \
     --components "main restricted universe multiverse" \
-    --othermirror "${SHAMAN_MIRROR}" \
+    --override-config
+
+sudo pbuilder update \
+    --distribution $DIST \
+    --basetgz $PBUILDDIR/$DIST.tgz \
+    --removepackages "librados2 libcephfs2 librgw2 librados-dev libcephfs-dev librgw-dev libntirpc-dev" \
+    --override-config
+
+sudo pbuilder update \
+    --distribution $DIST \
+    --basetgz $PBUILDDIR/$DIST.tgz \
+    --extrapackages "libntirpc-dev" \
     --othermirror "deb [trusted=yes] file://$WORKSPACE/dist/ntirpc/deb ./" \
     --bindmounts "$WORKSPACE/dist/ntirpc/deb" \
+    --override-config
+
+# use libcephfs and librgw from shaman
+sudo pbuilder update \
+    --distribution $DIST \
+    --basetgz $PBUILDDIR/$DIST.tgz \
+    --extrapackages "librados2 libcephfs2 librgw2 librados-dev libcephfs-dev librgw-dev" \
+    --othermirror "${SHAMAN_MIRROR}" \
     --override-config
 
 echo "Building debs for $DIST"

--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -51,12 +51,12 @@
       - string:
           name: NTIRPC_BRANCH
           description: "The git branch (or tag) to build"
-          default: "v1.7"
+          default: "v1.7.1"
 
       - string:
           name: NTIRPC_DEBIAN_BRANCH
           description: "The git branch (or tag) for debian build scripts for ntirpc"
-          default: "xenial-libntirpc-1.5"
+          default: "xenial-libntirpc-1.7"
 
       - string:
           name: NFS_GANESHA_DEBIAN_BRANCH
@@ -148,9 +148,9 @@ If this is checked, then the binaries will be built and pushed to chacra even if
     builders:
       - shell: |
           echo "Cleaning up top-level workarea (shared among workspaces)"
-          rm -rf dist
-          rm -rf venv
-          rm -rf release
+          sudo rm -rf dist
+          sudo rm -rf venv
+          sudo rm -rf release
       # debian build scripts
       - shell:
           !include-raw:

--- a/nfs-ganesha/build/build_deb
+++ b/nfs-ganesha/build/build_deb
@@ -108,8 +108,15 @@ mkdir -p $WORKSPACE/dist/deb
 sudo pbuilder update \
     --basetgz $PBUILDDIR/$DIST.tgz \
     --distribution $DIST \
-    --extrapackages "apt-transport-https apt-utils ca-certificates" \
+    --extrapackages "apt-transport-https apt-utils ca-certificates debhelper python-all liblttng-ust0 liblttng-ust-dev liblttng-ctl-dev pkgconf quilt" \
     --components "main restricted universe multiverse"
+
+# make sure no ceph packages are left over in pbuilder env
+sudo pbuilder update \
+    --basetgz $PBUILDDIR/$DIST.tgz \
+    --distribution $DIST \
+    --removepackages "librados2 libcephfs2 librgw2 librados-dev libcephfs-dev librgw-dev" \
+    --override-config
 
 # add other mirror to pbuilder
 sudo pbuilder update \
@@ -131,7 +138,6 @@ sudo pbuilder build \
     --buildresult $WORKSPACE/dist/deb/ \
     --debbuildopts "-j`grep -c processor /proc/cpuinfo`" \
     $WORKSPACE/nfs-ganesha_${VERSION}-1${DIST}.dsc
-
 
 ## Upload the created debs to chacra
 chacra_endpoint="nfs-ganesha/${NFS_GANESHA_BRANCH}/${GIT_COMMIT}/${DISTRO}/${DIST}"


### PR DESCRIPTION
various fixes to nfs-ganesha-stable deb building
update stable config defaults
add removal of old ceph packages from pbuilder
to normal nfs-ganesha debian job

Signed-off-by: Ali Maredia <amaredia@redhat.com>