### PR TITLE
ceph-ansible-pr-syntax-check: always fetch origin

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -84,6 +84,7 @@ function test_ceph_release_in_ceph_default {
 cd "$WORKSPACE"/ceph-ansible
 syntax_check
 #ansible_lint
+git fetch origin
 group_vars_check
 test_sign_off
 test_ceph_release_in_ceph_default


### PR DESCRIPTION
We need to fetch origin to always ensure we have the right version.

Signed-off-by: Sébastien Han <seb@redhat.com>