### PR TITLE
ceph-ansible-prs: don't display podman job on github on stable-3.2

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -27,6 +27,3 @@ done
 popd
 # In the same logic, clean fact cache
 rm -rf $HOME/ansible/facts/*
-
-# stable-3.2 doesn't support podman.
-[[ "$ghprbTargetBranch" == "stable-3.2" && "$SCENARIO" == "podman" ]] || start_tox

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -134,6 +134,14 @@
               echo "Only docs were modified.  Skipping the rest of the job."
               exit 1
             fi
+            if [[ "$ghprbTargetBranch" =~ stable-3. && "$SCENARIO" == "podman" ]]; then
+              echo "This scenario isn't available on this branch."
+              exit 1
+            fi
+            if [[ "$ghprbTargetBranch" == stable-3.1 && "$SCENARIO" =~ lvm_batch|lvm_osds ]]; then
+              echo "This scenario isn't available on this branch."
+              exit 1
+            fi
           on-evaluation-failure: dont-run
           steps:
             - shell:


### PR DESCRIPTION
This should avoid to display this job on the github status.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>