### PR TITLE
add add_mdss scenario to CI

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -120,6 +120,27 @@
           condition-command: |
             #!/bin/bash
             set -x
+            # if the target branch is master we RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ "stable-" ]]; then
+              exit 1
+            fi
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'infrastructure-playbooks/add-mon|tests/functional/add-mdss'
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible add_mdss playbook testing'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-add_mdss'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-container-add_mdss'
+                    current-parameters: true
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            set -x
             # if the target branch is stable-3.2 or master we DON'T RUN these tests.
             if [[ "$ghprbTargetBranch" =~ stable-3.2|master ]]; then
               exit 1

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -23,6 +23,7 @@
       - lvm_batch
       - add_osds
       - add_mons
+      - add_mdss
       - rgw_multisite
       - purge
       - lvm_auto_discovery


### PR DESCRIPTION
Add add_mdss scenario to CI so that it can be tested against master.
Related to [`add-mds.yml` PR](https://github.com/ceph/ceph-ansible/pull/3599).