### PR TITLE
ceph-dashboard-pull-requests: Change google-chrome-stable rpm installation

### DIFF
--- a/ceph-dashboard-pull-requests/setup/setup
+++ b/ceph-dashboard-pull-requests/setup/setup
@@ -10,14 +10,16 @@ if grep -q  debian /etc/*-release; then
     sudo apt-get install -y python-requests python-openssl python-jinja2 python-jwt
 
 elif grep -q rhel /etc/*-release; then
-    sudo dd of=/etc/yum.repos.d/google-chrome.repo status=none <<EOF
-[google-chrome]
-name=google-chrome
-baseurl=https://dl.google.com/linux/chrome/rpm/stable/x86_64
-enabled=1
-gpgcheck=1
-gpgkey=https://dl.google.com/linux/linux_signing_key.pub
-EOF
-    sudo yum install -y google-chrome-stable
+    wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
+    #sudo dd of=/etc/yum.repos.d/google-chrome.repo status=none <<EOF
+#[google-chrome]
+#name=google-chrome
+#baseurl=https://dl.google.com/linux/chrome/rpm/stable/x86_64
+#enabled=1
+#gpgcheck=1
+#gpgkey=https://dl.google.com/linux/linux_signing_key.pub
+#EOF
+    #sudo yum install -y google-chrome-stable
+    sudo rpm -i -y google-chrome-stable_current_x86_64.rpm
     sudo yum install -y python-requests pyOpenSSL python-jinja2 python-jwt
 fi


### PR DESCRIPTION

There are currently some 404 errors when trying to access the official
Google download link, sometimes it seems to work to install the package
but then again there's an error message in the Jenkins log output saying
"No package google-chrome-stable available".
With this PR I'd like to test if this alternative approach is more reliable
for the time being in order to avoid job failures.

404 error: https://dl.google.com/linux/chrome/rpm/stable/x86_64

Signed-off-by: Laura Paduano <lpaduano@suse.com>