### PR TITLE
Revert "*/scm: only pull the PR under test"

### DIFF
--- a/ceph-ansible-docs-prs/config/definitions/ceph-ansible-docs-prs.yml
+++ b/ceph-ansible-docs-prs/config/definitions/ceph-ansible-docs-prs.yml
@@ -20,10 +20,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -20,10 +20,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -927,7 +924,7 @@
           url: https://github.com/ceph/ceph-ansible.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 60
           skip-tag: true

--- a/ceph-ansible-pr-syntax-check/config/definitions/ceph-ansible-pr-syntax-check.yml
+++ b/ceph-ansible-pr-syntax-check/config/definitions/ceph-ansible-pr-syntax-check.yml
@@ -5,7 +5,7 @@
           url: https://github.com/ceph/ceph-ansible.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -35,10 +35,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -265,10 +265,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -292,7 +289,7 @@
           url: https://github.com/ceph/ceph-ansible.git
           branches:
             - ${{sha1}}
-          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
+++ b/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
@@ -64,7 +64,7 @@
           url: https://github.com/ceph/ceph-ansible.git
           branches:
             - $BRANCH
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -21,10 +21,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -45,7 +42,7 @@
           url: https://github.com/ceph/ceph-build.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-container-flake8/config/definitions/ceph-container-flake8.yml
+++ b/ceph-container-flake8/config/definitions/ceph-container-flake8.yml
@@ -5,7 +5,7 @@
           url: https://github.com/ceph/ceph-container.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -29,10 +29,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/ceph-container-lint/config/definitions/ceph-container-lint.yml
+++ b/ceph-container-lint/config/definitions/ceph-container-lint.yml
@@ -5,7 +5,7 @@
           url: https://github.com/ceph/ceph-container.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -29,10 +29,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/ceph-container-prs/config/definitions/ceph-container-prs.yml
+++ b/ceph-container-prs/config/definitions/ceph-container-prs.yml
@@ -35,10 +35,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -62,7 +59,7 @@
           url: https://github.com/ceph/ceph-container.git
           branches:
             - ${{sha1}}
-          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -110,10 +107,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -137,7 +131,7 @@
           url: https://github.com/ceph/ceph-container.git
           branches:
             - ${{sha1}}
-          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-dashboard-pr-backend/config/definitions/ceph-dashboard-pr-backend.yml
+++ b/ceph-dashboard-pr-backend/config/definitions/ceph-dashboard-pr-backend.yml
@@ -23,10 +23,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -52,7 +49,7 @@
           url: https://github.com/ceph/ceph.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -23,10 +23,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -53,7 +50,7 @@
           url: https://github.com/ceph/ceph.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -8,7 +8,7 @@
           url: https://github.com/ceph/ceph-deploy.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -50,10 +50,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/ceph-iscsi-cli-flake8/config/definitions/ceph-iscsi-config-flake8.yml
+++ b/ceph-iscsi-cli-flake8/config/definitions/ceph-iscsi-config-flake8.yml
@@ -5,7 +5,7 @@
           url: https://github.com/ceph/ceph-iscsi-cli.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -36,10 +36,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/ceph-iscsi-config-flake8/config/definitions/ceph-iscsi-config-flake8.yml
+++ b/ceph-iscsi-config-flake8/config/definitions/ceph-iscsi-config-flake8.yml
@@ -5,7 +5,7 @@
           url: https://github.com/ceph/ceph-iscsi-config.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -36,10 +36,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/ceph-iscsi-tox/config/definitions/ceph-iscsi-tox.yml
+++ b/ceph-iscsi-tox/config/definitions/ceph-iscsi-tox.yml
@@ -5,7 +5,7 @@
           url: https://github.com/ceph/ceph-iscsi.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -36,10 +36,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/ceph-medic-pull-requests/config/definitions/ceph-medic-pull-requests.yml
+++ b/ceph-medic-pull-requests/config/definitions/ceph-medic-pull-requests.yml
@@ -5,7 +5,7 @@
           url: https://github.com/ceph/ceph-medic
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           basedir: "ceph-medic"
@@ -38,10 +38,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -5,7 +5,7 @@
           url: https://github.com/ceph/ceph.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -47,10 +47,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -38,7 +38,7 @@
           browser: auto
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           skip-tag: true
           timeout: 20
           wipe-workspace: true

