### PR TITLE
ceph-ansible: add container_podman to the pipeline

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -456,6 +456,8 @@
                     current-parameters: true
                   - name: 'ceph-ansible-prs-dev-docker_cluster_collocation'
                     current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-container_podman'
+                    current-parameters: true
       - conditional-step:
           condition-kind: shell
           condition-command: |


### PR DESCRIPTION
container_podman must run on every PR as it's the same scenario as
docker but using podman.

Signed-off-by: Sébastien Han <seb@redhat.com>