### PR TITLE
ceph-*-pull-requests*: use ghprbPullId to define branches

### DIFF
--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -19,7 +19,7 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - ${sha1}
+            - origin/pr/${ghprbPullId}/merge
           refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
           timeout: 20
           basedir: "ceph-pr"
@@ -93,8 +93,8 @@
 
     parameters:
       - string:
-          name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
+          name: ghprbPullId
+          description: "the GitHub pull id, like '72' in 'ceph/pull/72'"
 
     triggers:
       - github-pull-request:

--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -12,8 +12,8 @@
     node: 'arm64 && !centos8'
     parameters:
     - string:
-        name: sha1
-        description: "commit id or a refname, like 'origin/pr/72/head'"
+        name: ghprbPullId
+        description: "the GitHub pull id, like '72' in 'ceph/pull/72'"
         default: origin/master
     project-type: freestyle
     properties:
@@ -43,7 +43,7 @@
         url: https://github.com/ceph/ceph.git
         name: origin
         branches:
-          - ${sha1}
+          - origin/pr/${ghprbPullId}/merge
         refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
         skip-tag: true
         shallow-clone: true

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -22,8 +22,8 @@
 
     parameters:
       - string:
-          name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
+          name: ghprbPullId
+          description: "the GitHub pull id, like '72' in 'ceph/pull/72'"
 
     triggers:
       - github-pull-request:
@@ -45,7 +45,7 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - ${sha1}
+            - origin/pr/${ghprbPullId}/merge
           refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
           browser: auto
           timeout: 20


### PR DESCRIPTION
* add "ghprbPullId" param, simpler to use than "sha1"
* instead of using "sha1", use "ghprbPullId" to define branches to build,
  more consistent this way. as we pull the refs using
  `+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*`
  and after the change, the ref to build is specified using
  `origin/pr/${ghprbPullId}/merge`. also, by removing "sha1",
  we can specify a single parameter when rebuilding/building a branch
  on jenkins instead of two parameters.

Signed-off-by: Kefu Chai <kchai@redhat.com>