### PR TITLE
scripts: do not specify directories with find -delete, rm the path

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -728,7 +728,7 @@ prune_stale_vagrant_vms() {
     shopt -s globstar
 
     # From the global workspace path, find any machine stale from other jobs
-    sudo find "$SEARCH_PATH" -type d -path "*/.vagrant/machines/*" -delete
+    sudo find "$SEARCH_PATH" -path "*/.vagrant/machines/*" -delete
 
     # unset extended pattern globbing, to prevent messing up other functions
     shopt -u globstar


### PR DESCRIPTION
Follow up on PR #1383 . We need to remove the path, not specify the directory. We need to remove the directory restriction, otherwise it will only remove directories and we want to remove files as well. 