### PR TITLE
ceph-volume-pr: run py36 tox tests

### DIFF
--- a/ceph-volume-pr/build/build
+++ b/ceph-volume-pr/build/build
@@ -14,8 +14,6 @@ cd src/ceph-volume
 
 GITHUB_STATUS_STATE="pending" $VENV/github-status create
 
-# ceph-volume has a 3.6 environ but most machines don't have it,
-# so until then, we do them piecemeal
-$VENV/tox -v -e py27,py35,flake8
+$VENV/tox -v -e py27,py35,py36,flake8
 
 GITHUB_STATUS_STATE="success" $VENV/github-status create


### PR DESCRIPTION
We will now skip any missing interpreters, so we should
run all the tests here always.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>