### PR TITLE
ceph-*-build: skip unavailable repo when yum-builddep

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -45,7 +45,7 @@ sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 # python2-rpm-macro we use for identify the python related dependencies
 $SUDO yum install -y python36-devel
 
-$SUDO yum-builddep -y $DIR/ceph.spec
+$SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -45,7 +45,7 @@ sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 # python2-rpm-macro we use for identify the python related dependencies
 $SUDO yum install -y python36-devel
 
-$SUDO yum-builddep -y $DIR/ceph.spec
+$SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -45,7 +45,7 @@ sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 # python2-rpm-macro we use for identify the python related dependencies
 $SUDO yum install -y python36-devel
 
-$SUDO yum-builddep -y $DIR/ceph.spec
+$SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
 
 BRANCH=`branch_slash_filter $BRANCH`
 


### PR DESCRIPTION
As centos-sclo-rh-source leads us to 404 at this moment. and we are not
using the source repo for building ceph. so we can just skip any
unavailable repo.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>