### PR TITLE
add new container_podman scenario to ceph-ansible

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -105,6 +105,7 @@
       - add_osds_container
       - rgw_multisite
       - rgw_multisite_container
+      - container_podman
     jobs:
       - 'ceph-ansible-prs-trigger'
 


### PR DESCRIPTION
This scenario allows us testing podman instead of docker and also python
3 for ou rmodules.

Signed-off-by: Sébastien Han <seb@redhat.com>