### PR TITLE
ceph-ansible: isolate switch_to_container scenario

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -28,6 +28,22 @@
         - 'ceph-ansible-prs-pipeline'
 
 - project:
+    name: ceph-ansible-prs-pipeline-switch
+    slave_labels: 'vagrant && libvirt && smithi'
+    release:
+      - dev
+      - luminous
+    distribution:
+      - centos
+      - ubuntu
+    deployment:
+      - non_container
+    scenario:
+      - switch_to_containers
+    jobs:
+        - 'ceph-ansible-prs-pipeline'
+
+- project:
     name: ceph-ansible-prs-pipeline-containers
     slave_labels: 'vagrant && libvirt && smithi'
     release:
@@ -40,7 +56,6 @@
       - container
     scenario:
       - podman
-      - switch_to_containers
       - ooo_collocation
     jobs:
         - 'ceph-ansible-prs-pipeline'


### PR DESCRIPTION
let's make this scenario based as a 'non_container' one so tox.ini will
set right values for`CEPH_ANSIBLE_VAGRANT_BOX` and `PLAYBOOK`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>