### PR TITLE
ceph-ansible: split tox configuration file

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -757,6 +757,15 @@ case $SCENARIO in
   update)
     TOX_INI_FILE=tox-update.ini
     ;;
+  rgw_multisite)
+    TOX_INI_FILE=tox-rgw_multisite.ini
+    ;;
+  purge)
+    TOX_INI_FILE=tox-purge.ini
+    ;;
+  switch_to_containers)
+    TOX_INI_FILE=tox-switch_to_containers.ini
+    ;;
   *)
     TOX_INI_FILE=tox.ini
     ;;


### PR DESCRIPTION
The tox.ini file became too big, let's split it so it more readable.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>