--- a/ceph-pr-render-docs/config/definitions/ceph-pr-render-docs.yml
+++ b/ceph-pr-render-docs/config/definitions/ceph-pr-render-docs.yml
@@ -38,7 +38,7 @@
           browser: auto
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           skip-tag: true
           timeout: 20
           wipe-workspace: true

--- a/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
@@ -20,10 +20,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -45,7 +42,7 @@
           url: https://github.com/ceph/ceph.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -12,12 +12,9 @@
     node: arm64
     parameters:
     - string:
-        name: sha1
-        description: "commit id or a refname, like 'origin/pr/72/head'"
         default: origin/master
-    - string:
-        name: ghprbPullId
-        description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+        description: A pull request ID, like 'origin/pr/72/head'
+        name: sha1
     project-type: freestyle
     properties:
     - build-discarder:
@@ -49,7 +46,7 @@
           <userRemoteConfigs>
           <hudson.plugins.git.UserRemoteConfig>
           <name>origin</name>
-          <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
+          <refspec>+refs/pull/*:refs/remotes/origin/pr/*</refspec>
           <url>https://github.com/ceph/ceph.git</url>
           </hudson.plugins.git.UserRemoteConfig>
           </userRemoteConfigs>

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -23,10 +23,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -49,7 +46,7 @@
           url: https://github.com/ceph/ceph.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -21,10 +21,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -53,7 +50,7 @@
           url: https://github.com/ceph/ceph-qa-suite.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -89,10 +89,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
       # this is injected by the ghprb plugin, and is fully optional but may help in manually triggering
       # a job that can end up updating a PR
@@ -131,7 +128,7 @@
           url: https://github.com/ceph/ceph.git
           branches:
             - ${{sha1}}
-          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
@@ -17,10 +17,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
       # this is injected by the ghprb plugin, and is fully optional but may help in manually triggering
       # a job that can end up updating a PR
@@ -56,7 +53,7 @@
           browser: auto
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           skip-tag: true
           timeout: 20
           wipe-workspace: true

--- a/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
+++ b/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
@@ -46,7 +46,7 @@
           url: $CEPH_REPO_URL
           branches:
             - $CEPH_BRANCH
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/cephmetrics-pull-requests/config/definitions/cephmetrics-pull-requests.yml
+++ b/cephmetrics-pull-requests/config/definitions/cephmetrics-pull-requests.yml
@@ -21,10 +21,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -45,7 +42,7 @@
           url: https://github.com/ceph/cephmetrics.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/chacra-pull-requests/config/definitions/chacra-pull-requests.yml
+++ b/chacra-pull-requests/config/definitions/chacra-pull-requests.yml
@@ -5,7 +5,7 @@
           url: https://github.com/ceph/chacra
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           basedir: "chacra"
@@ -51,10 +51,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
+++ b/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
@@ -19,10 +19,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -54,7 +51,7 @@
           url: https://github.com/alfredodeza/merfi.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
+++ b/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
@@ -8,7 +8,7 @@
           url: https://github.com/ceph/radosgw-agent.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -49,10 +49,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/shaman-pull-requests/config/definitions/shaman-pull-requests.yml
+++ b/shaman-pull-requests/config/definitions/shaman-pull-requests.yml
@@ -5,7 +5,7 @@
           url: https://github.com/ceph/shaman
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           basedir: "shaman"
@@ -51,10 +51,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:

--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -21,10 +21,7 @@
     parameters:
       - string:
           name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-      - string:
-          name: ghprbPullId
-          description: "A pull request ID, like '72' in https://github.com/ceph/ceph/pull/72"
+          description: "A pull request ID, like 'origin/pr/72/head'"
 
     triggers:
       - github-pull-request:
@@ -58,7 +55,7 @@
           url: https://github.com/ceph/teuthology.git
           branches:
             - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20
           skip-tag: true


### PR DESCRIPTION
This reverts commit 4eae5698a6a1383c69338ec7781e4cee6c087a9f.

It breaks all pull-request jobs for ceph-volume at least, haven't been
able to investigate all other affected