### PR TITLE
ceph-build: Install latest rpm macros

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -38,6 +38,10 @@ elif [ "$ARCH" = arm64 ]; then
     $SUDO yum-config-manager --enable centos-sclo-rh-testing
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
+
+# Make sure we have all the rpm macros installed and at the latest version before installing the dependencies
+$SUDO yum install -y \*rpm-macros
+
 $SUDO yum-builddep -y $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -38,6 +38,10 @@ elif [ "$ARCH" = arm64 ]; then
     $SUDO yum-config-manager --enable centos-sclo-rh-testing
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
+
+# Make sure we have all the rpm macros installed and at the latest version before installing the dependencies
+$SUDO yum install -y \*rpm-macros
+
 $SUDO yum-builddep -y $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -38,6 +38,10 @@ elif [ "$ARCH" = arm64 ]; then
     $SUDO yum-config-manager --enable centos-sclo-rh-testing
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
+
+# Make sure we have all the rpm macros installed and at the latest version before installing the dependencies
+$SUDO yum install -y \*rpm-macros
+
 $SUDO yum-builddep -y $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`


### PR DESCRIPTION
We should make sure that all the rpm and srpm macros are installed and
at the latest version before installing the build dependencies.

Otherwise, the macros can get updated and we might not get all the
dependencies installed with yum-builddep.

Signed-off-by: Boris Ranto <branto@redhat.com>