### PR TITLE
ceph-*-build: skip unavailable repo when yum-builddep

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -38,7 +38,7 @@ elif [ "$ARCH" = arm64 ]; then
     $SUDO yum-config-manager --enable centos-sclo-rh-testing
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-$SUDO yum-builddep -y $DIR/ceph.spec
+$SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -38,7 +38,7 @@ elif [ "$ARCH" = arm64 ]; then
     $SUDO yum-config-manager --enable centos-sclo-rh-testing
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-$SUDO yum-builddep -y $DIR/ceph.spec
+$SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -38,7 +38,7 @@ elif [ "$ARCH" = arm64 ]; then
     $SUDO yum-config-manager --enable centos-sclo-rh-testing
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-$SUDO yum-builddep -y $DIR/ceph.spec
+$SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 


### PR DESCRIPTION
as centos-sclo-rh-source leads us to 404 at this moment. and we are not
using the source repo for building ceph. so we can just skip any
unavailable repo.

Fixes: http://tracker.ceph.com/issues/37707
Signed-off-by: Kefu Chai <kchai@redhat.com>