### PR TITLE
ceph-ansible: allow doc and syntax job to be run on smithi node

### DIFF
--- a/ceph-ansible-docs-prs/config/definitions/ceph-ansible-docs-prs.yml
+++ b/ceph-ansible-docs-prs/config/definitions/ceph-ansible-docs-prs.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-ansible-docs-pull-requests
-    node: small && (centos7 || trusty)
+    node: (small && (centos7 || trusty)) || (vagrant && libvirt && smithi)
     project-type: freestyle
     defaults: global
     display-name: 'ceph-ansible: docs pull requests'

--- a/ceph-ansible-pr-syntax-check/config/definitions/ceph-ansible-pr-syntax-check.yml
+++ b/ceph-ansible-pr-syntax-check/config/definitions/ceph-ansible-pr-syntax-check.yml
@@ -14,7 +14,7 @@
 
 - job:
     name: ceph-ansible-pr-syntax-check
-    node: (centos7 || trusty) && x86_64
+    node: ((centos7 || trusty) && x86_64) || (vagrant && libvirt && smithi)
     project-type: freestyle
     defaults: global
     concurrent: true


### PR DESCRIPTION
Sometimes, a ceph-ansible PRs are stuck because no OVH nodes are available
while a lot of smithi node aren't busy at all. It's not worth it to block a PR
just because of jobs which take usually less than 2min to be done.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>