### PR TITLE
do not interpret variables in write_exec_cmd_script()

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -854,11 +854,11 @@ write_exec_cmd_script() {
     sudo sh -c 'cat > /usr/local/bin/exec_cmd.sh << EOF
 #!/bin/bash
 
-script="$VENV"/"$1"
+script="\$VENV"/"\$1"
 
-shebang=$(head -1 "$script")
-interp=( ${shebang#\#!} )
-exec "${interp[@]}" "${@}"
+shebang=\$(head -1 "\$script")
+interp=( \${shebang#\#!} )
+exec "\${interp[@]}" "\${@}"
 EOF'
     sudo chmod +x /usr/local/bin/exec_cmd.sh
 }


### PR DESCRIPTION
variable are interpreted which is not what we want.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>