### PR TITLE
ceph-container-lint: Add selinux flag to volume

### DIFF
--- a/ceph-container-lint/build/build
+++ b/ceph-container-lint/build/build
@@ -25,7 +25,7 @@ function check(){
     while read -r filename; do
         pushd "$(dirname "$filename")"
         file=$(basename "$filename")
-        sudo docker run -v "$(pwd)"/"$file":/"$file" koalaman/shellcheck --external-sources --exclude "$IGNORE_THESE_CODES" /"$file"
+        sudo docker run -v "$(pwd)"/"$file":/"$file":z koalaman/shellcheck --external-sources --exclude "$IGNORE_THESE_CODES" /"$file"
         popd
     done
     return $?


### PR DESCRIPTION
Without the selinux flag on the container volume, the container
command will fail:

: openBinaryFile: permission denied (Permission denied)

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>