### PR TITLE
ceph-pr-commits: wipe workspace to prevent repo corruption

### DIFF
--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -9,7 +9,7 @@
           browser: auto
           timeout: 20
           skip-tag: true
-          wipe-workspace: false
+          wipe-workspace: true
           basedir: "ceph"
 
 - scm:


### PR DESCRIPTION
The repos for ceph-pr-commits job is corrupted and is causing builds to keep failing, this should fix that