### PR TITLE
ceph-ansible: test podman on centos instead rhel

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -66,7 +66,7 @@
       - centos
       - ubuntu
     deployment:
-      - non_container
+      - container
     scenario:
       - ooo_collocation
     ceph_ansible_branch:

--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -80,7 +80,7 @@
                     current-parameters: true
                   - name: 'ceph-ansible-prs-dev-ubuntu-container-all_daemons'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-rhel-container-podman'
+                  - name: 'ceph-ansible-prs-dev-centos-container-podman'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-dev-centos-non_container-dashboard'
                     current-parameters: true
@@ -152,7 +152,7 @@
                     current-parameters: true
                   - name: 'ceph-ansible-prs-nautilus-ubuntu-container-all_daemons'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-nautilus-rhel-container-podman'
+                  - name: 'ceph-ansible-prs-nautilus-centos-container-podman'
                     current-parameters: true
             - multijob:
                 name: 'ceph-ansible cluster second testing phase'

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -58,19 +58,6 @@
       - container
     scenario:
       - ooo_collocation
-    jobs:
-        - 'ceph-ansible-prs-pipeline'
-
-- project:
-    name: ceph-ansible-prs-master-podman-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
-    release:
-      - dev
-    distribution:
-      - rhel
-    deployment:
-      - container
-    scenario:
       - podman
     jobs:
         - 'ceph-ansible-prs-pipeline'
@@ -134,19 +121,6 @@
       - container
     scenario:
       - ooo_collocation
-    jobs:
-        - 'ceph-ansible-prs-pipeline'
-
-- project:
-    name: ceph-ansible-prs-nautilus-podman-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
-    release:
-      - nautilus
-    distribution:
-      - rhel
-    deployment:
-      - container
-    scenario:
       - podman
     jobs:
         - 'ceph-ansible-prs-pipeline'

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -6,7 +6,6 @@
       - dev
     distribution:
       - centos
-      - ubuntu
     deployment:
       - container
       - non_container
@@ -29,6 +28,21 @@
       - purge
       - lvm_auto_discovery
       - dashboard
+    jobs:
+        - 'ceph-ansible-prs-pipeline'
+
+- project:
+    name: ceph-ansible-prs-master-pipeline-ubuntu
+    slave_labels: 'vagrant && libvirt && smithi'
+    release:
+      - dev
+    distribution:
+      - ubuntu
+    deployment:
+      - container
+      - non_container
+    scenario:
+      - all_daemons
     jobs:
         - 'ceph-ansible-prs-pipeline'
 
@@ -70,7 +84,6 @@
       - nautilus
     distribution:
       - centos
-      - ubuntu
     deployment:
       - container
       - non_container
@@ -92,6 +105,21 @@
       - rgw_multisite
       - purge
       - lvm_auto_discovery
+    jobs:
+        - 'ceph-ansible-prs-pipeline'
+
+- project:
+    name: ceph-ansible-prs-nautilus-pipeline-ubuntu
+    slave_labels: 'vagrant && libvirt && smithi'
+    release:
+      - nautilus
+    distribution:
+      - ubuntu
+    deployment:
+      - container
+      - non_container
+    scenario:
+      - all_daemons
     jobs:
         - 'ceph-ansible-prs-pipeline'
 

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -782,6 +782,9 @@ case $SCENARIO in
   dashboard)
     TOX_INI_FILE=tox-dashboard.ini
     ;;
+  podman)
+    TOX_INI_FILE=tox-podman.ini
+    ;;
   *)
     TOX_INI_FILE=tox.ini
     ;;


### PR DESCRIPTION
podman is available on atomic os, from upstream perspective it's better
to test against this image instead a rhel8 which was a beta image outdated.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>