### PR TITLE
ceph*build/build/build_deb: upload *.ddeb packages

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -95,7 +95,7 @@ echo lintian --allow-root $releasedir/$cephver/*$bpvers*.deb
 
 if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
-    find release/$vers/ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+    find release/$vers/ | egrep "*\.(changes|deb|ddeb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
     # write json file with build info
     cat > $WORKSPACE/repo-extra.json << EOF
 {

--- a/ceph-dev-build/build/build_deb
+++ b/ceph-dev-build/build/build_deb
@@ -95,7 +95,7 @@ echo lintian --allow-root $releasedir/$cephver/*$bpvers*.deb
 
 if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
-    find release/$vers/ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+    find release/$vers/ | egrep "*\.(changes|deb|ddeb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
     # write json file with build info
     cat > $WORKSPACE/repo-extra.json << EOF
 {

--- a/ceph-dev-new-build/build/build_deb
+++ b/ceph-dev-new-build/build/build_deb
@@ -95,7 +95,7 @@ echo lintian --allow-root $releasedir/$cephver/*$bpvers*.deb
 
 if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
-    find release/$vers/ | egrep "*\.(changes|deb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+    find release/$vers/ | egrep "*\.(changes|deb|ddeb|dsc|gz)$" | egrep -v "(Packages|Sources|Contents)" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}
     # write json file with build info
     cat > $WORKSPACE/repo-extra.json << EOF
 {


### PR DESCRIPTION
ubuntu names `*dbgsym*` packages .ddeb in hope to put them into a
separated repo. while debian just use the plain .deb extension for them.
so, to include the dbgsym packages created by ubuntu, we need to upload
the .ddeb packages as well.

Signed-off-by: Kefu Chai <kchai@redhat.com>