### PR TITLE
ceph-dev-trigger: add missing escape for grep on master

### DIFF
--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -83,7 +83,7 @@
       - conditional-step:
           condition-kind: shell
           condition-command: |
-            echo "${GIT_BRANCH}" | grep -v '\(jewel\|kraken\|luminous\|master|octopus\)'
+            echo "${GIT_BRANCH}" | grep -v '\(jewel\|kraken\|luminous\|master\|octopus\)'
           on-evaluation-failure: dont-run
           steps:
             - shell:


### PR DESCRIPTION
I believe this was causing master to still build Xenial