### PR TITLE
ceph-medic-pull-requests python3.6 support

### DIFF
--- a/ceph-medic-pull-requests/build/build
+++ b/ceph-medic-pull-requests/build/build
@@ -4,6 +4,9 @@
 pkgs=( "tox" )
 install_python_packages "pkgs[@]"
 
+sudo yum install -y epel-release
+sudo yum --enablerepo epel install -y python36
+
 cd "$WORKSPACE/ceph-medic"
 
 $VENV/tox -rv

--- a/ceph-medic-pull-requests/config/definitions/ceph-medic-pull-requests.yml
+++ b/ceph-medic-pull-requests/config/definitions/ceph-medic-pull-requests.yml
@@ -17,7 +17,7 @@
     name: ceph-medic-pull-requests
     description: Runs tox tests for ceph-medic on each GitHub PR
     project-type: freestyle
-    node: python3
+    node: python3 && centos7
     block-downstream: false
     block-upstream: false
     defaults: global


### PR DESCRIPTION
This allows ceph-medic PRs to pass tests with `tox`. At some point we might want to enable python3.6 everywhere because it is otherwise impossible. The 'python3' label is a bit of a lie right now