### PR TITLE
nfs-ganesha: don't build on xenial

### DIFF
--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -57,8 +57,8 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: bionic, xenial, centos7"
-          default: "centos7 xenial bionic"
+          description: "A list of distros to build for. Available options are: bionic, centos7"
+          default: "centos7 bionic"
 
       - string:
           name: ARCHS


### PR DESCRIPTION
Ceph no longer builds its master branch on Xenial. See:

https://github.com/ceph/ceph-build/pull/1345

So we can no longer build the latest nfs-ganesha V2.9-dev on Xenial.