### PR TITLE
ceph-ansible: add more slaves

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -97,7 +97,6 @@
       - add_osds
       - rgw_multisite
       - purge
-      - lvm_auto_discovery
     ceph_ansible_branch:
       - stable-3.2
     jobs:

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,7 +1,7 @@
 # master
 - project:
     name: ceph-ansible-prs-master-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - dev
     distribution:
@@ -31,7 +31,7 @@
 
 - project:
     name: ceph-ansible-prs-master-non_container-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - dev
     distribution:
@@ -46,7 +46,7 @@
 
 - project:
     name: ceph-ansible-prs-master-ooo-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - dev
     distribution:
@@ -60,7 +60,7 @@
 
 - project:
     name: ceph-ansible-prs-master-podman-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - dev
     distribution:
@@ -75,7 +75,7 @@
 # nautilus
 - project:
     name: ceph-ansible-prs-nautilus-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - nautilus
     distribution:
@@ -105,7 +105,7 @@
 
 - project:
     name: ceph-ansible-prs-nautilus-non_container-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - nautilus
     distribution:
@@ -120,7 +120,7 @@
 
 - project:
     name: ceph-ansible-prs-nautilus-ooo-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - nautilus
     distribution:
@@ -134,7 +134,7 @@
 
 - project:
     name: ceph-ansible-prs-nautilus-podman-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - nautilus
     distribution:


### PR DESCRIPTION
let's try to use ovh slaves as well, at least for master and stable-4.0
jobs.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>