### PR TITLE
ceph-dashboard-pull-requests: add cobertura coverage report

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -62,3 +62,21 @@
           !include-raw:
             - ../../setup/setup
       - shell: "cd src/pybind/mgr/dashboard; timeout 7200 ./run-frontend-e2e-tests.sh"
+
+    publishers:
+      - cobertura:
+          report-file: "src/pybind/mgr/dashboard/frontend/coverage/cobertura-coverage.xml"
+          only-stable: "true"
+          health-auto-update: "false"
+          stability-auto-update: "false"
+          zoom-coverage-chart: "true"
+          source-encoding: "Big5"
+          targets:
+            - files:
+                healthy: 10
+                unhealthy: 20
+                failing: 30
+            - method:
+                healthy: 10
+                unhealthy: 20
+                failing: 30


### PR DESCRIPTION
Note: I guess someone would need to install/enable the cobertura plugin for the [ceph dashboard Jenkins job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) first.

Signed-off-by: Laura Paduano <lpaduano@suse.com>