### PR TITLE
jjb: install jq package

### DIFF
--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -6,7 +6,7 @@
 # definitions.
 #
 
-set -ex
+set -euxo pipefail
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "jenkins-job-builder==2.0.3" )


### PR DESCRIPTION
This sets the `-o pipefail` to avoid this situation :

```
++ sort
++ grep -v jenkins-job-builder
++ jq -r '.jobs[].name'
/tmp/jenkins7521600802673204021.sh: line 1043: jq: command not found
++ curl -s https://2.jenkins.ceph.com/api/json
[PostBuildScript] - Executing post build scripts.
[jenkins-job-builder] $ /bin/sh -xe /tmp/jenkins7309655147676749318.sh
+ rm /home/jenkins-build/.jenkins_jobs.2.jenkins.ceph.com.ini
Finished: SUCCESS
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>