### PR TITLE
ceph-dev-new-trigger: only use positive match for filter

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -51,7 +51,7 @@
       - conditional-step:
           condition-kind: shell
           condition-command: |
-            echo "${GIT_BRANCH}" | grep -v '\(jewel\|kraken\|luminous\)' | grep '\(mimic\|nautilus\)'
+            echo "${GIT_BRANCH}" | grep '\(mimic\|nautilus\)'
           on-evaluation-failure: dont-run
           steps:
             - shell:


### PR DESCRIPTION
there is no need to put
```
grep -v '\(jewel\|kraken\|luminous\)' | grep '\(mimic\|nautilus\)'
```

as we are not likely to have both "jewel" and "mimic" in a branch name.

this change is a follow-up of the discussion when reviewing #1345

Signed-off-by: Kefu Chai <kchai@redhat.com>