### PR TITLE
ceph-pr-submodules: do not use shallow-clone

### DIFF
--- a/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
@@ -46,7 +46,6 @@
           browser: auto
           timeout: 20
           skip-tag: true
-          shallow-clone: true
           wipe-workspace: true
 
     builders:


### PR DESCRIPTION
we use
```
git diff --submodule=log origin/$ghprbTargetBranch...$ghprbActualCommit
```

for checking the differences between the delta since their common
ancestor, so we have to do a non-shallow clone for accessing the
common ancestor.

Signed-off-by: Kefu Chai <kchai@redhat.com>