### PR TITLE
Revert "ceph-*-build: skip unavailable repo when yum-builddep"

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -38,7 +38,7 @@ elif [ "$ARCH" = arm64 ]; then
     $SUDO yum-config-manager --enable centos-sclo-rh-testing
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-$SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
+$SUDO yum-builddep -y $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -38,7 +38,7 @@ elif [ "$ARCH" = arm64 ]; then
     $SUDO yum-config-manager --enable centos-sclo-rh-testing
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-$SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
+$SUDO yum-builddep -y $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -38,7 +38,7 @@ elif [ "$ARCH" = arm64 ]; then
     $SUDO yum-config-manager --enable centos-sclo-rh-testing
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
-$SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
+$SUDO yum-builddep -y $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 


### PR DESCRIPTION
The CentOS infra admins resolved the repository issue at https://bugs.centos.org/view.php?id=15606 .

Generally speaking, we want Yum to bail out early if there is a Yum repo problem, rather than silently skipping over failures and possibly introducing side effects to our builds.

This reverts commit 806f274710ebddb92541d6a1f82746beff530323.