### PR TITLE
scripts: use a loop instead of globbing directly

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -728,7 +728,11 @@ prune_stale_vagrant_vms() {
     shopt -s globstar
 
     # From the global workspace path, find any machine stale from other jobs
-    sudo find $SEARCH_PATH -path "*/.vagrant/machines/*" -delete
+    # A loop is required here to avoid having problems when matching too many
+    # paths in $SEARCH_PATH
+    for path in $SEARCH_PATH; do
+        sudo find $path -path "*/.vagrant/machines/*" -delete
+    done
 
     # unset extended pattern globbing, to prevent messing up other functions
     shopt -u globstar


### PR DESCRIPTION
My previous attempts where still causing issues when too many directories are matched because they are _still_ processed all at the same time:

```
sudo: unable to execute /bin/find: Argument list too long
```

This is now using a loop