### PR TITLE
ceph-dashboard-pull-requests: Temporary remove Ubuntu node(s)

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && (centos7 || xenial) && rebootable
+    node: huge && centos7 && rebootable
     display-name: 'ceph: dashboard Pull Requests'
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
In order to be able to get to the step where the dashboard end-to-end tests
are being executed (which seem to pass on centos) the proposal is to temporary remove
the Ubuntu nodes.
When the current issues with Ubuntu have been fixed the plan is to
re-add Ubuntu (xenial) again to the configuration of this Jenkins job.
Since the job is being triggered automatically it would also prevent failing
jobs (which currently happens all the time and is eating up resources).

@tchaikov pointed me to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84428 wrt to the current failures of the job.
For example, see: https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/94/console

Signed-off-by: Laura Paduano <lpaduano@suse.com>