### PR TITLE
ceph-volume-test: adds on-evaluation-failure to the simple build step

### DIFF
--- a/ceph-volume-test/config/definitions/ceph-volume-test.yml
+++ b/ceph-volume-test/config/definitions/ceph-volume-test.yml
@@ -86,6 +86,7 @@
             if [[ ! "$CEPH_BRANCH" =~ luminous|mimic ]]; then
               exit 1
             fi
+          on-evaluation-failure: dont-run
           steps:
           - multijob:
               name: 'testing ceph-volume simple'


### PR DESCRIPTION
This makes the job skip the simple tests if the condition fails instead
of failing the run.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>