### PR TITLE
ceph-pr-commits: add trigger phrase

### DIFF
--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -54,7 +54,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          trigger-phrase: ''
+          trigger-phrase: 'jenkins test signed'
           only-trigger-phrase: false
           github-hooks: true
           permit-all: true


### PR DESCRIPTION
When Jenkins fails to clone a repo, signed-off checks will fail. If
all other checks have passed, there's no reason to force a full run of
Jenkins jobs again on that PR. This PR introduces `jenkins test signed`
trigger phrase to allow re-running the pr-commit check.

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>