### PR TITLE
scripts: use find's -delete option to prevent 'argument too long'

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -728,7 +728,7 @@ prune_stale_vagrant_vms() {
     shopt -s globstar
 
     # From the global workspace path, find any machine stale from other jobs
-    sudo find $SEARCH_PATH -type d -wholename '*/.vagrant/machines' -exec rm -rv {} +
+    sudo find "$SEARCH_PATH" -type d -path "*/.vagrant/machines/*" -delete
 
     # unset extended pattern globbing, to prevent messing up other functions
     shopt -u globstar


### PR DESCRIPTION
Fixes the problem that causes this:

```
sudo: unable to execute /bin/find: Argument list too long
Build step 'Execute shell' marked build as failure
```

When calling `exec` as before, all the paths found by `find` are done in a single call, since ceph-volume has several dozen jobs, the argument becomes impossible for the system. By using `-delete` we are preventing this from happening.