### PR TITLE
ceph-ansible-prs: run ooo_collocation on container only

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -13,6 +13,17 @@
       - purge
       - collocation
       - lvm_batch
+    jobs:
+        - 'ceph-ansible-prs-auto'
+
+- project:
+    name: ceph-ansible-prs-ooo
+    slave_labels: 'vagrant && libvirt && (smithi || centos7)'
+    distribution:
+      - centos
+    deployment:
+      - container
+    scenario:
       - ooo_collocation
     jobs:
         - 'ceph-ansible-prs-auto'


### PR DESCRIPTION
Add a dedicated project for ooo_collocation since we don't want it to
run in non_container context.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>