### PR TITLE
ceph-ansible: build job name properly

### DIFF
--- a/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
+++ b/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
@@ -46,7 +46,18 @@
           name: CEPH_DOCKER_IMAGE_TAG
           description: "The docker image tag used for containerized scenarios"
           default: "latest"
-
+      - string:
+          name: RELEASE
+          description: "The ceph release version used"
+          default: "dev"
+      - string:
+          name: DEPLOYMENT
+          description: "Type of deployment: container or non_container"
+          default: "non_container"
+      - string:
+          name: DISTRIBUTION
+          description: "The distribution used (ubuntu or centos)"
+          default: "centos"
 
     scm:
       - git:


### PR DESCRIPTION
Since tox.ini file has been split, this is needed to be able to run the
individual scenario testing. Those parameters are used to build the job
name passed to start_tox() function.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>