### PR TITLE
kernel-trigger: Build any wip branch

### DIFF
--- a/kernel-trigger/config/definitions/kernel-trigger.yml
+++ b/kernel-trigger/config/definitions/kernel-trigger.yml
@@ -42,7 +42,7 @@
                 <name>origin/for-linus</name>
               </hudson.plugins.git.BranchSpec>
               <hudson.plugins.git.BranchSpec>
-                <name>origin/wip*</name>
+                <name>*/wip*</name>
               </hudson.plugins.git.BranchSpec>
               <hudson.plugins.git.BranchSpec>
                 <name>origin/ceph-iscsi*</name>


### PR DESCRIPTION
I honestly don't know why this works and origin/wip* didn't but here we are.

Signed-off-by: David Galloway <dgallowa@redhat.com>