### PR TITLE
ceph-ansible-prs: allow more than 1 sign-offs on a commit

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -62,7 +62,7 @@ function match_file {
 }
 
 function test_sign_off {
-  test "$(git log --oneline --no-merges origin/"${ghprbTargetBranch}"..HEAD | wc -l)" -ne "$(git log --no-merges origin/"${ghprbTargetBranch}"..HEAD | grep -c Signed-off-by)" && echo "One or more commits is/are missing a Signed-off-by. Add it with 'git commit -s'." && return 1
+  test "$(git log --oneline --no-merges origin/"${ghprbTargetBranch}"..HEAD | wc -l)" -ge "$(git log --no-merges origin/"${ghprbTargetBranch}"..HEAD | grep -c Signed-off-by)" && echo "One or more commits is/are missing a Signed-off-by. Add it with 'git commit -s'." && return 1
 
   # if we arrive here the test command successed and we can return 0
   echo "Sign-off ok!" && return 0


### PR DESCRIPTION
Should fix the CI failure here - https://2.jenkins.ceph.com/job/ceph-ansible-pr-syntax-check/4928/consoleFull#88551894390bf0a16-7808-4900-b8be-382bb070d2e0. I am taking over [PR #2510](https://github.com/ceph/ceph-ansible/pull/2510) from someone else, so the commit there would need multiple sign-offs.