### PR TITLE
ceph-ansible-prs: run all jobs for all PRs

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -1,7 +1,6 @@
 - project:
     name: ceph-ansible-nightly-stable3.1
     release:
-      - jewel
       - luminous
     distribution:
       - centos
@@ -47,7 +46,6 @@
 - project:
     name: ceph-ansible-nightly-non_container-stable3.1
     release:
-      - jewel
       - luminous
     distribution:
       - centos
@@ -64,7 +62,6 @@
 - project:
     name: ceph-ansible-nightly-ooo-stable3.1
     release:
-      - jewel
       - luminous
     distribution:
       - centos
@@ -133,6 +130,64 @@
       - switch_to_containers
     ceph_ansible_branch:
       - stable-3.2
+    jobs:
+        - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
+
+- project:
+    name: ceph-ansible-nightly-stable4.0
+    release:
+      - nautilus
+    distribution:
+      - centos
+      - ubuntu
+    deployment:
+      - container
+      - non_container
+    scenario:
+      - all_daemons
+      - collocation
+      - update
+      - bluestore_lvm_osds
+      - lvm_osds
+      - shrink_mon
+      - shrink_osd
+      - lvm_batch
+      - add_osds
+      - rgw_multisite
+      - purge
+      - lvm_auto_discovery
+    ceph_ansible_branch:
+      - stable-4.0
+    jobs:
+        - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
+
+- project:
+    name: ceph-ansible-nightly-stable4.0_ooo
+    release:
+      - nautilus
+    distribution:
+      - centos
+    deployment:
+      - container
+    scenario:
+      - ooo_collocation
+    ceph_ansible_branch:
+      - stable-4.0
+    jobs:
+        - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
+
+- project:
+    name: ceph-ansible-nightly-stable4.0_non_container
+    release:
+      - nautilus
+    distribution:
+      - centos
+    deployment:
+      - non_container
+    scenario:
+      - switch_to_containers
+    ceph_ansible_branch:
+      - stable-4.0
     jobs:
         - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
 

--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -55,6 +55,76 @@
       - conditional-step:
           condition-kind: shell
           condition-command: |
+            # if the target branch is not master then we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" != "master" ]]; then
+              exit 1
+            fi
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible cluster first testing phase'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-all_daemons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-container-all_daemons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-lvm_osds'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-container-lvm_osds'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-ubuntu-non_container-all_daemons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-ubuntu-container-all_daemons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-rhel-container-podman'
+                    current-parameters: true
+            - multijob:
+                name: 'ceph-ansible cluster second testing phase'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-purge'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-ubuntu-non_container-purge'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-container-purge'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-ubuntu-container-purge'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-switch_to_containers'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-update'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-container-update'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-storage_inventory'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-container-storage_inventory'
+                    current-parameters: true
+            - multijob:
+                name: 'ceph-ansible cluster third testing phase'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-dev-centos-container-collocation'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-bluestore_lvm_osds'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-container-bluestore_lvm_osds'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-lvm_batch'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-container-lvm_batch'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-lvm_auto_discovery'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-container-lvm_auto_discovery'
+                    current-parameters: true
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
             #!/bin/bash
             set -x
             # if the target branch is master we RUN these tests.
@@ -168,48 +238,6 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is not master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" != "master" ]]; then
-              exit 1
-            fi
-            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/purge-docker-cluster.yml'
-          on-evaluation-failure: dont-run
-          steps:
-            - multijob:
-                name: 'ceph-ansible purge playbook testing'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-dev-centos-container-purge'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-ubuntu-container-purge'
-                    current-parameters: true
-      - conditional-step:
-          condition-kind: shell
-          condition-command: |
-            #!/bin/bash
-            set -x
-            # if the target branch is not master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" != "master" ]]; then
-              exit 1
-            fi
-            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/purge-cluster.yml'
-          on-evaluation-failure: dont-run
-          steps:
-            - multijob:
-                name: 'ceph-ansible purge playbook testing'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-dev-centos-non_container-purge'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-ubuntu-non_container-purge'
-                    current-parameters: true
-      - conditional-step:
-          condition-kind: shell
-          condition-command: |
-            #!/bin/bash
-            set -x
             # if the target branch is master then we DON'T RUN these tests.
             if [[ "$ghprbTargetBranch" == "master" ]]; then
               exit 1
