### PR TITLE
ceph-{dev-,dev-new-,}-build: install epel reppo

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -29,6 +29,7 @@ tar xzf *.orig.tar.gz
 cd ceph-*
 pwd
 
+$SUDO yum install -y epel-release
 $SUDO yum install -y yum-utils
 if [ "$ARCH" = x86_64 ]; then
     $SUDO yum install -y centos-release-scl

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -29,6 +29,7 @@ tar xzf *.orig.tar.gz
 cd ceph-*
 pwd
 
+$SUDO yum install -y epel-release
 $SUDO yum install -y yum-utils
 if [ "$ARCH" = x86_64 ]; then
     $SUDO yum install -y centos-release-scl

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -29,6 +29,7 @@ tar xzf *.orig.tar.gz
 cd ceph-*
 pwd
 
+$SUDO yum install -y epel-release
 $SUDO yum install -y yum-utils
 if [ "$ARCH" = x86_64 ]; then
     $SUDO yum install -y centos-release-scl


### PR DESCRIPTION
so we can install python36-{devel,Cython,setuptools}, if
${python3_pkgversion} is 36.

Signed-off-by: Kefu Chai <kchai@redhat.com>