### PR TITLE
ceph-ansible-prs: re-add shrink/rgw_multisite jobs

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -41,6 +41,26 @@
         - 'ceph-ansible-prs-auto'
 
 - project:
+    name: ceph-ansible-prs-common-trigger
+    slave_labels: 'vagrant && libvirt && (smithi || centos7)'
+    distribution:
+      - centos
+      - ubuntu
+    deployment:
+      - container
+      - non_container
+    scenario:
+      - rgw_multisite
+      - shrink_mon
+      - shrink_mgr
+      - shrink_osd
+      - shrink_rgw
+      - shrink_mds
+      - shrink_rbdmirror
+    jobs:
+        - 'ceph-ansible-prs-common-trigger'
+
+- project:
     name: ceph-ansible-prs-ubuntu-trigger
     slave_labels: 'vagrant && libvirt && (smithi || centos7)'
     distribution:
@@ -55,12 +75,6 @@
       - lvm_osds
       - lvm_batch
       - collocation
-      - shrink_mon
-      - shrink_mgr
-      - shrink_osd
-      - shrink_rgw
-      - shrink_mds
-      - shrink_rbdmirror
     jobs:
         - 'ceph-ansible-prs-ubuntu-trigger'
 
@@ -98,6 +112,101 @@
           skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
           trigger-phrase: '^jenkins test {distribution}-{deployment}-{scenario}|jenkins test all.*'
           only-trigger-phrase: false
+          github-hooks: true
+          permit-all: true
+          auto-close-on-fail: false
+          status-context: "Testing: {distribution}-{deployment}-{scenario}"
+          started-status: "Running: {distribution}-{deployment}-{scenario}"
+          success-status: "OK - {distribution}-{deployment}-{scenario}"
+          failure-status: "FAIL - {distribution}-{deployment}-{scenario}"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-ansible.git
+          branches:
+            - ${{sha1}}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: false
+
+    builders:
+      - inject:
+          properties-content: |
+            DISTRIBUTION={distribution}
+            DEPLOYMENT={deployment}
+            SCENARIO={scenario}
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            # Returns 1 if only .rst and README files were modified
+            echo "Checking if only rst and READMEs were modified"
+            git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -v '\.rst\|README'
+            if [ $? -eq 1 ]; then
+              echo "Only docs were modified.  Skipping the rest of the job."
+              exit 1
+            fi
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw-escape:
+                  - ../../../scripts/build_utils.sh
+                  - ../../build/build
+
+    publishers:
+      - postbuildscript:
+          builders:
+            - role: SLAVE
+              build-on:
+                  - FAILURE
+                  - ABORTED
+              build-steps:
+                - shell:
+                    !include-raw-escape:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown
+
+      - archive:
+          artifacts: 'logs/**'
+          allow-empty: true
+          latest-only: false
+
+- job-template:
+    name: 'ceph-ansible-prs-{distribution}-{deployment}-{scenario}'
+    id: 'ceph-ansible-prs-common-trigger'
+    node: '{slave_labels}'
+    concurrent: true
+    defaults: global
+    display-name: 'ceph-ansible: Pull Requests [{distribution}-{deployment}-{scenario}]'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/ceph-ansible
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+
+    parameters:
+      - string:
+          name: sha1
+          description: "A pull request ID, like 'origin/pr/72/head'"
+
+    triggers:
+      - github-pull-request:
+          cancel-builds-on-update: true
+          allow-whitelist-orgs-as-admins: true
+          org-list:
+            - ceph
+          skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
+          trigger-phrase: '^jenkins test {distribution}-{deployment}-{scenario}|jenkins test all.*'
+          only-trigger-phrase: true
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false


### PR DESCRIPTION
Since the pipeline refactoring we're not able to trigger manually the
shrink and rgw_multisite jobs. The shrink jobs were only configured for
ubuntu and rgw_multisite was missing.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>