### PR TITLE
ceph-ansible-pipeline: add purge_lvm_osds_container scenario

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -132,7 +132,26 @@
             if [[ "$ghprbTargetBranch" != "master" ]]; then
               exit 1
             fi
-            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/purge'
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/purge-docker-cluster.yml'
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible purge playbook testing'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-dev-purge_lvm_osds_container'
+                    current-parameters: true
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            set -x
+            # if the target branch is not master then we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" != "master" ]]; then
+              exit 1
+            fi
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/purge-cluster.yml'
           on-evaluation-failure: dont-run
           steps:
             - multijob:


### PR DESCRIPTION
Add scenario purge_lvm_osds_container for master branch.

Only run scenario for corresponding purge playbook (container vs. non
container).

Corresponding ceph-ansible PR: ceph/ceph-ansible#3395

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>