### PR TITLE
ceph-dashboard-pull-requests: added blacklist for luminous branch

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -32,6 +32,8 @@
             - ceph
           white-list-labels: 
             - dashboard
+          black-list-target-branches:
+            - luminous
           trigger-phrase: 'jenkins test dashboard'
           skip-build-phrase: '^jenkins do not test.*'
           only-trigger-phrase: false


### PR DESCRIPTION
Added "black-list-target-branches" to triggers to avoid an automated
run of the job on PRs targeting luminous.
Note: For some reason the job currently gets randomly triggered on luminous PRs which do not even have the "dashboard" label assigned.
Signed-off-by: Laura Paduano <lpaduano@suse.com>