### PR TITLE
ceph-volume: pick stable-3.2 ceph-ansible branches 

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -29,6 +29,14 @@ update_vagrant_boxes
 
 cd src/ceph-volume/ceph_volume/tests/functional/$SUBCOMMAND
 
-CEPH_DEV_BRANCH=$ghprbTargetBranch $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt
+if [[ "$ghprbTargetBranch" == "mimic" ]]; then
+    CEPH_ANSIBLE_BRANCH="stable-3.2"
+elif [[ "$ghprbTargetBranch" == "luminous" ]]; then
+    CEPH_ANSIBLE_BRANCH="stable-3.2"
+else
+    CEPH_ANSIBLE_BRANCH="master"
+fi
+
+CEPH_ANSIBLE_BRANCH=$CEPH_ANSIBLE_BRANCH CEPH_DEV_BRANCH=$ghprbTargetBranch $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt
 
 GITHUB_STATUS_STATE="success" $VENV/github-status create

--- a/ceph-volume-nightly/build/build
+++ b/ceph-volume-nightly/build/build
@@ -21,4 +21,13 @@ update_vagrant_boxes
 
 cd src/ceph-volume/ceph_volume/tests/functional/$SUBCOMMAND
 
-VAGRANT_RELOAD_FLAGS="--debug --no-provision" CEPH_DEV_BRANCH=$CEPH_BRANCH $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt
+if [[ "$CEPH_DEV_BRANCH" == "mimic" ]]; then
+    CEPH_ANSIBLE_BRANCH="stable-3.2"
+elif [[ "$CEPH_DEV_BRANCH" == "luminous" ]]; then
+    CEPH_ANSIBLE_BRANCH="stable-3.2"
+else
+    CEPH_ANSIBLE_BRANCH="master"
+fi
+
+
+VAGRANT_RELOAD_FLAGS="--debug --no-provision" CEPH_ANSIBLE_BRANCH=$CEPH_ANSIBLE_BRANCH CEPH_DEV_BRANCH=$CEPH_BRANCH $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt


### PR DESCRIPTION
PR https://github.com/ceph/ceph-ansible/pull/3312 caused backwards incompatible changes when using ceph-ansible master branch. It is now required to use stable-3.2 when luminous and mimic ceph branches are targeted.