### PR TITLE
ceph-dashboard-pr-backend: add job config

### DIFF
--- a/ceph-dashboard-pr-backend/build/build
+++ b/ceph-dashboard-pr-backend/build/build
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+n_build_jobs=$(get_nr_build_jobs)
+n_test_jobs=$(($(nproc) / 4))
+export CHECK_MAKEOPTS="-j${n_test_jobs} -N -Q"
+export BUILD_MAKEOPTS="-j${n_build_jobs}"
+timeout 3h ./run-make-check.sh
+sleep 5
+ps -ef | grep ceph || true

--- a/ceph-dashboard-pr-backend/config/definitions/ceph-dashboard-pr-backend.yml
+++ b/ceph-dashboard-pr-backend/config/definitions/ceph-dashboard-pr-backend.yml
@@ -1,0 +1,63 @@
+- job:
+    name: ceph-dashboard-pr-backend
+    project-type: freestyle
+    defaults: global
+    concurrent: true
+    node: huge && x86_64 && centos7 && rebootable
+    display-name: 'ceph: dashboard Pull Requests backend'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 300
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+      - github:
+          url: https://github.com/ceph/ceph/
+      - rebuild:
+          auto-rebuild: true
+
+    parameters:
+      - string:
+          name: sha1
+          description: "A pull request ID, like 'origin/pr/72/head'"
+
+    triggers:
+      - github-pull-request:
+          allow-whitelist-orgs-as-admins: true
+          org-list:
+            - ceph
+          black-list-target-branches:
+            - luminous
+            - mimic
+          trigger-phrase: 'jenkins test dashboard backend'
+          skip-build-phrase: '^jenkins do not test.*'
+          only-trigger-phrase: true
+          github-hooks: true
+          permit-all: true
+          auto-close-on-fail: false
+          status-context: "ceph dashboard backend API tests"
+          started-status: "running ceph dashboard backend API tests"
+          success-status: "ceph dashboard backend API tests succeeded"
+          failure-status: "ceph dashboard backend API tests failed"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph.git
+          branches:
+            - ${sha1}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+      - shell: "cd src/pybind/mgr/dashboard; timeout 7200 ./run-backend-api-tests.sh"


### PR DESCRIPTION
When we tried adding the "run-backend-api-tests.sh" to the
"ceph dashboard tests" job it would cause all builds to fail
all the time and it would require some more fixes/investigation
in order to fix it. Therefore we would like to use this temporary
Job to avoid breaking the "ceph dashboard tests" for all PRs and
to not interrupt the Job builds.

Signed-off-by: Laura Paduano <lpaduano@suse.com>