### PR TITLE
ceph-ansible-prs: clean fact cache in teardown

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -25,6 +25,8 @@ for scenario in $scenarios; do
   popd
 done
 popd
+# In the same logic, clean fact cache
+rm -rf $HOME/ansible/facts/*
 
 # stable-3.0 doesn't have ceph-volume and therefore doesn't support LVM scenarios.
 # Rather than running a bunch of conditional steps in the pipeline to check if

--- a/ceph-ansible-prs/build/teardown
+++ b/ceph-ansible-prs/build/teardown
@@ -4,3 +4,6 @@ cd $WORKSPACE/tests
 
 # the method exists in scripts/build_utils.sh
 teardown_vagrant_tests
+
+# clean fact cache
+rm -rf $HOME/ansible/facts/*


### PR DESCRIPTION
This commit clean the fact cache after a run.
Sometimes it might cause issue because ansible thinks the cache is valid
in some cases making some tasks failing.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>