### PR TITLE
ceph-volume: cleanup workspace before running tests

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -132,7 +132,7 @@
           browser: auto
           timeout: 20
           skip-tag: true
-          wipe-workspace: false
+          wipe-workspace: true
 
     builders:
       - inject:

--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -111,7 +111,7 @@
           browser: auto
           timeout: 20
           skip-tag: true
-          wipe-workspace: false
+          wipe-workspace: true
 
     builders:
       - inject:


### PR DESCRIPTION
The repos were never getting cleaned up causing `git fetch` to fail. This is already tested and making ceph-volume tests pass again.

/cc @jan--f 