### PR TITLE
ceph-volume-nightly check against CEPH_BRANCH, not CEPH_DEV_BRANCH

### DIFF
--- a/ceph-volume-nightly/build/build
+++ b/ceph-volume-nightly/build/build
@@ -21,9 +21,9 @@ update_vagrant_boxes
 
 cd src/ceph-volume/ceph_volume/tests/functional/$SUBCOMMAND
 
-if [[ "$CEPH_DEV_BRANCH" == "mimic" ]]; then
+if [ "$CEPH_BRANCH" = "mimic" ]; then
     CEPH_ANSIBLE_BRANCH="stable-3.2"
-elif [[ "$CEPH_DEV_BRANCH" == "luminous" ]]; then
+elif [ "$CEPH_BRANCH" = "luminous" ]; then
     CEPH_ANSIBLE_BRANCH="stable-3.2"
 else
     CEPH_ANSIBLE_BRANCH="master"


### PR DESCRIPTION
It is causing the following which is wrong (defaulting to master):

    + [[ '' == \m\i\m\i\c ]]
    + [[ '' == \l\u\m\i\n\o\u\s ]]
    + CEPH_ANSIBLE_BRANCH=master
    + VAGRANT_RELOAD_FLAGS='--debug --no-provision'
    + CEPH_ANSIBLE_BRANCH=master
    + CEPH_DEV_BRANCH=mimic
