### PR TITLE
ceph-volume jobs: remove installation of python-netaddr

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -8,14 +8,6 @@ WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 # if this project was started manually
 github_status_setup
 
-# ceph-ansible now requires a dependency on the control node (this machine) in
-# order to work properly
-if test -f /etc/redhat-release ; then
-    sudo yum install python-netaddr
-else
-    sudo apt-get install python-netaddr
-fi
-
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" "github-status>0.0.3" )
 install_python_packages "pkgs[@]"

--- a/ceph-volume-nightly/build/build
+++ b/ceph-volume-nightly/build/build
@@ -2,14 +2,6 @@
 set -ex
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
-# ceph-ansible now requires a dependency on the control node (this machine) in
-# order to work properly
-if test -f /etc/redhat-release ; then
-    sudo yum install python-netaddr
-else
-    sudo apt-get install python-netaddr
-fi
-
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
 install_python_packages "pkgs[@]"

--- a/ceph-volume-scenario/build/build
+++ b/ceph-volume-scenario/build/build
@@ -2,14 +2,6 @@
 set -ex
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
-# ceph-ansible now requires a dependency on the control node (this machine) in
-# order to work properly
-if test -f /etc/redhat-release ; then
-    sudo yum install python-netaddr
-else
-    sudo apt-get install python-netaddr
-fi
-
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
 install_python_packages "pkgs[@]"


### PR DESCRIPTION
This was wrongly assumed, netaddr required to be installed in the
virtualenv, and that is the case now. This is no longer necessary, so
removing

Signed-off-by: Alfredo Deza <adeza@redhat.com>