### PR TITLE
nfs-ganesha: minor apt-get update tweak for build_deb

### DIFF
--- a/nfs-ganesha/build/build_deb
+++ b/nfs-ganesha/build/build_deb
@@ -30,7 +30,7 @@ if [[ "$REPO_FOUND" -eq 0 ]]; then
 fi
 
 # We need this for system and to run the cmake
-sudo apt-get update
+sudo apt-get -y update -o Acquire::Languages=none || true
 
 # Normalize variables across rpm/deb builds
 NORMAL_DISTRO=$DISTRO


### PR DESCRIPTION
There are occasional problems with failures in "apt-get update" because of the yandex.ru mirror. This just tweaks the command so we don't fail when the mirror is not available.

Similar to: https://github.com/ceph/ceph-build/pull/940/files

Signed-off-by: Thomas Serlin <tserlin@redhat.com>