### PR TITLE
ceph-ansible: use more slave in CI

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,7 +1,7 @@
 # master
 - project:
     name: ceph-ansible-prs-master-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - dev
     distribution:
@@ -33,7 +33,7 @@
 
 - project:
     name: ceph-ansible-prs-master-pipeline-ubuntu
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - dev
     distribution:
@@ -48,7 +48,7 @@
 
 - project:
     name: ceph-ansible-prs-master-non_container-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - dev
     distribution:
@@ -63,7 +63,7 @@
 
 - project:
     name: ceph-ansible-prs-master-ooo-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - dev
     distribution:
@@ -79,7 +79,7 @@
 # nautilus
 - project:
     name: ceph-ansible-prs-nautilus-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - nautilus
     distribution:
@@ -110,7 +110,7 @@
 
 - project:
     name: ceph-ansible-prs-nautilus-pipeline-ubuntu
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - nautilus
     distribution:
@@ -125,7 +125,7 @@
 
 - project:
     name: ceph-ansible-prs-nautilus-non_container-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - nautilus
     distribution:
@@ -140,7 +140,7 @@
 
 - project:
     name: ceph-ansible-prs-nautilus-ooo-pipeline
-    slave_labels: 'vagrant && libvirt && smithi'
+    slave_labels: 'vagrant && libvirt && centos7'
     release:
       - nautilus
     distribution:


### PR DESCRIPTION
we stopped to use OVH nodes because of an old ceph-disk race condition.
Since ceph-disk isn't present anymore as of nautilus, let's use ovh
nodes again.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>