### PR TITLE
nfs-ganesha: switch to using our own fork for now

### DIFF
--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -2,7 +2,7 @@
     name: nfs-ganesha
     scm:
       - git:
-          url: https://github.com/nfs-ganesha/nfs-ganesha.git
+          url: https://github.com/ceph/nfs-ganesha.git
           branches:
             - $NFS_GANESHA_BRANCH
           skip-tag: true
@@ -46,7 +46,7 @@
       - string:
           name: NFS_GANESHA_BRANCH
           description: "The git branch (or tag) to build"
-          default: "V2.7-stable"
+          default: "V2.7-ceph"
 
       - string:
           name: NTIRPC_BRANCH


### PR DESCRIPTION
We are currently building a version of nfs-ganesha for nautilus that
lacks many needed patches. Some of those aren't suitable for inclusion
into V2.7-stable, but are already merged for V2.8 (which isn't released
yet).

Switch (at least for now) to building from a custom branch in the
ceph/nfs-ganesha fork.

Signed-off-by: Jeff Layton <jlayton@redhat.com>