### PR TITLE
nfs-ganesha-stable: enable Ubuntu Bionic builds

### DIFF
--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -127,6 +127,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           values:
             - centos7
             - xenial
+            - bionic
       - axis:
           type: dynamic
           name: DIST


### PR DESCRIPTION
Allow building for Ubuntu 18.04 in jenkins.ceph.com.

Up till now, we've only done Xenial builds for nfs-ganesha-stable. Here's an example of a successful build:
https://jenkins.ceph.com/job/nfs-ganesha-stable/213/

Signed-off-by: Thomas Serlin <tserlin@redhat.com>