### PR TITLE
nfs-ganesha: disable google-chrome yum repo

### DIFF
--- a/nfs-ganesha/build/build_rpm
+++ b/nfs-ganesha/build/build_rpm
@@ -9,6 +9,9 @@ fi
 ## Get some basic information about the system and the repository
 RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
 
+# Disable the google-chrome repo, which is not needed
+sudo yum-config-manager --disable google-chrome
+
 # Clean up Jenkins slave before each build
 sudo rm -rf /var/cache/yum/*
 sudo yum -y clean all


### PR DESCRIPTION
The yum repo for google-chrome is not correct -- possibly a bad URL. This is preventing builds; see:

https://jenkins.ceph.com/job/nfs-ganesha/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=centos7,DIST=centos7,MACHINE_SIZE=huge/41/console
https://jenkins.ceph.com/job/nfs-ganesha/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=centos7,DIST=centos7,MACHINE_SIZE=huge/42/console

Since we don't need it anyway for nfs-ganesha, just disable it.