### PR TITLE
Debian buster support for releases

### DIFF
--- a/ceph-build/build/setup_deb
+++ b/ceph-build/build/setup_deb
@@ -37,6 +37,7 @@ get_bptag() {
     dist=$1
 
     [ "$dist" = "sid" ] && dver=""
+    [ "$dist" = "buster" ] && dver="~bpo10+1"
     [ "$dist" = "stretch" ] && dver="~bpo90+1"
     [ "$dist" = "jessie" ] && dver="~bpo80+1"
     [ "$dist" = "wheezy" ] && dver="~bpo70+1"
@@ -67,7 +68,7 @@ vers=`cat ./dist/version`
 # like project/ref/ubuntu/jessie/.
 distro=""
 case $DIST in
-    stretch|jessie|wheezy)
+    buster|stretch|jessie|wheezy)
         distro="debian"
         ;;
     *)
@@ -82,6 +83,7 @@ gen_debian_version() {
     dist=$2
 
     [ "$dist" = "sid" ] && dver="$raw"
+    [ "$dist" = "buster" ] && dver="$raw~bpo10+1"
     [ "$dist" = "stretch" ] && dver="$raw~bpo90+1"
     [ "$dist" = "jessie" ] && dver="$raw~bpo80+1"
     [ "$dist" = "wheezy" ] && dver="$raw~bpo70+1"

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -35,6 +35,7 @@
             - centos7
             - jessie
             - stretch
+            - buster
             - precise
             - centos6
             - wheezy

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -304,6 +304,10 @@ get_distro_and_target() {
     # Get distro from DIST for chacra uploads
     DISTRO=""
     case $DIST in
+        buster*)
+            DIST=buster
+            DISTRO="debian"
+            ;;
         stretch*)
             DIST=stretch
             DISTRO="debian"

--- a/scripts/sync-pull
+++ b/scripts/sync-pull
@@ -14,7 +14,7 @@ echo "********************************************"
 
 # This ugly loop check all possible DEB combinations to see which repo has the most packages since that's likely the repo you want to sync.
 current_highest_count=0
-for combo in debian/jessie debian/stretch ubuntu/trusty ubuntu/xenial ubuntu/bionic; do
+for combo in debian/jessie debian/stretch debian/buster ubuntu/trusty ubuntu/xenial ubuntu/bionic; do
   combo_count=$(curl -s https://chacra.ceph.com/r/$project/$release/$sha1/${combo}/flavors/default/pool/main/c/ceph/ | wc -l)
   if [ $combo_count -gt $current_highest_count ]; then
     current_highest_count=$combo_count


### PR DESCRIPTION
Are there additional changes required in order to bring ceph builds to buster?