### PR TITLE
nfs-ganesha-stable: revert back to original repo

### DIFF
--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -51,7 +51,7 @@
       - string:
           name: NTIRPC_BRANCH
           description: "The git branch (or tag) to build"
-          default: "v1.7.2"
+          default: "v1.7.3"
 
       - string:
           name: NTIRPC_DEBIAN_BRANCH

--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -40,7 +40,7 @@
     block-upstream: false
     properties:
       - github:
-          url: https://github.com/ceph/nfs-ganesha
+          url: https://github.com/nfs-ganesha/nfs-ganesha
     concurrent: true
     parameters:
       - string:

--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -2,7 +2,7 @@
     name: nfs-ganesha
     scm:
       - git:
-          url: https://github.com/ceph/nfs-ganesha.git
+          url: https://github.com/nfs-ganesha/nfs-ganesha.git
           branches:
             - $NFS_GANESHA_BRANCH
           skip-tag: true
@@ -46,7 +46,7 @@
       - string:
           name: NFS_GANESHA_BRANCH
           description: "The git branch (or tag) to build"
-          default: "V2.7-ceph"
+          default: "V2.7-stable"
 
       - string:
           name: NTIRPC_BRANCH


### PR DESCRIPTION
Now that nfs-ganesha 2.7.3 is released, we can go back to using the original repo instead of the temporary https://github.com/ceph/nfs-ganesha/tree/V2.7-ceph branch set up by Jeff Layton.