### PR TITLE
ceph-ansible-syntax: temporary fix CI error

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -4,13 +4,12 @@ set -e
 
 # the following two methods exist in scripts/build_utils.sh
 # shellcheck disable=SC2034
-pkgs=( "ansible-lint" )
 # force virtualenv to be created earlier for this occurence, so we are not stuck because of ansible-lint dependencie,
 # which would enforce latest ansible version to be installed.
 virtualenv $TEMPVENV
 "$VENV"/pip install --upgrade pip
 "$VENV"/pip install -r <(grep ansible "$WORKSPACE"/ceph-ansible/tests/requirements.txt)
-install_python_packages "pkgs[@]"
+"$VENV"/pip install ansible-lint
 
 
 #############


### PR DESCRIPTION
CI is failing at the moment because of a pip error:

```
+ /tmp/venv.x2V7jCYRmJ/bin/pip install pip==10.0.0
Traceback (most recent call last):
  File "/tmp/venv.x2V7jCYRmJ/bin/pip", line 11, in <module>
    load_entry_point('pip==19.1', 'console_scripts', 'pip')()
  File "/tmp/venv.x2V7jCYRmJ/lib/python2.7/site-packages/pkg_resources/__init__.py", line 565, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/tmp/venv.x2V7jCYRmJ/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2631, in load_entry_point
    return ep.load()
  File "/tmp/venv.x2V7jCYRmJ/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2291, in load
    return self.resolve()
  File "/tmp/venv.x2V7jCYRmJ/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2297, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/tmp/venv.x2V7jCYRmJ/lib/python2.7/site-packages/pip/_internal/__init__.py", line 40, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/tmp/venv.x2V7jCYRmJ/lib/python2.7/site-packages/pip/_internal/cli/autocompletion.py", line 8, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/tmp/venv.x2V7jCYRmJ/lib/python2.7/site-packages/pip/_internal/cli/main_parser.py", line 8, in <module>
    from pip._internal.cli import cmdoptions
  File "/tmp/venv.x2V7jCYRmJ/lib/python2.7/site-packages/pip/_internal/cli/cmdoptions.py", line 24, in <module>
    from pip._internal.utils.ui import BAR_TYPES
  File "/tmp/venv.x2V7jCYRmJ/lib/python2.7/site-packages/pip/_internal/utils/ui.py", line 11, in <module>
    from pip._vendor.progress import HIDE_CURSOR, SHOW_CURSOR
ImportError: cannot import name HIDE_CURSOR
```

since I'm unsure we really need to pin pip to 10.0.0 for the syntax
check job let's not use `install_python_packages` function from
`build_utils.sh` to install `ansible-lint`.

I'll revert this patch as soon as I'll have figured out the proper fix
to apply.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>