### PR TITLE
ceph-ansible: add purge_lvm_osds_container to PRs

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -97,6 +97,7 @@
       - lvm_osds
       - lvm_batch
       - purge_lvm_osds
+      - purge_lvm_osds_container
       - bluestore_lvm_osds
       - lvm_osds_container
       - lvm_batch_container


### PR DESCRIPTION
Add purge_lvm_osds_container definition to the existing list of PRs that
are automatically triggered in the pipeline.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>