### PR TITLE
nfs-ganesha: clean up Jenkins slave

### DIFF
--- a/nfs-ganesha/build/build_rpm
+++ b/nfs-ganesha/build/build_rpm
@@ -9,6 +9,11 @@ fi
 ## Get some basic information about the system and the repository
 RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
 
+# Clean up Jenkins slave before each build
+sudo yum -y clean all
+sudo yum -y remove librgw-devel librgw2 librados-devel librados3 libcephfs-devel libcephfs2
+sudo yum -y autoremove
+
 # Get .repo file from appropriate shaman build
 REPO_URL="https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/$CEPH_SHA1/$DISTRO/$RELEASE/flavors/default/repo"
 TIME_LIMIT=1200


### PR DESCRIPTION
The daily nfs-ganesha builds for CentOS were consistently failing because cmake could not properly find the RGW library, e.g.:

```
-- Looking for rgw_mount in rgw
-- Looking for rgw_mount in rgw - not found
-- Found rgw libraries: /usr/lib64/librgw.so
CMake Error at cmake/modules/FindPackageHandleStandardArgs.cmake:109 (message):
  Could NOT find RGW: Found unsuitable version "0.0.0", but required is at
  least "1.1.6" (found )
Call Stack (most recent call first):
  cmake/modules/FindPackageHandleStandardArgs.cmake:315 (_FPHSA_FAILURE_MESSAGE)
  cmake/modules/FindRGW.cmake:95 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:711 (find_package)
```

Removing leftover ceph packages from previous Jenkins jobs seems to fix the issue.

Signed-off-by: Thomas Serlin <tserlin@redhat.com>