### PR TITLE
ceph-ansible: Remove bluestore_lvm_osds scenario

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -51,7 +51,6 @@
       - non_container
     scenario:
       - purge_lvm_osds
-      - bluestore_lvm_osds
       - switch_to_containers
       - lvm_osds
     ceph_ansible_branch:
@@ -89,7 +88,6 @@
       - all_daemons
       - collocation
       - update
-      - bluestore_lvm_osds
       - lvm_osds
       - shrink_mon
       - shrink_osd
@@ -146,7 +144,6 @@
       - all_daemons
       - collocation
       - update
-      - bluestore_lvm_osds
       - lvm_osds
       - shrink_mon
       - shrink_osd

--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -533,27 +533,6 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is not stable-3.2 then we DON'T RUN these tests
-            if [[ "$ghprbTargetBranch" =~ stable-3.[0-1]|stable-4.0|master ]]; then
-              exit 1
-            fi
-            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-defaults/tasks/facts.yml|roles/ceph-osd|ceph-validate'
-          on-evaluation-failure: dont-run
-          steps:
-            - multijob:
-                name: 'ceph-ansible osd scenarios playbook testing'
-                condition: SUCCESSFUL
-                execution-type: PARALLEL
-                projects:
-                  - name: 'ceph-ansible-prs-luminous-centos-non_container-bluestore_lvm_osds'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-luminous-centos-container-bluestore_lvm_osds'
-                    current-parameters: true
-      - conditional-step:
-          condition-kind: shell
-          condition-command: |
-            #!/bin/bash
-            set -x
             # if the target branch is stable-3.2 then we RUN these tests.
             if [[ "$ghprbTargetBranch" =~ stable-3.[0-1]|stable-4.0|master ]]; then
               exit 1

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -15,7 +15,6 @@
       - cluster
       - collocation
       - update
-      - bluestore_lvm_osds
       - lvm_osds
       - shrink_mon
       - shrink_osd
@@ -89,7 +88,6 @@
       - cluster
       - collocation
       - update
-      - bluestore_lvm_osds
       - lvm_osds
       - shrink_mon
       - shrink_osd
@@ -163,7 +161,6 @@
       - all_daemons
       - collocation
       - update
-      - bluestore_lvm_osds
       - lvm_osds
       - shrink_mon
       - shrink_osd
@@ -334,10 +331,8 @@
       - lvm_osds
       - lvm_batch
       - purge_lvm_osds
-      - bluestore_lvm_osds
       - lvm_osds_container
       - lvm_batch_container
-      - bluestore_lvm_osds_container
       - add_osds
       - add_osds_container
       - rgw_multisite


### PR DESCRIPTION
Testing bluestore is handled in the lvm_osds scenario. We don't need
a dedicated one for that.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>