### PR TITLE
Revert "ceph-*build/build/setup_rpm: downgrade to gcc-c++-8.2.1"

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -44,8 +44,6 @@ $SUDO yum install -y \*rpm-macros
 
 $SUDO yum-builddep -y $DIR/ceph.spec
 
-maybe_downgrade_gcc
-
 BRANCH=`branch_slash_filter $BRANCH`
 
 if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -44,8 +44,6 @@ $SUDO yum install -y \*rpm-macros
 
 $SUDO yum-builddep -y $DIR/ceph.spec
 
-maybe_downgrade_gcc
-
 BRANCH=`branch_slash_filter $BRANCH`
 
 if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -44,8 +44,6 @@ $SUDO yum install -y \*rpm-macros
 
 $SUDO yum-builddep -y $DIR/ceph.spec
 
-maybe_downgrade_gcc
-
 BRANCH=`branch_slash_filter $BRANCH`
 
 if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1005,12 +1005,3 @@ get_nr_build_jobs() {
     fi
     echo $n_build_jobs
 }
-
-maybe_downgrade_gcc() {
-    # see also https://bugzilla.redhat.com/show_bug.cgi?id=1726630
-    if [ $(rpm -q --queryformat "%{VERSION}" devtoolset-8-gcc-c++) = 8.3.1 ]; then
-        # rollback to avoid using a buggy version
-        $SUDO yum remove -y devtoolset-8-gcc-c++ devtoolset-8-gcc devtoolset-8-libstdc++-devel
-        $SUDO yum install -y devtoolset-8-gcc-c++-8.2.1-3.el7
-    fi
-}


### PR DESCRIPTION
This reverts commit cf2c26b181a86738e2a8bb17545f45d6aa1c7c45.

since https://bugzilla.redhat.com/show_bug.cgi?id=1726630 has been
fixed. and we have devtoolset-8-gcc-c++-8.3.1-3.1.el7.x86_64.rpm.

no reason to stick to devtoolset-8-gcc-c++-8.2.1-3 anymore.

Fixes: https://tracker.ceph.com/issues/40646
Signed-off-by: Kefu Chai <kchai@redhat.com>