### PR TITLE
ceph-ansible: Disable dashboard container job

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -84,8 +84,6 @@
                     current-parameters: true
                   - name: 'ceph-ansible-prs-dev-centos-non_container-dashboard'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-container-dashboard'
-                    current-parameters: true
             - multijob:
                 name: 'ceph-ansible cluster second testing phase'
                 condition: SUCCESSFUL


### PR DESCRIPTION
The ceph-ansible dashboard job with containerized deployment requires
some changes not merged yet upstream.
This job will be reenable when all the changes are merged.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>