### PR TITLE
ceph-volume-pr: remove escape which doubles the curly brackets

### DIFF
--- a/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
@@ -86,6 +86,6 @@
                   - ABORTED
               build-steps:
                 - shell:
-                    !include-raw-escape:
+                    !include-raw:
                       - ../../../scripts/build_utils.sh
                       - ../../build/teardown


### PR DESCRIPTION
Which results in syntax errors:

```
[ceph-volume-pr] $ /bin/bash /tmp/jenkins7828397761648251834.sh
++ mktemp -td venv.XXXXXXXXXX
+ TEMPVENV=/tmp/venv.hGLjCWEQk2
+ VENV=/tmp/venv.hGLjCWEQk2/bin
/tmp/jenkins7828397761648251834.sh: line 8: syntax error near unexpected token `{{'
```

Removing the escape made the script run correctly.  From the docs:


> When used as a macro !include-raw-escape: should only be used if parameters are passed into the escaped file and you would like to escape those parameters. If the file does not have any jjb parameters passed into it then !include-raw: should be used instead otherwise you will run into an interesting issue where include-raw-escape: actually adds additional curly braces around existing curly braces. For example ${PROJECT} becomes ${{PROJECT}} which may break bash scripts.