### PR TITLE
nfs-ganesha: Disable LizardFS FSAL

### DIFF
--- a/nfs-ganesha/build/build_rpm
+++ b/nfs-ganesha/build/build_rpm
@@ -94,7 +94,7 @@ mkdir build
 cd build
 
 # generate .spec file, edit .spec file for correct versions of libs and make source tarball
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRICT_PACKAGE=ON -DUSE_FSAL_ZFS=OFF -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=ON -DRADOS_URLS=ON -DUSE_RADOS_RECOV=ON -DUSE_LTTNG=ON $WORKSPACE/nfs-ganesha/src && make dist || exit 1
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRICT_PACKAGE=ON -DUSE_FSAL_ZFS=OFF -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=ON -DUSE_FSAL_LIZARDFS=OFF -DRADOS_URLS=ON -DUSE_RADOS_RECOV=ON -DUSE_LTTNG=ON $WORKSPACE/nfs-ganesha/src && make dist || exit 1
 
 sed -i 's/libcephfs1-devel/libcephfs-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 sed -i 's/librgw2-devel/librgw-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec


### PR DESCRIPTION
LizardFS FSAL has been added in [1] and it's enabled by default. This
is currently failing in the CI.

CMake Error at CMakeLists.txt:595 (message):
  STRICT_PACKAGE: Cannot find LizardFS client lib.  Disabling lizardfs fsal

This patch configures the USE_FSAL_LIZARDFS option to OFF.

[1] https://github.com/nfs-ganesha/nfs-ganesha/commit/884ec97

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>