### PR TITLE
ceph-ansible-pipeline: remove old scenario from stable-3.2 tests

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -311,8 +311,33 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is master then we DON'T RUN these tests
-            if [[ "$ghprbTargetBranch" == "master" ]]; then
+            # if the target branch is master or stable-3.2 then we DON'T RUN these tests
+            if [[ "$ghprbTargetBranch" =~ stable-3.2|master ]]; then
+              exit 1
+            fi
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-defaults/tasks/facts.yml|roles/ceph-osd|ceph-validate'
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible osd scenarios playbook testing'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-luminous-bluestore_osds_container'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-luminous-bluestore_osds_non_container'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-luminous-filestore_osds_container'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-luminous-filestore_osds_non_container'
+                    current-parameters: true
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            set -x
+            # if the target branch is not master or stable-3.2 then we DON'T RUN these tests
+            if [[ "$ghprbTargetBranch" =~ stable-3.[0-1] ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-defaults/tasks/facts.yml|roles/ceph-osd|ceph-validate'
@@ -324,14 +349,6 @@
                 execution-type: PARALLEL
                 projects:
                   - name: 'ceph-ansible-prs-luminous-bluestore_lvm_osds'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-bluestore_osds_container'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-bluestore_osds_non_container'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-filestore_osds_container'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-filestore_osds_non_container'
                     current-parameters: true
       - conditional-step:
           condition-kind: shell


### PR DESCRIPTION
filestore|bluestore old osds scenarios shouldn't be run when branch is
stable-3.2

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>