### PR TITLE
ceph-ansible: rename basic scenario for stable-3.2

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -544,9 +544,9 @@
                 condition: SUCCESSFUL
                 execution-type: PARALLEL
                 projects:
-                  - name: 'ceph-ansible-prs-luminous-centos-non_container-cluster'
+                  - name: 'ceph-ansible-prs-luminous-centos-non_container-all_daemons'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-centos-container-cluster'
+                  - name: 'ceph-ansible-prs-luminous-centos-container-all_daemons'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-luminous-centos-container-collocation'
                     current-parameters: true


### PR DESCRIPTION
due to recent changes, the scenarios have to be renamed accordingly.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>