### PR TITLE
start_tox: list scenario in the corresponding tox ini file

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -762,7 +762,7 @@ case $SCENARIO in
     ;;
 esac
 
-for tox_env in $("$VENV"/tox -l)
+for tox_env in $("$VENV"/tox -c "$TOX_INI_FILE" -l)
 do
   if [[ "$ENV_NAME" == "$tox_env" ]]; then
 # shellcheck disable=SC2116


### PR DESCRIPTION
since a split of the tox ini file has been introduced in ceph-ansible,
we must compare the scenario by listing them in the right tox ini file
according to the scenario being run.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>