### PR TITLE
ceph-pull-requests-arm64: Don't make check on CentOS8 yet

### DIFF
--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -9,7 +9,7 @@
     concurrent: true
     disabled: false
     name: ceph-pull-requests-arm64
-    node: arm64
+    node: 'arm64 && !centos8'
     parameters:
     - string:
         name: sha1


### PR DESCRIPTION
Until deps are in epel8 or we figure out an alternative

Signed-off-by: David Galloway <dgallowa@redhat.com>