@@ -242,27 +270,6 @@
                 execution-type: PARALLEL
                 projects:
                   - name: 'ceph-ansible-prs-luminous-centos-non_container-purge'
-                    current-parameters: true
-      - conditional-step:
-          condition-kind: shell
-          condition-command: |
-            #!/bin/bash
-            set -x
-            # if the target branch is not master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" != "master" ]]; then
-              exit 1
-            fi
-            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/rolling_update'
-          on-evaluation-failure: dont-run
-          steps:
-            - multijob:
-                name: 'ceph-ansible rolling_update playbook testing'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-dev-centos-non_container-update'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-container-update'
                     current-parameters: true
       - conditional-step:
           condition-kind: shell
@@ -374,25 +381,6 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is not master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" != "master" ]]; then
-              exit 1
-            fi
-            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons'
-          on-evaluation-failure: dont-run
-          steps:
-            - multijob:
-                name: 'ceph-ansible switch_to_containers playbook testing'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-dev-centos-non_container-switch_to_containers'
-                    current-parameters: true
-      - conditional-step:
-          condition-kind: shell
-          condition-command: |
-            #!/bin/bash
-            set -x
             # if the target branch is master then we DON'T RUN these tests.
             if [[ "$ghprbTargetBranch" == "master" ]]; then
               exit 1
@@ -458,39 +446,6 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is not master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" != "master" ]]; then
-              exit 1
-            fi
-            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-defaults/tasks/facts.yml|roles/ceph-osd|ceph-validate|library/ceph_volume.py'
-          on-evaluation-failure: dont-run
-          steps:
-            - multijob:
-                name: 'ceph-ansible osd scenarios playbook testing'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-dev-centos-non_container-lvm_osds'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-container-lvm_osds'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-non_container-bluestore_lvm_osds'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-container-bluestore_lvm_osds'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-non_container-lvm_batch'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-container-lvm_batch'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-non_container-lvm_auto_discovery'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-container-lvm_auto_discovery'
-                    current-parameters: true
-      - conditional-step:
-          condition-kind: shell
-          condition-command: |
-            #!/bin/bash
-            set -x
             # if the target branch is stable-3.2 then we RUN these tests.
             if [[ "$ghprbTargetBranch" =~ stable-3.[0-1]|master ]]; then
               exit 1
@@ -527,45 +482,6 @@
                   - name: 'ceph-ansible-prs-dev-centos-non_container-rgw_multisite'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-dev-centos-container-rgw_multisite'
-                    current-parameters: true
-      - conditional-step:
-          condition-kind: shell
-          condition-command: |
-            #!/bin/bash
-            set -x
-            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -v 'infrastructure-playbooks'
-            if [ $? -eq 1 ]; then
-              echo "Infra playbooks modified.  Not testing remaining scenarios."
-              exit 1
-            fi
-            # do not run if roles/ceph-osd has been touched since the task above play osds already
-            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-osd'
-            if [ $? -eq 0 ]; then
-              echo "ceph-osd role modified, nothing to test, the ceph-osd role test is handled by another pipeline job."
-              exit 1
-            fi
-            # if the target branch is not master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" != "master" ]]; then
-              exit 1
-            fi
-          on-evaluation-failure: dont-run
-          steps:
-            - multijob:
-                name: 'ceph-ansible basic cluster testing phase'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-dev-centos-non_container-all_daemons'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-container-all_daemons'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-container-collocation'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-ubuntu-non_container-all_daemons'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-ubuntu-container-all_daemons'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-rhel-container-podman'
                     current-parameters: true
       - conditional-step:
           condition-kind: shell

--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -125,6 +125,76 @@
       - conditional-step:
           condition-kind: shell
           condition-command: |
