### PR TITLE
ceph-dashboard-pull-requests: Added dashboard backend api tests

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -61,4 +61,5 @@
       - shell:
           !include-raw:
             - ../../setup/setup
+      - shell: "cd src/pybind/mgr/dashboard; timeout 7200 ./run-backend-api-tests.sh"
       - shell: "cd src/pybind/mgr/dashboard; timeout 7200 ./run-frontend-e2e-tests.sh"


### PR DESCRIPTION
Add the dashboard ``run-backend-api-tests``-script to the ceph dashboard tests so we could check on a PR-basis if a PR would introduce a breakage or would require any changes in the backend api tests before it can get merged.

Signed-off-by: Laura Paduano <lpaduano@suse.com>