### PR TITLE
ceph-dashboard-pull-requests: Disable running tests

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -57,7 +57,7 @@
           wipe-workspace: true
 
     builders:
-      - shell: "export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
+      - shell: "export NPROC=$(nproc) CHECK_MAKEOPTS='-j$(nproc) -N -Q'; timeout 7200 ./run-make-check.sh"
       - shell:
           !include-raw:
             - ../../setup/setup


### PR DESCRIPTION
Since all the tests are already run in make check,
there is no reason to run them again in the dashboard.

Signed-off-by: Tiago Melo <tmelo@suse.com>