### PR TITLE
ceph-pr-submodules: wipe the workspace to prevent repo corruption

### DIFF
--- a/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
@@ -46,7 +46,7 @@
           browser: auto
           timeout: 20
           skip-tag: true
-          wipe-workspace: false
+          wipe-workspace: true
 
     builders:
       - shell:


### PR DESCRIPTION
Same fix for all the other jobs that are failing... this one just started out to get issues as well