### PR TITLE
build_utils: revert previous approach to get around shebang limitation

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -26,8 +26,6 @@ for scenario in $scenarios; do
 done
 popd
 
-write_exec_cmd_script
-
 # stable-3.0 doesn't have ceph-volume and therefore doesn't support LVM scenarios.
 # Rather than running a bunch of conditional steps in the pipeline to check if
 # a PR is merging into the stable-3.0 branch, we'll just pass LVM jobs.

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -850,19 +850,6 @@ write_collect_logs_playbook() {
 EOF
 }
 
-write_exec_cmd_script() {
-    sudo sh -c 'cat > /home/jenkins-build/bin/exec_cmd.sh << EOF
-#!/bin/bash
-
-script="$VENV"/"$1"
-
-shebang=$(head -1 "$script")
-interp=( ${shebang#\#!} )
-exec "${interp[@]}" "${@}"
-EOF'
-    sudo chmod +x /usr/local/bin/exec_cmd.sh
-}
-
 collect_ceph_logs() {
     # this is meant to be run in a testing scenario directory
     # with running vagrant vms. the ansible playbook will connect

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -854,11 +854,11 @@ write_exec_cmd_script() {
     sudo sh -c 'cat > /usr/local/bin/exec_cmd.sh << EOF
 #!/bin/bash
 
-script="\$VENV"/"\$1"
+script="$VENV"/"$1"
 
-shebang=\$(head -1 "\$script")
-interp=( \${shebang#\#!} )
-exec "\${interp[@]}" "\${@}"
+shebang=$(head -1 "$script")
+interp=( ${shebang#\#!} )
+exec "${interp[@]}" "${@}"
 EOF'
     sudo chmod +x /usr/local/bin/exec_cmd.sh
 }

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -851,7 +851,7 @@ EOF
 }
 
 write_exec_cmd_script() {
-    sudo sh -c 'cat > /usr/local/bin/exec_cmd.sh << EOF
+    sudo sh -c 'cat > /home/jenkins-build/bin/exec_cmd.sh << EOF
 #!/bin/bash
 
 script="$VENV"/"$1"

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -751,7 +751,7 @@ function build_job_name() {
 }
 
 # shellcheck disable=SC2116
-if ! eval "$(echo "${TOX_RUN_ENV[@]}")" "$VENV"/tox -rv -e="$(build_job_name $RELEASE $DISTRIBUTION $DEPLOYMENT $SCENARIO)" -- --provider=libvirt; then echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
+if ! eval "$(echo "${TOX_RUN_ENV[@]}")" "$VENV"/tox --workdir="$TEMPVENV" -v -e="$(build_job_name $RELEASE $DISTRIBUTION $DEPLOYMENT $SCENARIO)" -- --provider=libvirt; then echo "ERROR: Job didn't complete successfully or got stuck for more than 3h."
   exit 1
 fi
 }


### PR DESCRIPTION
revert previous approach and simply use tox with `--workdir`