### PR TITLE
ceph-ansible: reintroduce ubuntu testing

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -532,11 +532,15 @@
                 projects:
                   - name: 'ceph-ansible-prs-dev-centos-non_container-all_daemons'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-rhel-container-podman'
-                    current-parameters: true
                   - name: 'ceph-ansible-prs-dev-centos-container-all_daemons'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-dev-centos-container-collocation'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-ubuntu-non_container-all_daemons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-ubuntu-container-all_daemons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-rhel-container-podman'
                     current-parameters: true
       - conditional-step:
           condition-kind: shell


### PR DESCRIPTION
add back ubuntu testing on ceph-ansible PRs.

Closes: ceph/ceph-ansible#3590

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>