### PR TITLE
nfs-ganesha: clean out yum cache before build

### DIFF
--- a/nfs-ganesha/build/build_rpm
+++ b/nfs-ganesha/build/build_rpm
@@ -10,6 +10,7 @@ fi
 RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
 
 # Clean up Jenkins slave before each build
+sudo rm -rf /var/cache/yum/*
 sudo yum -y clean all
 sudo yum -y remove librgw-devel librgw2 librados-devel librados3 libcephfs-devel libcephfs2
 sudo yum -y autoremove


### PR DESCRIPTION
We occasionally see "HTTP Error 404 - Not Found" when the jenkins slave tries to contact the EPEL mirrors. Clean up the entire /var/cache/yum/ directory and see if that helps.

Reference: https://wiki.centos.org/yum-errors
