### PR TITLE
ceph-ansible: remove add_mons scenario for stable-3.2

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -98,7 +98,6 @@
       - shrink_osd
       - lvm_batch
       - add_osds
-      - add_mons
       - rgw_multisite
       - purge
       - lvm_auto_discovery


### PR DESCRIPTION
this scenario doesn't exist in stable-3.2

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>