### PR TITLE
ceph-ansible-pr-syntax-check: get latest version of pip

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -8,6 +8,7 @@ pkgs=( "ansible-lint" )
 # force virtualenv to be created earlier for this occurence, so we are not stuck because of ansible-lint dependencie,
 # which would enforce latest ansible version to be installed.
 virtualenv $TEMPVENV
+"$VENV"/pip install --upgrade pip
 "$VENV"/pip install -r <(grep ansible "$WORKSPACE"/ceph-ansible/tests/requirements.txt)
 install_python_packages "pkgs[@]"
 

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -819,21 +819,6 @@ write_collect_logs_playbook() {
 - hosts: all
   become: yes
   tasks:
-    - name: get yum repoinfo result
-      command: yum repoinfo
-      failed_when: false
-      when: ansible_distribution == 'CentOS'
-
-    - name: get date result
-      command: date
-      failed_when: false
-      when: ansible_distribution == 'CentOS'
-
-    - name: get yum check-update result
-      command: yum check-update
-      failed_when: false
-      when: ansible_distribution == 'CentOS'
-
     - name: find ceph logs
       command: find /var/log/ceph -name "*.log"
       register: ceph_logs


### PR DESCRIPTION
ensure the latest version of pip is installed for this job to avoid the
following error:

```
ValueError: ('Expected version spec in', 'ansible~=2.7,<2.8', 'at', '~=2.7,<2.8')
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>