### PR TITLE
teuthology-PRs: Add trigger phrase

### DIFF
--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -45,6 +45,7 @@
             - idryomov
             - vasukulkarni
             - ivotron
+          trigger-phrase: 'jenkins test.*|jenkins retest.*'
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false


### PR DESCRIPTION
Not sure if there was a default that used to work in the past but this
field was blank in the Jenkins web UI and I had to set it before commenting
'jenkins test' triggered a build.