### PR TITLE
build_utils: add a wrapper for tox in ceph-ansible

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -26,6 +26,8 @@ for scenario in $scenarios; do
 done
 popd
 
+write_exec_cmd_script
+
 # stable-3.0 doesn't have ceph-volume and therefore doesn't support LVM scenarios.
 # Rather than running a bunch of conditional steps in the pipeline to check if
 # a PR is merging into the stable-3.0 branch, we'll just pass LVM jobs.

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -850,6 +850,19 @@ write_collect_logs_playbook() {
 EOF
 }
 
+write_exec_cmd_script() {
+    sudo sh -c 'cat > /home/jenkins-build/bin/exec_cmd.sh << EOF
+#!/bin/bash
+
+script="$VENV"/"$1"
+
+shebang=$(head -1 "$script")
+interp=( ${shebang#\#!} )
+exec "${interp[@]}" "${@}"
+EOF'
+    sudo chmod +x /usr/local/bin/exec_cmd.sh
+}
+
 collect_ceph_logs() {
     # this is meant to be run in a testing scenario directory
     # with running vagrant vms. the ansible playbook will connect


### PR DESCRIPTION
This is a wrapper to be able to run scripts with tox that contain
shebang with more than 127 char.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>