### PR TITLE
ceph-ansible: add add_rbdmirrors scenario to CI

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -361,6 +361,47 @@
           condition-command: |
             #!/bin/bash
             set -x
+            # if the target branch is master we RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ "stable-" ]]; then
+              exit 1
+            fi
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'tests/functional/add-rbdmirrors'
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible add_rbdmirrors playbook testing'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-dev-centos-non_container-add_rbdmirrors'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-dev-centos-container-add_rbdmirrors'
+                    current-parameters: true
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            set -x
+            # if the target branch is stable-4.0 we RUN these tests.
+            if [[ "$ghprbTargetBranch" =~ stable-3.[0-2]|master ]]; then
+              exit 1
+            fi
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'tests/functional/add-rbdmirrors'
+          on-evaluation-failure: dont-run
+          steps:
+            - multijob:
+                name: 'ceph-ansible add_rbdmirrors playbook testing'
+                condition: SUCCESSFUL
+                execution-type: PARALLEL
+                projects:
+                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-add_rbdmirrors'
+                    current-parameters: true
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-add_rbdmirrors'
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            set -x
             # if the target branch is stable-3.2 or stable-4.0 or master we DON'T RUN these tests.
             if [[ "$ghprbTargetBranch" =~ stable-3.2|stable-4.0|master ]]; then
               exit 1

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -23,6 +23,7 @@
       - add_mons
       - add_mdss
       - add_rgws
+      - add_rbdmirrors
       - rgw_multisite
       - purge
       - lvm_auto_discovery
@@ -97,6 +98,7 @@
       - add_mons
       - add_mdss
       - add_rgws
+      - add_rbdmirrors
       - rgw_multisite
       - purge
       - lvm_auto_discovery


### PR DESCRIPTION
Add add_rbdmirrors scenario to CI so that it can be tested against master.