### PR TITLE
Add container builds using ceph-container.git for centos7

### DIFF
--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -2,6 +2,11 @@
 set -ex
 
 
+# set to "true" or "false" so that both string comparisons
+# and 'if $CI_CONTAINER' work as expected.  Conventions vary across the
+# set of shell scripts and repos involved.
+CI_CONTAINER=${CI_CONTAINER:-false}
+
 # create a release directory for ceph-build tools
 mkdir -p release
 cp -a dist release/${vers}
@@ -178,6 +183,30 @@ EOF
     $VENV/chacractl repo update ${chacra_repo_endpoint}
 
     echo Check the status of the repo at: https://shaman.ceph.com/api/repos/${chacra_endpoint}/flavors/${FLAVOR}/
+fi
+
+# XXX perhaps use job parameters instead of literals; then
+# later stages can also use them to compare etc.
+if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $RELEASE == "7" && $FLAVOR == "default" ]] ; then
+    loop=0
+    ready=false
+    while ((loop < 15)); do
+      if [[ $(curl -s https://shaman.ceph.com/api/repos/${chacra_endpoint}/flavors/${FLAVOR}/ | jq '.[0].status') == '"ready"' ]] ; then ready=true; break; fi
+      ((loop = loop + 1))
+      sleep 60
+    done
+
+    if [[ "$ready" == "false" ]] ; then
+      echo "FAIL: timed out waiting for shaman repo to be built:  https://shaman.ceph.com/api/repos/${chacra_endpoint}/flavors/${FLAVOR}/"
+      # don't fail the build here on purpose
+      # update_build_status "failed" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+      # exit 1
+    fi
+
+    cd $WORKSPACE/ceph-container
+    # avoid failing the build if build-push fails
+    CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
+    cd $WORKSPACE
 fi
 
 # update shaman with the completed build status

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -14,6 +14,16 @@
           days-to-keep: 30
           artifact-days-to-keep: 30
 
+    scm:
+      - git:
+          url: git@github.com:ceph/ceph-container.git
+          basedir: ceph-container
+          credentials-id: 'jenkins-build'
+          branches:
+            - $CONTAINER_BRANCH
+          skip-tag: true
+          wipe-workspace: true
+
     execution-strategy:
        combination-filter: |
          DIST == AVAILABLE_DIST && ARCH == AVAILABLE_ARCH &&

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -131,3 +131,7 @@
           - text:
               credential-id: shaman-api-key
               variable: SHAMAN_API_KEY
+          - username-password-separated:
+              credential-id: dmick-quay
+              username: CONTAINER_REPO_USERNAME
+              password: CONTAINER_REPO_PASSWORD

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -60,6 +60,11 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           default: "default"
           description: "Type of Ceph build, choices are: crimson, notcmalloc, default (i.e. with tcmalloc). Defaults to: 'default'"
 
+      - string:
+          name: CONTAINER_BRANCH
+          description: "For CI_CONTAINER: Branch of ceph-container to use"
+          default: master
+
     builders:
       - multijob:
           name: 'ceph dev setup phase'

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -61,9 +61,24 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           description: "Type of Ceph build, choices are: crimson, notcmalloc, default (i.e. with tcmalloc). Defaults to: 'default'"
 
       - string:
+          name: CI_CONTAINER
+          description: 'Build container with development release of Ceph.  Note: this must be "false" or "true" so that it can execute a command or satisfy a string comparison'
+          default: "true"
+
+      - string:
           name: CONTAINER_BRANCH
           description: "For CI_CONTAINER: Branch of ceph-container to use"
           default: master
+
+      - string:
+          name: CONTAINER_REPO_HOSTNAME
+          description: "For CI_CONTAINER: Name of container repo server (i.e. 'quay.io')"
+          default: "quay.io"
+
+      - string:
+          name: CONTAINER_REPO_ORGANIZATION
+          description: "For CI_CONTAINER: Name of container repo organization (i.e. 'cephci')"
+          default: "cephci"
 
     builders:
       - multijob:


### PR DESCRIPTION
This adds a checkout of ceph-container to ceph-dev-new builds and gives the option to build a daemon-base container (for centos7 only) and push it to a configurable (with build variables) container repo.  The idea is to build containers for wip- branches and push them to quay.io to allow testing.

This depends on changes to ceph-container.git in https://github.com/ceph/ceph-container/pull/1457.
