### PR TITLE
Add ceph container nightly devel build job

### DIFF
--- a/ceph-container-build-push-imgs-devel-nightly/build/build
+++ b/ceph-container-build-push-imgs-devel-nightly/build/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+
+cd "$WORKSPACE"/ceph-container/ || exit
+bash -x contrib/build-push-ceph-container-imgs.sh

--- a/ceph-container-build-push-imgs-devel-nightly/config/JENKINS_URL
+++ b/ceph-container-build-push-imgs-devel-nightly/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-container-build-push-imgs-devel-nightly/config/definitions/ceph-container-build-push-imgs-devel-nightly.yml
+++ b/ceph-container-build-push-imgs-devel-nightly/config/definitions/ceph-container-build-push-imgs-devel-nightly.yml
@@ -1,0 +1,49 @@
+- job:
+    name: ceph-container-build-push-imgs-devel-nightly
+    node: huge && trusty && x86_64
+    project-type: freestyle
+    defaults: global
+    display-name: 'ceph-container: Nightly build and push devel container images to Docker Hub'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+      - github:
+          url: https://github.com/ceph/ceph-container
+
+    triggers:
+      - timed: '@daily'
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-container.git
+          branches:
+            - master
+          browser: auto
+          basedir: "ceph-container"
+          timeout: 20
+
+    builders:
+      - inject:
+          properties-content: |
+            DEVEL=true
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: docker-hub-leseb
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD


### PR DESCRIPTION
The ceph container images are only built on github event and also based
on stable ceph content.
We can also have nightly builds with ceph developement content from
shaman/chacra.

See https://github.com/ceph/ceph-container/pull/1411

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>