### PR TITLE
configshell-fb: initial builder for python-configshell packages

### DIFF
--- a/configshell-fb/build/build_rpm
+++ b/configshell-fb/build/build_rpm
@@ -1,0 +1,63 @@
+#! /usr/bin/bash
+set -ex
+
+BRANCH=`branch_slash_filter $BRANCH`
+
+# Only do actual work when we are an RPM distro
+if test "$DISTRO" != "fedora" -a "$DISTRO" != "centos" -a "$DISTRO" != "rhel"; then
+    exit 0
+fi
+
+## Install any setup-time deps
+# We need these for the build
+sudo yum install -y python-devel epydoc python-setuptools systemd-units
+
+# We use fpm to create the package
+sudo yum install -y rubygems ruby-devel
+sudo gem install fpm
+
+
+## Get some basic information about the system and the repository
+# Get version
+RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
+VERSION="$(git describe --abbrev=0 --tags HEAD | sed -e 's/v//1;')"
+REVISION="$(git describe --tags HEAD | sed -e 's/v//1;' | cut -d - -f 2- | sed 's/-/./')"
+if [ "$VERSION" = "$REVISION" ]; then
+  REVISION="1"
+fi
+
+## Create the package
+# Make sure there are no other packages, first
+rm -f *.rpm
+
+# Create the package
+fpm -s python -t rpm -n python-configshell -v ${VERSION} --iteration ${REVISION} -d python-kmod -d python-six -d python-pyudev setup.py
+
+
+## Upload the created RPMs to chacra
+chacra_endpoint="python-configshell/${BRANCH}/${GIT_COMMIT}/${DISTRO}/${RELEASE}"
+
+[ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
+
+# push binaries to chacra
+find *.rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/noarch/
+PACKAGE_MANAGER_VERSION=$(rpm --queryformat '%{VERSION}-%{RELEASE}\n' -qp $(find *.rpm | egrep "\.noarch\.rpm" | head -1))
+
+# write json file with build info
+cat > $WORKSPACE/repo-extra.json << EOF
+{
+    "version":"$VERSION",
+    "package_manager_version":"$PACKAGE_MANAGER_VERSION",
+    "build_url":"$BUILD_URL",
+    "root_build_cause":"$ROOT_BUILD_CAUSE",
+    "node_name":"$NODE_NAME",
+    "job_name":"$JOB_NAME"
+}
+EOF
+# post the json to repo-extra json to chacra
+curl -X POST -H "Content-Type:application/json" --data "@$WORKSPACE/repo-extra.json" -u $CHACRACTL_USER:$CHACRACTL_KEY ${chacra_url}repos/${chacra_endpoint}/extra/
+
+# start repo creation
+$VENV/chacractl repo update ${chacra_endpoint}
+
+echo Check the status of the repo at: https://shaman.ceph.com/api/repos/${chacra_endpoint}

--- a/configshell-fb/build/setup
+++ b/configshell-fb/build/setup
@@ -1,0 +1,44 @@
+#! /usr/bin/bash
+#
+# Ceph distributed storage system
+#
+# Copyright (C) 2016 Red Hat <contact@redhat.com>
+#
+# Author: Boris Ranto <branto@redhat.com>
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2.1 of the License, or (at your option) any later version.
+#
+set -ex
+
+# Make sure we execute at the top level directory before we do anything
+cd $WORKSPACE
+
+# This will set the DISTRO and MOCK_TARGET variables
+get_distro_and_target
+
+# Perform a clean-up
+git clean -fxd
+
+# Make sure the dist directory is clean
+rm -rf dist
+mkdir -p dist
+
+# Print some basic system info
+HOST=$(hostname --short)
+echo "Building on $(hostname) with the following env"
+echo "*****"
+env
+echo "*****"
+
+export LC_ALL=C # the following is vulnerable to i18n
+
+pkgs=( "chacractl>=0.0.4" )
+install_python_packages "pkgs[@]"
+
+# ask shaman which chacra instance to use
+chacra_url=`curl -f -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
+# create the .chacractl config file using global variables
+make_chacractl_config $chacra_url

--- a/configshell-fb/config/definitions/configshell-fb.yml
+++ b/configshell-fb/config/definitions/configshell-fb.yml
@@ -1,0 +1,103 @@
+- job:
+    name: configshell-fb
+    project-type: matrix
+    defaults: global
+    display-name: 'configshell-fb'
+    block-downstream: false
+    block-upstream: false
+    concurrent: true
+    parameters:
+      - string:
+          name: BRANCH
+          description: "The git branch (or tag) to build"
+          default: "master"
+
+      - string:
+          name: DISTROS
+          description: "A list of distros to build for. Available options are: xenial, centos7, centos6, trusty-pbuilder, precise, wheezy, and jessie"
+          default: "centos7"
+
+      - string:
+          name: ARCHS
+          description: "A list of architectures to build for. Available options are: x86_64"
+          default: "x86_64"
+
+      - bool:
+          name: FORCE
+          description: "
+If this is unchecked, then nothing is built or pushed if they already exist in chacra. This is the default.
+
+If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra."
+
+      - string:
+          name: BUILD_VIRTUALENV
+          description: "Base parent path for virtualenv locations, set to avoid issues with extremely long paths that are incompatible with tools like pip. Defaults to '/tmp/' (note the trailing slash, which is required)."
+          default: "/tmp/"
+
+    execution-strategy:
+       combination-filter: DIST==AVAILABLE_DIST && ARCH==AVAILABLE_ARCH && (ARCH=="x86_64" || (ARCH == "arm64" && (DIST == "xenial" || DIST == "centos7")))
+    axes:
+      - axis:
+          type: label-expression
+          name: MACHINE_SIZE
+          values:
+            - small
+      - axis:
+          type: label-expression
+          name: AVAILABLE_ARCH
+          values:
+            - x86_64
+      - axis:
+          type: label-expression
+          name: AVAILABLE_DIST
+          values:
+            - centos7
+      - axis:
+          type: dynamic
+          name: DIST
+      - axis:
+          type: dynamic
+          name: DIST
+          values:
+            - DISTROS
+      - axis:
+          type: dynamic
+          name: ARCH
+          values:
+            - ARCHS
+
+    scm:
+      - git:
+          url: git@github.com:open-iscsi/configshell-fb.git
+          # Use the SSH key attached to the ceph-jenkins GitHub account.
+          credentials-id: 'jenkins-build'
+          branches:
+            - $BRANCH
+          skip-tag: true
+          wipe-workspace: true
+
+    builders:
+      - shell: |
+          echo "Cleaning up top-level workarea (shared among workspaces)"
+          rm -rf dist
+          rm -rf venv
+          rm -rf release
+      # rpm build scripts
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/setup
+            - ../../build/build_rpm
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - text:
+              credential-id: chacractl-key
+              variable: CHACRACTL_KEY
+      - credentials-binding:
+          - text:
+              credential-id: shaman-api-key
+              variable: SHAMAN_API_KEY


### PR DESCRIPTION
This updated package is required by ceph-iscsi but won't be available
until CentOS 7.7(ish).

Signed-off-by: Jason Dillaman <dillaman@redhat.com>