### PR TITLE
ceph-ansible-docs: build doc for stable-3.1 and stable-3.2

### DIFF
--- a/ceph-ansible-docs/config/definitions/ceph-ansible-docs.yml
+++ b/ceph-ansible-docs/config/definitions/ceph-ansible-docs.yml
@@ -28,6 +28,8 @@
             - stable-2.1
             - stable-2.2
             - stable-3.0
+            - stable-3.1
+            - stable-3.2
           browser: auto
           skip-tag: true
           timeout: 20


### PR DESCRIPTION
Let's build the upstream documentation for stable-3.1 and stable-3.2

Closes: ceph/ceph-ansible#3224

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>