### PR TITLE
ceph-dev-build: fix deb and rpm validate

### DIFF
--- a/ceph-dev-build/build/validate_deb
+++ b/ceph-dev-build/build/validate_deb
@@ -2,6 +2,12 @@
 set -ex
 
 # Only do actual work when we are a DEB distro
-if test -f /etc/redhat-release ; then
-    exit 0
-fi
+( source /etc/os-release
+  case $ID in
+    debian|ubuntu)
+      exit 0
+      ;;
+    *)
+      exit 1
+      ;;
+  esac) || exit 0

--- a/ceph-dev-build/build/validate_rpm
+++ b/ceph-dev-build/build/validate_rpm
@@ -2,6 +2,12 @@
 set -ex
 
 # only do work if we are a RPM distro
-if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then
-    exit 0
-fi
+( source /etc/os-release
+  case $ID in
+    centos|rhel|fedora)
+      exit 0
+      ;;
+    *)
+      exit 1
+      ;;
+  esac) || exit 0


### PR DESCRIPTION
validate_deb - not redhat does not mean it is deb distro,
there can be other packaging systems
validate_rpm - we do not want to proceed for zypper based,
we only want to proceed for redhat like repo

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>