### PR TITLE
ceph-ansible: use start_tox function in ansible-scenario job

### DIFF
--- a/ceph-ansible-scenario/build/build
+++ b/ceph-ansible-scenario/build/build
@@ -17,6 +17,4 @@ update_vagrant_boxes
 # In the same logic, clean fact cache
 rm -rf $HOME/ansible/facts/*
 
-# the $SCENARIO var is injected by the job configuration. It maps
-# to an actual, defined, tox environment
-$VENV/tox -rv -e=$SCENARIO --workdir=$WORKDIR -- --provider=libvirt
+start_tox


### PR DESCRIPTION
otherwise it always tries to run scenario using tox.ini only.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>