### PR TITLE
ceph-ansible: remove shrink_mds from oldstable

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -342,8 +342,6 @@
       - filestore_osds_container
       - shrink_mon
       - shrink_mon_container
-      - shrink_mds
-      - shrink_mds_container
       - shrink_osd
       - shrink_osd_container
       - lvm_osds


### PR DESCRIPTION
We don't need to run shrink_mds against "oldstable" releases.