### PR TITLE
ceph-tag: Use binaries

### DIFF
--- a/ceph-tag/build/build
+++ b/ceph-tag/build/build
@@ -9,7 +9,7 @@ fi
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "ansible" )
-install_python_packages_no_binary "pkgs[@]"
+install_python_packages "pkgs[@]"
 
 # run ansible to do all the tagging and release specifying
 # a local connection and 'localhost' as the host where to execute


### PR DESCRIPTION
There was an issue with pynacl (I think) not having a wheel for the latest version.  Despite manually downloading the required (newer) version in a separate pip transaction, pip would still download the old version and try to use it when installing ansible which broke the build.

Signed-off-by: David Galloway <dgallowa@redhat.com>