+            # if the target branch is not master then we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" != "stable-4.0" ]]; then
+              exit 1
+            fi
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible cluster first testing phase'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-all_daemons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-all_daemons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-lvm_osds'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-lvm_osds'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-ubuntu-non_container-all_daemons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-ubuntu-container-all_daemons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-rhel-container-podman'
+                    current-parameters: true
+            - multijob:
+                name: 'ceph-ansible cluster second testing phase'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-purge'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-ubuntu-non_container-purge'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-purge'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-ubuntu-container-purge'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-switch_to_containers'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-update'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-update'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-storage_inventory'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-storage_inventory'
+                    current-parameters: true
+            - multijob:
+                name: 'ceph-ansible cluster third testing phase'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-collocation'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-bluestore_lvm_osds'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-bluestore_lvm_osds'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-lvm_batch'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-lvm_batch'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-lvm_auto_discovery'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-lvm_auto_discovery'
+                    current-parameters: true
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
             #!/bin/bash
             set -x
             # if the target branch is master we RUN these tests.

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -6,7 +6,6 @@
       - dev
     distribution:
       - centos
-      - rhel
       - ubuntu
     deployment:
       - container
@@ -73,6 +72,80 @@
     jobs:
         - 'ceph-ansible-prs-pipeline'
 
+# nautilus
+- project:
+    name: ceph-ansible-prs-nautilus-pipeline
+    slave_labels: 'vagrant && libvirt && smithi'
+    release:
+      - nautilus
+    distribution:
+      - centos
+      - ubuntu
+    deployment:
+      - container
+      - non_container
+    scenario:
+      - all_daemons
+      - cluster
+      - collocation
+      - update
+      - bluestore_lvm_osds
+      - lvm_osds
+      - shrink_mon
+      - shrink_osd
+      - lvm_batch
+      - add_osds
+      - add_mons
+      - add_mdss
+      - rgw_multisite
+      - purge
+      - lvm_auto_discovery
+    jobs:
+        - 'ceph-ansible-prs-pipeline'
+
+- project:
+    name: ceph-ansible-prs-nautilus-non_container-pipeline
+    slave_labels: 'vagrant && libvirt && smithi'
+    release:
+      - nautilus
+    distribution:
+      - centos
+      - ubuntu
+    deployment:
+      - non_container
+    scenario:
+      - switch_to_containers
+    jobs:
+        - 'ceph-ansible-prs-pipeline'
+
+- project:
+    name: ceph-ansible-prs-nautilus-ooo-pipeline
+    slave_labels: 'vagrant && libvirt && smithi'
+    release:
+      - nautilus
+    distribution:
+      - centos
+    deployment:
+      - container
+    scenario:
+      - ooo_collocation
+    jobs:
+        - 'ceph-ansible-prs-pipeline'
+
+- project:
+    name: ceph-ansible-prs-nautilus-podman-pipeline
+    slave_labels: 'vagrant && libvirt && smithi'
+    release:
+      - nautilus
+    distribution:
+      - rhel
+    deployment:
+      - container
+    scenario:
+      - podman
+    jobs:
+        - 'ceph-ansible-prs-pipeline'
+
 # luminous, stable-3.2, stable 3.1
 - project:
     name: ceph-ansible-prs-luminous-pipeline
@@ -110,7 +183,6 @@
     name: ceph-ansible-prs-stable-ooo-pipeline
     slave_labels: 'vagrant && libvirt && smithi'
     release:
-      - jewel
       - luminous
     distribution:
       - centos
@@ -125,7 +197,6 @@
     name: ceph-ansible-prs-stable-non_container-pipeline
     slave_labels: 'vagrant && libvirt && smithi'
     release:
-      - jewel
       - luminous
     distribution:
       - centos
@@ -134,31 +205,6 @@
       - non_container
     scenario:
       - switch_to_containers
-    jobs:
-        - 'ceph-ansible-prs-pipeline'
-
-# jewel
-- project:
-    name: ceph-ansible-prs-jewel-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
-    release:
-      - jewel
-    distribution:
-      - centos
-      - ubuntu
-    deployment:
-      - container
-      - non_container
-    scenario:
-      - all_daemons
-      - cluster
-      - filestore_osds
-      - collocation
-      - update
-      - shrink_mon
-      - shrink_osd
-      - purge
-      - purge_filestore
     jobs:
         - 'ceph-ansible-prs-pipeline'
 


### PR DESCRIPTION
- ceph-ansible is missing a lot of coverage because we don't run all jobs
on every PR.
- add stable-4.0 testing 

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>