### PR TITLE
ceph-ansible-pipeline: refact pipeline

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -112,10 +112,6 @@
                 projects:
                   - name: 'ceph-ansible-prs-dev-centos-container-collocation'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-non_container-bluestore_lvm_osds'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-container-bluestore_lvm_osds'
-                    current-parameters: true
                   - name: 'ceph-ansible-prs-dev-centos-non_container-lvm_batch'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-dev-centos-container-lvm_batch'
@@ -184,10 +180,6 @@
                 projects:
                   - name: 'ceph-ansible-prs-nautilus-centos-container-collocation'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-bluestore_lvm_osds'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-nautilus-centos-container-bluestore_lvm_osds'
-                    current-parameters: true
                   - name: 'ceph-ansible-prs-nautilus-centos-non_container-lvm_batch'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-nautilus-centos-container-lvm_batch'
@@ -223,7 +215,7 @@
             #!/bin/bash
             set -x
             # if the target branch is stable-3.2 we RUN these tests.
-            if [[ "$ghprbTargetBranch" =~ stable-3.[0-1]|master ]]; then
+            if [[ "$ghprbTargetBranch" =~ stable-3.[0-1]|stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'infrastructure-playbooks/add-osd|tests/functional/centos/7/add-osds'
@@ -237,6 +229,27 @@
                   - name: 'ceph-ansible-prs-luminous-centos-non_container-add_osds'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-luminous-centos-container-add_osds'
+                    current-parameters: true
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            set -x
+            # if the target branch is stable-4.0 we RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-3.[0-2]|master ]]; then
+              exit 1
+            fi
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'infrastructure-playbooks/add-osd|tests/functional/centos/7/add-osds'
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible add_osds playbook testing'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-add_osds'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-add_osds'
                     current-parameters: true
       - conditional-step:
           condition-kind: shell
@@ -264,6 +277,27 @@
           condition-command: |
             #!/bin/bash
             set -x
+            # if the target branch is stable-4.0 we RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-3.[0-2]|master ]]; then
+              exit 1
+            fi
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'infrastructure-playbooks/add-mon|tests/functional/add-mons'
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible add_mons playbook testing'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-add_mons'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-add_mons'
+                    current-parameters: true
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            set -x
             # if the target branch is master we RUN these tests.
             if [[ "$ghprbTargetBranch" =~ "stable-" ]]; then
               exit 1
@@ -285,8 +319,8 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is stable-3.2 or master we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" =~ stable-3.2|master ]]; then
+            # if the target branch is stable-3.2 or stable-4.0 or master we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-3.2|stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/purge'
@@ -312,8 +346,8 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" == "master" ]]; then
+            # if the target branch is master or stable-4.0 then we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/purge-docker-cluster.yml'
@@ -331,8 +365,8 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" == "master" ]]; then
+            # if the target branch is master or stable-4.0 then we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/purge-cluster.yml'
@@ -350,8 +384,8 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" == "master" ]]; then
+            # if the target branch is master or stable-4.0 then we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/rolling_update'
@@ -392,8 +426,8 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" == "master" ]]; then
+            # if the target branch is master or stable-4.0 then we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/shrink-mon'
@@ -434,8 +468,8 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" == "master" ]]; then
+            # if the target branch is master or stable-4.0 then we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'infrastructure-playbooks/shrink-osd|tests/functional/centos/7/shrink_osd'
@@ -455,8 +489,8 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" == "master" ]]; then
+            # if the target branch is master or stable-4.0 then we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep 'infrastructure-playbooks/switch-from-non-containerized-to-containerized-ceph-daemons'
@@ -474,8 +508,8 @@
           condition-command: |
             #!/bin/bash
             set -x
-            # if the target branch is master or stable-3.2 then we DON'T RUN these tests
-            if [[ "$ghprbTargetBranch" =~ stable-3.2|master ]]; then
+            # if the target branch is master or stable-3.2 or stable-4.0 then we DON'T RUN these tests
+            if [[ "$ghprbTargetBranch" =~ stable-3.2|stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-defaults/tasks/facts.yml|roles/ceph-osd|ceph-validate'
@@ -541,6 +575,27 @@
           condition-command: |
             #!/bin/bash
             set -x
+            # if the target branch is stable-4.0 then we RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-3.[0-2]|master ]]; then
+              exit 1
+            fi
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-rgw/tasks/multisite|tests/functional/centos/7/rgw-multisite'
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible rgw multisite scenarios playbook testing'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-rgw_multisite'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-rgw_multisite'
+                    current-parameters: true
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            set -x
             # if the target branch is master then we RUN these tests.
             if [[ "$ghprbTargetBranch" =~ "stable-" ]]; then
               exit 1
@@ -573,8 +628,8 @@
               echo "ceph-osd role modified, nothing to test, the ceph-osd role test is handled by another pipeline job."
               exit 1
             fi
-            # if the target branch is master then we DON'T RUN these tests.
-            if [[ "$ghprbTargetBranch" == "master" ]]; then
+            # if the target branch is master or stable-4.0 then we DON'T RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-4.0|master ]]; then
               exit 1
             fi
           on-evaluation-failure: dont-run


### PR DESCRIPTION
- remove bluestore_lvm_osds which is no longer needed in stable-4.0 and
master.
- fix stable-4.0 testing: do not play luminous jobs.
- update some scenarios so they are triggered on stable-4.0

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>