### PR TITLE
slave.yml: Add jenkins-build user to jenkins-build group

### DIFF
--- a/ansible/slave.yml
+++ b/ansible/slave.yml
@@ -60,6 +60,7 @@
     - name: "create a {{ jenkins_user }} user"
       user:
         name: "{{ jenkins_user }}"
+        group: "{{ jenkins_user }}"
         state: present
         comment: "Jenkins Build Slave User"
 


### PR DESCRIPTION
On ubuntu, at least, with the addition of the "create a jenkins-build group" task, the creation of the user wasn't adding the user to the group.  I discovered this by seeing a docker command fail after the socket was 'chgrp'ed to jenkins-build

```
+ sudo chgrp jenkins-build /var/run/docker.sock
+ do_clean
+ make clean.all
Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock
```

I logged in to the slave and confirmed this was the case.

Signed-off-by: David Galloway <dgallowa@redhat.com>