### PR TITLE
ceph-ansible: remove dashboard scenarios

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -82,8 +82,6 @@
                     current-parameters: true
                   - name: 'ceph-ansible-prs-dev-centos-container-podman'
                     current-parameters: true
-                  - name: 'ceph-ansible-prs-dev-centos-non_container-dashboard'
-                    current-parameters: true
             - multijob:
                 name: 'ceph-ansible cluster second testing phase'
                 condition: SUCCESSFUL
@@ -151,8 +149,6 @@
                   - name: 'ceph-ansible-prs-nautilus-ubuntu-container-all_daemons'
                     current-parameters: true
                   - name: 'ceph-ansible-prs-nautilus-centos-container-podman'
-                    current-parameters: true
-                  - name: 'ceph-ansible-prs-nautilus-centos-non_container-dashboard'
                     current-parameters: true
             - multijob:
                 name: 'ceph-ansible cluster second testing phase'

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -31,7 +31,6 @@
       - rgw_multisite
       - purge
       - lvm_auto_discovery
-      - dashboard
     jobs:
         - 'ceph-ansible-prs-pipeline'
 
@@ -113,7 +112,6 @@
       - rgw_multisite
       - purge
       - lvm_auto_discovery
-      - dashboard
     jobs:
         - 'ceph-ansible-prs-pipeline'
 


### PR DESCRIPTION
since dashboard is enabled by default, we test it in all_daemons
scenario.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>