### PR TITLE
kernel: update the trigger list

### DIFF
--- a/kernel-trigger/config/definitions/kernel-trigger.yml
+++ b/kernel-trigger/config/definitions/kernel-trigger.yml
@@ -33,13 +33,16 @@
             </userRemoteConfigs>
             <branches>
               <hudson.plugins.git.BranchSpec>
-                <name>origin/testing*</name>
+                <name>origin/testing</name>
               </hudson.plugins.git.BranchSpec>
               <hudson.plugins.git.BranchSpec>
-                <name>origin/master*</name>
+                <name>origin/master</name>
               </hudson.plugins.git.BranchSpec>
               <hudson.plugins.git.BranchSpec>
                 <name>origin/for-linus</name>
+              </hudson.plugins.git.BranchSpec>
+              <hudson.plugins.git.BranchSpec>
+                <name>origin/wip*</name>
               </hudson.plugins.git.BranchSpec>
               <hudson.plugins.git.BranchSpec>
                 <name>origin/ceph-iscsi*</name>


### PR DESCRIPTION
We didn't trigger on wip* branches like other ceph projects because
there was a lot of old branches matching that mask in the repository.
Now that they are cleaned up, drop the workarounds (testing*/master*)
and add wip*.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>