### PR TITLE
pr-syntax-check - install all requirements

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -8,7 +8,7 @@ set -e
 # which would enforce latest ansible version to be installed.
 virtualenv $TEMPVENV
 "$VENV"/pip install --upgrade pip
-"$VENV"/pip install -r <(grep ansible "$WORKSPACE"/ceph-ansible/tests/requirements.txt)
+"$VENV"/pip install -r "$WORKSPACE"/ceph-ansible/requirements.txt
 "$VENV"/pip install ansible-lint
 
 


### PR DESCRIPTION
This change removes the grep for 'ansible' when isntalling
requirements in ceph-ansible-pr-syntax-check. The grep
cause onlye the ansible requirement to be installed, ignoring
the other packages. This causes an issue in PR[1] which
introduce a filter plugin that depend on the netaddr package.

[1] https://github.com/ceph/ceph-ansible/pull/4339

Closes: #1390

Signed-off-by: Harald Jensås <hjensas@redhat.com>