### PR TITLE
ceph-volume: allow passing GITHUB_TOKEN as a password to manually set github status

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -102,6 +102,9 @@
       - string:
           name: GITHUB_SHA
           description: "The tip (last commit) in the PR, a sha1 like 7d787849556788961155534039886aedfcdb2a88 (if set, will report status to Github)"
+      - password:
+          name: GITHUB_OAUTH_TOKEN
+          description: "Secret API Token to set status. Only needed when manually triggering a PR test"
 
 
     triggers:

--- a/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
@@ -30,6 +30,9 @@
       - string:
           name: GITHUB_SHA
           description: "The tip (last commit) in the PR, a sha1 like 7d787849556788961155534039886aedfcdb2a88 (if set, will report status to Github)"
+      - password:
+          name: GITHUB_OAUTH_TOKEN
+          description: "Secret API Token to set status. Only needed when manually triggering a PR test"
 
     triggers:
       - github-pull-request:


### PR DESCRIPTION
Before, we stored the GITHUB_TOKEN in Jenkins which was super duper bad, now we only pass it in when we need it, and it remains obscured in logs and parameters. 

This is useful when requesting the tests manually, so Jenkins has a way to set the status without being triggered from Github.