### PR TITLE
ceph-dev-*: remove xenial for master and octopus

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -85,7 +85,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=bionic xenial centos7
+                    DISTROS=bionic centos7
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -40,6 +40,28 @@
     builders:
       - conditional-step:
           condition-kind: regex-match
+          regex: .*(master|octopus).*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=bionic centos7
+                - project: 'ceph-dev'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=centos7
+                    FLAVOR=notcmalloc
+      - conditional-step:
+          condition-kind: regex-match
           regex: .*(jewel|kraken|luminous).*
           label: '${GIT_BRANCH}'
           on-evaluation-failure: dont-run
@@ -61,7 +83,7 @@
       - conditional-step:
           condition-kind: shell
           condition-command: |
-            echo "${GIT_BRANCH}" | grep -v '\(jewel\|kraken\|luminous\)'
+            echo "${GIT_BRANCH}" | grep -v '\(jewel\|kraken\|luminous\|master|octopus\)'
           on-evaluation-failure: dont-run
           steps:
             - shell:


### PR DESCRIPTION
Since https://github.com/ceph/ceph/pull/28943 merged, Ceph does not need to have Xenial built for master or Octopus.

This PR should allow building Xenial for older releases. It also tries to document a bit better the mind-melting conditional steps. Hopefully it clarifies what they are trying to accomplish. *Extra caution* when double checking those comments would be great because it is entirely possible that I am not right.