### PR TITLE
scripts/build_utils.sh: only use GCC-9 for building crimson

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -480,7 +480,12 @@ use_ppa() {
                 xenial)
                     use_ppa=true;;
                 bionic)
-                    use_ppa=true;;
+                    if [ "$FLAVOR" = "crimson" ]; then
+                        use_ppa=true
+                    else
+                        use_ppa=false
+                    fi
+                    ;;
                 *)
                     use_ppa=false;;
             esac


### PR DESCRIPTION
using GCC-9 for building mimic and other stable releases has following
consequences:

* it brings runtime dependencies of libstdc++ runtime shipped along with
  GCC-9
* GCC-9 is more picky, so some 3rd party libraries fail to build due to
  -Werror.

let's continue using GCC-8 on bionic when building non-crimson flavors

Signed-off-by: Kefu Chai <kchai@redhat.com>