### PR TITLE
ansible: remove spec file changes for remoto

### DIFF
--- a/ansible/roles/remoto-release/tasks/release.yml
+++ b/ansible/roles/remoto-release/tasks/release.yml
@@ -15,11 +15,13 @@
     DEBEMAIL: "{{ debemail }}"
     DEBFULLNAME: "{{ debfullname }}"
 
-- name: set the version in the spec file
-  lineinfile: dest=remoto/remoto.spec
-              regexp="Version{{':'}}\s+"
-              line="Version{{':'}}       {{ version }}"
-              state=present
+# we don't have a spec file in remoto, this is being built
+# separately
+#- name: set the version in the spec file
+#  lineinfile: dest=remoto/remoto.spec
+#              regexp="Version{{':'}}\s+"
+#              line="Version{{':'}}       {{ version }}"
+#              state=present
 
 - name: commit the version changes
   command: git commit -a -m "{{ version }}" chdir=remoto


### PR DESCRIPTION
No need for spec file changes for now, since it is being taken care in Fedora. Leaving it commented out because we might want it since EPEL has really old versions for CentOS7