### PR TITLE
ceph-ansible: make it possible to run nighly job on custom branch

### DIFF
--- a/ceph-ansible-nightly/build/build
+++ b/ceph-ansible-nightly/build/build
@@ -36,10 +36,7 @@ function run_tox {
       CEPH_DOCKER_IMAGE_TAG=$(find_latest_tag "$RELEASE")
       ;;
     master)
-      CEPH_DOCKER_IMAGE_TAG="latest"
-      ;;
-    *)
-      CEPH_DOCKER_IMAGE_TAG=""
+      CEPH_DOCKER_IMAGE_TAG="latest-master"
       ;;
   esac
 

--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -211,6 +211,10 @@
           name: CEPH_ANSIBLE_BRANCH
           description: "The ceph-ansible branch (or tag) to test"
           default: "{ceph_ansible_branch}"
+      - string:
+          name: CEPH_DOCKER_IMAGE_TAG
+          description: "The ceph-container image tag to use"
+          default: ""
 
     triggers:
       - timed: '@daily'


### PR DESCRIPTION
When running manually a nightly containerized job against a custom branch of
ceph-ansible, it fails because `CEPH_DOCKER_IMAGE_TAG` is not set.

Typical error:
```
+ case "$CEPH_ANSIBLE_BRANCH" in
+ CEPH_DOCKER_IMAGE_TAG=
+ '[' -n '' ']'
Build step 'Execute shell' marked build as failure
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>