### PR TITLE
ceph-ansible: add rhel8/podman scenario

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -511,6 +511,8 @@
                 projects:
                   - name: 'ceph-ansible-prs-dev-centos-non_container-all_daemons'
                     current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-rhel-container-podman'
+                    current-parameters: true
                   - name: 'ceph-ansible-prs-dev-centos-container-all_daemons'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-dev-centos-container-collocation'

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -7,6 +7,7 @@
       - luminous
     distribution:
       - centos
+      - rhel
       - ubuntu
     deployment:
       - container
@@ -25,38 +26,8 @@
       - rgw_multisite
       - purge
       - lvm_auto_discovery
-    jobs:
-        - 'ceph-ansible-prs-pipeline'
-
-- project:
-    name: ceph-ansible-prs-pipeline-switch
-    slave_labels: 'vagrant && libvirt && smithi'
-    release:
-      - dev
-      - luminous
-    distribution:
-      - centos
-      - ubuntu
-    deployment:
-      - non_container
-    scenario:
-      - switch_to_containers
-    jobs:
-        - 'ceph-ansible-prs-pipeline'
-
-- project:
-    name: ceph-ansible-prs-pipeline-containers
-    slave_labels: 'vagrant && libvirt && smithi'
-    release:
-      - dev
-      - luminous
-    distribution:
-      - centos
-      - ubuntu
-    deployment:
-      - container
-    scenario:
       - podman
+      - switch_to_containers
       - ooo_collocation
     jobs:
         - 'ceph-ansible-prs-pipeline'


### PR DESCRIPTION
This commit does the following:

- add an upstream test against rhel8/podman to catch earlier potential
failures.
- refact a bit the pipeline (since there's a check if the scenario
actually exist in build_utils.sh we can define a global matrix).

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>