### PR TITLE
ceph-ansible: give a common inventory for syntax-check

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -16,8 +16,8 @@ virtualenv $TEMPVENV
 # FUNCTIONS #
 #############
 function syntax_check {
-  "$VENV"/ansible-playbook -i '127.0.0.1,' site.yml.sample --syntax-check --list-tasks -vv
-  "$VENV"/ansible-playbook -i '127.0.0.1,' site-docker.yml.sample --syntax-check --list-tasks -vv
+  "$VENV"/ansible-playbook -i "$WORKSPACE"/ceph-ansible/tests/functional/all_daemons/hosts site.yml.sample --syntax-check --list-tasks -vv
+  "$VENV"/ansible-playbook -i "$WORKSPACE"/ceph-ansible/tests/functional/all_daemons/hosts site-docker.yml.sample --syntax-check --list-tasks -vv
 
   # move roles and group_vars into the
   # infrastructure-playbooks directory for easier syntax checking
@@ -26,7 +26,7 @@ function syntax_check {
   mv infrastructure-playbooks/group_vars/all.yml.sample infrastructure-playbooks/group_vars/all.yml
   export ANSIBLE_LIBRARY=$WORKSPACE/ceph-ansible/library
 
-  "$VENV"/ansible-playbook -i '127.0.0.1,' infrastructure-playbooks/*.yml --syntax-check --list-tasks -vv
+  "$VENV"/ansible-playbook -i "$WORKSPACE"/ceph-ansible/tests/functional/all_daemons/hosts infrastructure-playbooks/*.yml --syntax-check --list-tasks -vv
 }
 
 function ansible_lint {


### PR DESCRIPTION
let's provide a typical 'all_daemons' inventory host file for the syntax
check process. Otherwise we can get failure because the site.yml file
contains `hosts:` which try to resolve some `{{ groups }}` variables.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>