### PR TITLE
ceph-ansible: remove useless command for syntax

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -18,20 +18,12 @@ virtualenv $TEMPVENV
 function syntax_check {
   "$VENV"/ansible-playbook -i "$WORKSPACE"/ceph-ansible/tests/functional/all_daemons/hosts site.yml.sample --syntax-check --list-tasks -vv
   "$VENV"/ansible-playbook -i "$WORKSPACE"/ceph-ansible/tests/functional/all_daemons/hosts site-docker.yml.sample --syntax-check --list-tasks -vv
-
-  # move roles and group_vars into the
-  # infrastructure-playbooks directory for easier syntax checking
-  cp -r roles infrastructure-playbooks/
-  cp -r group_vars infrastructure-playbooks/
-  mv infrastructure-playbooks/group_vars/all.yml.sample infrastructure-playbooks/group_vars/all.yml
-  export ANSIBLE_LIBRARY=$WORKSPACE/ceph-ansible/library
-
   "$VENV"/ansible-playbook -i "$WORKSPACE"/ceph-ansible/tests/functional/all_daemons/hosts infrastructure-playbooks/*.yml --syntax-check --list-tasks -vv
 }
 
 function ansible_lint {
-  "$VENV"/ansible-lint site.yml.sample
-  "$VENV"/ansible-lint site-docker.yml.sample
+  "$VENV"/ansible-lint -x 204,205 site.yml.sample
+  "$VENV"/ansible-lint -x 204,205 site-docker.yml.sample
 }
 
 function group_vars_check {


### PR DESCRIPTION
Because we're now able to execute the infrastructure playbooks from
the main ceph-ansible directory, we don't need to define the ansible
library path (because already define in ansible.cfg).
The roles and group_vars directories are already present in the main
directory so we don't need to copy them anymore.
This commit also exclude both ansible-lint rules: 204 and 205

- [204] Lines should be no longer than 160 chars
- [205] Use ".yml" or ".yaml" playbook extension

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>