### PR TITLE
ceph-*-build: s/python36-devel/python3-devel/

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -40,10 +40,9 @@ fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 
 # Make sure we have all the rpm macros installed and at the latest version
-# before installing the dependencies, python3.6 is the main python offered
-# by CentOS/RHEL7 at this moment, and it requires the python-rpm-macro and
-# python2-rpm-macro we use for identify the python related dependencies
-$SUDO yum install -y python36-devel
+# before installing the dependencies, python3-devel requires the
+# python-rpm-macro we use for identifying the python related dependencies
+$SUDO yum install -y python3-devel
 
 $SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
 

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -39,11 +39,9 @@ elif [ "$ARCH" = arm64 ]; then
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 
-# Make sure we have all the rpm macros installed and at the latest version
-# before installing the dependencies, python3.6 is the main python offered
-# by CentOS/RHEL7 at this moment, and it requires the python-rpm-macro and
-# python2-rpm-macro we use for identify the python related dependencies
-$SUDO yum install -y python36-devel
+# before installing the dependencies, python3-devel requires the
+# python-rpm-macro we use for identifying the python related dependencies
+$SUDO yum install -y python3-devel
 
 $SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
 

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -39,11 +39,9 @@ elif [ "$ARCH" = arm64 ]; then
 fi
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 
-# Make sure we have all the rpm macros installed and at the latest version
-# before installing the dependencies, python3.6 is the main python offered
-# by CentOS/RHEL7 at this moment, and it requires the python-rpm-macro and
-# python2-rpm-macro we use for identify the python related dependencies
-$SUDO yum install -y python36-devel
+# before installing the dependencies, python3-devel requires the
+# python-rpm-macro we use for identifying the python related dependencies
+$SUDO yum install -y python3-devel
 
 $SUDO yum-builddep -y --setopt=*.skip_if_unavailable=true $DIR/ceph.spec
 


### PR DESCRIPTION
to silence the warning of

Package python36-devel is obsoleted by python3-devel, trying to install
python3-devel-3.6.8-10.el7.x86_64

Signed-off-by: Kefu Chai <kchai@redhat.com>