### PR TITLE
ceph-ansible-prs: re-add ooo_collocation

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -13,6 +13,7 @@
       - purge
       - collocation
       - lvm_batch
+      - ooo_collocation
     jobs:
         - 'ceph-ansible-prs-auto'
 


### PR DESCRIPTION
This commit adds the ooo_collocation that were removed recently.
Related ceph-ansible PR : https://github.com/ceph/ceph-ansible/pull/4401

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>