### PR TITLE
ceph-ansible: remove lvm_auto_discovery from stable-3.2

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -134,7 +134,6 @@
       - add_osds
       - rgw_multisite
       - purge
-      - lvm_auto_discovery
     ceph_ansible_branch:
       - stable-3.2
     jobs:


### PR DESCRIPTION
This has not been backported into stable-3.2

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>