### PR TITLE
ansible: replace sudo by become

### DIFF
--- a/ansible/examples/init.yml
+++ b/ansible/examples/init.yml
@@ -7,7 +7,7 @@
 
 # install python2.7 on xenial nodes
 - hosts: all
-  sudo: yes
+  become: yes
   user: admin 
   gather_facts: false
   tasks:
@@ -18,7 +18,7 @@
 
 - hosts: all
   user: admin
-  sudo: true
+  become: true
   tasks:
 
     - name: uncomment SSH port

--- a/ansible/examples/sensu.yml
+++ b/ansible/examples/sensu.yml
@@ -4,7 +4,7 @@
 #     ansible-galaxy install -r requirements/sensu-requirements.yml
 #
 - hosts: sensu-server
-  sudo: true
+  become: true
   vars_files:
     - vars/sensu-vars.yml
   roles:
@@ -38,7 +38,7 @@
           vhost: "%2Fsensu"
 
 - hosts: sensu-clients
-  sudo: true
+  become: true
   vars_files:
     - vars/sensu-vars.yml
   roles:

--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -4,7 +4,7 @@
 #
 # install python2.7 on xenial nodes
 - hosts: all
-  sudo: yes
+  become: yes
 # this will most likely need changed
   user: admin
   gather_facts: false
@@ -15,7 +15,7 @@
       failed_when: false
 
 - hosts: all
-  sudo: true
+  become: true
 # this will most likely need changed
   user: admin
   vars:
@@ -49,7 +49,7 @@
       authorized_key: user={{ jenkins_user }} key="{{ lookup('file', 'files/ssh/keys/jenkins_build.pub') }}"
 
     - name: ensure {{ jenkins_user }} can sudo without a prompt
-      sudo: yes
+      become: yes
       lineinfile:
         dest: /etc/sudoers
         regexp: '^{{ jenkins_user }} ALL'
@@ -84,7 +84,7 @@
 
     # smithi nodes do not have epel repos
     - name: install an yum epel repo
-      sudo: yes
+      become: yes
       template:
         src: "templates/yum-repos/epel.repo"
         dest: "/etc/yum.repos.d/epel.repo"
@@ -94,7 +94,7 @@
       when: ansible_pkg_mgr  == "yum"
 
     - name: Install RPM requirements (All distro versions)
-      sudo: yes
+      become: yes
       package:
         name: "{{ item }}"
         state: present
@@ -130,7 +130,7 @@
         - ansible_os_family == "RedHat"
 
     - name: Install RPM requirements (<=7)
-      sudo: yes
+      become: yes
       package:
         name: "{{ item }}"
         state: present
@@ -143,7 +143,7 @@
         - ansible_distribution_major_version|int <= 7
 
     - name: Install RPM requirements (>=8)
-      sudo: yes
+      become: yes
       package:
         name: "{{ item }}"
         state: present
@@ -168,7 +168,7 @@
       when: ansible_pkg_mgr  == "apt"
 
     - name: Install DEB requirements
-      sudo: yes
+      become: yes
       apt: name={{ item }} state=present
       with_items:
         - git
@@ -201,17 +201,17 @@
       when: ansible_pkg_mgr  == "apt"
 
     - name: Add the Debian Jessie Key
-      sudo: yes
+      become: yes
       when: ansible_pkg_mgr  == "apt"
       apt_key: id=2B90D010 url=https://ftp-master.debian.org/keys/archive-key-8.asc keyring=/etc/apt/trusted.gpg state=present
 
     - name: Add the Debian Security Jessie Key
-      sudo: yes
+      become: yes
       when: ansible_pkg_mgr  == "apt"
       apt_key: id=C857C906 url=https://ftp-master.debian.org/keys/archive-key-8-security.asc keyring=/etc/apt/trusted.gpg state=present
 
     - name: Add the Debian Jessie Stable Key
-      sudo: yes
+      become: yes
       when: ansible_pkg_mgr  == "apt"
       apt_key: id=518E17E1 url=http://download.ceph.com/keys/jessie-stable-release.asc keyring=/etc/apt/trusted.gpg state=present
 
@@ -260,12 +260,12 @@
         owner: "{{ jenkins_user }}"
 
     - name: Set Hostname with hostname command
-      sudo: yes
+      become: yes
       hostname:
         name: "{{ ansible_hostname }}"
 
     - name: ensure that the current host is in /etc/hosts. Yes this is a thing.
-      sudo: true
+      become: true
       replace:
         backup: yes
         dest: /etc/hosts
@@ -273,23 +273,23 @@
         replace: '\1 {{ ansible_hostname }}'
 
     - name: ensure that 127.0.1.1 is present with an actual hostname
-      sudo: true
+      become: true
       lineinfile:
         dest: /etc/hosts
         regexp: '^(127\.0\.1\.1(?!.*\b{{ ansible_hostname }}\b).*)$'
         line: '127.0.1.1 {{ ansible_hostname }}'
 
     - name: install six, latest one
-      sudo: true
+      become: true
       pip: name=six state=latest
 
     - name: install python-jenkins
-      sudo: true
+      become: true
       # https://review.openstack.org/460363
       pip: name=python-jenkins version=0.4.15
 
     - name: add github.com host key
-      sudo: true
+      become: true
       known_hosts:
         path: '/etc/ssh/ssh_known_hosts'
         # we need to use 'host' here because prado currently uses ansible-playbook==1.9.1
@@ -344,7 +344,7 @@
       template:
         src: "templates/systemd/jenkins.service.j2"
         dest: "/etc/systemd/system/jenkins.service"
-      sudo: true
+      become: true
       when: use_jnlp
 
     - name: start jenkins service
@@ -352,5 +352,5 @@
         name: jenkins
         state: started
         enabled: yes
-      sudo: yes
+      become: yes
       when: use_jnlp

--- a/ansible/roles/grafana/handlers/main.yml
+++ b/ansible/roles/grafana/handlers/main.yml
@@ -1,18 +1,18 @@
 ---
 
 - name: reload systemd
-  sudo: yes
+  become: yes
   command: systemctl daemon-reload
 
 - name: restart app
-  sudo: true
+  become: true
   service:
     name: grafana-server
     state: restarted
     enabled: yes
 
 - name: restart nginx
-  sudo: true
+  become: true
   service:
     name: nginx
     state: restarted

--- a/ansible/roles/grafana/tasks/main.yml
+++ b/ansible/roles/grafana/tasks/main.yml
@@ -2,10 +2,10 @@
 - name: update apt cache
   apt:
     update_cache: yes
-  sudo: yes
+  become: yes
 
 - name: install ssl system requirements
-  sudo: yes
+  become: yes
   apt:
     name: "{{ item }}"
     state: present
@@ -14,7 +14,7 @@
     - packages
 
 - name: install system packages
-  sudo: yes
+  become: yes
   apt:
     name: "{{ item }}"
     state: present
@@ -38,7 +38,7 @@
     dest: "/etc/grafana/grafana.ini"
   notify:
     - restart app
-  sudo: true
+  become: true
 
 - include: postgresql.yml
   tags:
@@ -47,14 +47,14 @@
 - include: nginx.yml
 
 - name: ensure nginx is running
-  sudo: true
+  become: true
   service:
     name: nginx
     state: started
     enabled: yes
 
 - name: ensure grafana is restarted
-  sudo: true
+  become: true
   service:
     name: grafana-server
     state: restarted

--- a/ansible/roles/grafana/tasks/nginx.yml
+++ b/ansible/roles/grafana/tasks/nginx.yml
@@ -1,10 +1,10 @@
 ---
 - name: create nginx site config
   action: template src=../templates/nginx_site.conf dest=/etc/nginx/sites-available/{{ app_name }}.conf
-  sudo: true
+  become: true
   notify:
     - restart nginx
 
 - name: link nginx config
   action: file src=/etc/nginx/sites-available/{{ app_name }}.conf dest=/etc/nginx/sites-enabled/{{ app_name }}.conf state=link
-  sudo: true
+  become: true

--- a/ansible/roles/grafana/tasks/postgresql.yml
+++ b/ansible/roles/grafana/tasks/postgresql.yml
@@ -4,10 +4,10 @@
     name: postgresql
     state: started
     enabled: yes
-  sudo: yes
+  become: yes
 
 - name: allow users to connect locally
-  sudo: yes
+  become: yes
   lineinfile:
      # TODO: should not hardcode that version
      dest: /etc/postgresql/9.5/main/pg_hba.conf
@@ -19,7 +19,7 @@
 - service:
     name: postgresql
     state: restarted
-  sudo: true
+  become: true
   when: pg_hba_conf.changed
 
 - name: make {{ app_name }} user
@@ -37,12 +37,12 @@
     owner: "{{ app_name }}"
     state: present
     login_user: postgres
-  sudo_user: postgres
-  sudo: yes
+  become_user: postgres
+  become: yes
 
 - name: ensure database service is up
   service:
     name: postgresql
     state: started
     enabled: yes
-  sudo: yes
+  become: yes

--- a/ansible/roles/graphite/handlers/main.yml
+++ b/ansible/roles/graphite/handlers/main.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: reload systemd
-  sudo: yes
+  become: yes
   command: systemctl daemon-reload
 
 - name: restart app
-  sudo: true
+  become: true
   service: 
     name: graphite 
     state: restarted 
@@ -16,5 +16,5 @@
     name: carbon-cache
     state: restarted
     enabled: yes
-  sudo: yes
+  become: yes
 

--- a/ansible/roles/graphite/tasks/carbon.yml
+++ b/ansible/roles/graphite/tasks/carbon.yml
@@ -6,7 +6,7 @@
     regexp: "^CARBON_CACHE_ENABLED=false"
     line: "CARBON_CACHE_ENABLED=true"
     state: present
-  sudo: true
+  become: true
 
 - name: enable whitelisting in carbon
   lineinfile:
@@ -15,7 +15,7 @@
     line: "USE_WHITELIST = True"
     state: present
     backrefs: true
-  sudo: true
+  become: true
 
 - name: create the rewrite config with the secret api key
   template:
@@ -23,7 +23,7 @@
     dest: "/etc/carbon/rewrite-rules.conf"
   notify:
     - restart carbon
-  sudo: true
+  become: true
 
 - name: create the whitelist/blacklist config allowing the api key only
   template:
@@ -31,7 +31,7 @@
     dest: "/etc/carbon/whitelist.conf"
   notify:
     - restart carbon
-  sudo: true
+  become: true
 
 - name: define the storage schemas
   template:
@@ -39,11 +39,11 @@
     dest: "/etc/carbon/storage-schemas.conf"
   notify:
     - restart carbon
-  sudo: true
+  become: true
 
 - name: ensure database service is up
   service:
     name: carbon-cache
     state: restarted
     enabled: yes
-  sudo: yes
+  become: yes

--- a/ansible/roles/graphite/tasks/main.yml
+++ b/ansible/roles/graphite/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Build hosts file"
-  sudo: yes
+  become: yes
   lineinfile:
     dest: /etc/hosts
     regexp: ".*{{ fqdn }}$"
@@ -9,16 +9,16 @@
     state: present
 
 - name: Set Hostname with hostname command
-  sudo: yes
+  become: yes
   hostname: name="{{ fqdn }}"
 
 - name: update apt cache
   apt:
     update_cache: yes
-  sudo: yes
+  become: yes
 
 - name: install ssl system requirements
-  sudo: yes
+  become: yes
   apt:
     name: "{{ item }}"
     state: present
@@ -27,7 +27,7 @@
     - packages
 
 - name: install system packages
-  sudo: yes
+  become: yes
   apt:
     name: "{{ item }}"
     state: present
@@ -38,7 +38,7 @@
 - command: cp /usr/share/graphite-web/graphite.wsgi /usr/lib/python2.7/dist-packages/graphite/graphite_web.py
   args:
     creates: "/usr/lib/python2.7/dist-packages/graphite/graphite_web.py"
-  sudo: true
+  become: true
 
 - include: carbon.yml
 
@@ -51,7 +51,7 @@
     - postgresql
 
 - name: ensure graphite is running
-  sudo: true
+  become: true
   service:
     name: graphite
     state: restarted

--- a/ansible/roles/graphite/tasks/postgresql.yml
+++ b/ansible/roles/graphite/tasks/postgresql.yml
@@ -4,10 +4,10 @@
     name: postgresql
     state: started
     enabled: yes
-  sudo: yes
+  become: yes
 
 - name: allow users to connect locally
-  sudo: yes
+  become: yes
   lineinfile:
      # TODO: should not hardcode that version
      dest: /etc/postgresql/9.5/main/pg_hba.conf
@@ -19,7 +19,7 @@
 - service:
     name: postgresql
     state: restarted
-  sudo: true
+  become: true
   when: pg_hba_conf.changed
 
 - name: generate pseudo-random password for the database connection
@@ -42,15 +42,15 @@
     owner: "{{ app_name }}"
     state: present
     login_user: postgres
-  sudo_user: postgres
-  sudo: yes
+  become_user: postgres
+  become: yes
 
 - name: ensure database service is up
   service:
     name: postgresql
     state: started
     enabled: yes
-  sudo: yes
+  become: yes
 
 - name: create the config file with the db password
   template:
@@ -58,14 +58,14 @@
     dest: "/etc/graphite/local_settings.py"
   notify:
     - restart app
-  sudo: true
+  become: true
 
   # there is a bug where if you don't migrate auth first only it will fail
   # with "ProgrammingError: relation "auth_user" does not exist"
 - name: run migrate for auth first
   command: graphite-manage migrate --noinput auth
-  sudo: true
+  become: true
 
 - name: run migrate to ensure database schema
   command: graphite-manage migrate --noinput
-  sudo: true
+  become: true

--- a/ansible/roles/graphite/tasks/systemd.yml
+++ b/ansible/roles/graphite/tasks/systemd.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: ensure /var/log/graphite dir exists
-  sudo: true
+  become: true
   file: 
     path: /var/log/graphite 
     state: directory 
@@ -13,12 +13,12 @@
   template: 
     src: systemd/graphite.service.j2 
     dest: /etc/systemd/system/graphite.service
-  sudo: true
+  become: true
   notify:
      - reload systemd
 
 - name: ensure graphite is enabled and running
-  sudo: true
+  become: true
   service: 
     name: graphite 
     state: running 

--- a/ansible/roles/kraken/handlers/main.yml
+++ b/ansible/roles/kraken/handlers/main.yml
@@ -7,5 +7,5 @@
 
 # prevents issues when updating systemd files
 - name: reload systemd
-  sudo: yes
+  become: yes
   command: systemctl daemon-reload

--- a/ansible/roles/kraken/tasks/systemd.yml
+++ b/ansible/roles/kraken/tasks/systemd.yml
@@ -2,21 +2,21 @@
 
 
 - name: ensure /etc/sysconfig/ dir exists
-  sudo: true
+  become: true
   file:
     path: /etc/sysconfig
     state: directory
 
 # prevents issues when updating systemd files
 - name: reload systemd
-  sudo: yes
+  become: yes
   command: systemctl daemon-reload
 
 - name: install the systemd configuration file for celery
   template:
     src: helga.sysconfig.j2
     dest: /etc/sysconfig/helga
-  sudo: true
+  become: true
   notify:
      - reload systemd
 
@@ -24,12 +24,12 @@
   template:
     src: helga.service.j2
     dest: /etc/systemd/system/helga.service
-  sudo: true
+  become: true
   notify:
      - reload systemd
 
 - name: ensure helga is enabled and running
-  sudo: true
+  become: true
   service:
     name: helga
     state: running 

--- a/ansible/roles/nginx/handlers/main.yml
+++ b/ansible/roles/nginx/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 
 - name: restart nginx
-  sudo: yes
+  become: yes
   action: service name=nginx state=restarted enabled=yes

--- a/ansible/roles/nginx/tasks/letsencrypt.yml
+++ b/ansible/roles/nginx/tasks/letsencrypt.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: install system packages
-  sudo: yes
+  become: yes
   apt:
     name: "letsencrypt"
     state: present
@@ -11,32 +11,32 @@
     path: "{{ ssl_webroot_base_path }}/{{ item.fqdn }}"
     state: "directory"
     mode: 0755
-  sudo: yes
+  become: yes
   with_items: nginx_hosts
 
 - name: unlink nginx configs
   file:
     path: "/etc/nginx/sites-enabled/{{ item.app_name }}.conf"
     state: "absent"
-  sudo: true
+  become: true
   with_items: nginx_hosts
 
 - name: create temporary nginx config
   template:
     src: "nginx_tmp_site.conf"
     dest: "/etc/nginx/sites-enabled/{{ item.app_name }}.conf"
-  sudo: true
+  become: true
   with_items: nginx_hosts
 
 - name: restart nginx
-  sudo: yes
+  become: yes
   service:
     name: nginx
     state: restarted
 
 - name: create (or renew) letsencrypt ssl cert
   command: "letsencrypt certonly --webroot -w {{ ssl_webroot_base_path }}/{{ item.fqdn }} -d {{ item.fqdn }} --email {{ ssl_support_email }} --agree-tos --renew-by-default"
-  sudo: yes
+  become: yes
   with_items: nginx_hosts
 
 - name: setup a cron to renew the SSL cert every day
@@ -45,12 +45,12 @@
     minute: "21"
     hour: "6,18"
     job: "letsencrypt renew --agree-tos  --email {{ ssl_support_email }}"
-  sudo: yes
+  become: yes
   with_items: nginx_hosts
 
 - name: unlink tmp nginx config
   file:
     path: "/etc/nginx/sites-enabled/{{ item.app_name }}.conf"
     state: "absent"
-  sudo: true
+  become: true
   with_items: nginx_hosts

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -3,34 +3,34 @@
   file:
     path: /etc/nginx/sites-available
     state: directory
-  sudo: true
+  become: true
 
 - name: ensure there is an nginx user
   user:
     name: nginx
     comment: "Nginx user"
-  sudo: true
+  become: true
 
 - name: ensure sites-enable for nginx
   file:
     path: /etc/nginx/sites-enabled
     state: directory
-  sudo: true
+  become: true
 
 - name: remove default nginx site
   file:
     path: /etc/nginx/sites-enabled/default
     state: absent
-  sudo: true
+  become: true
 
 - name: write nginx.conf
   template:
     src: nginx.conf
     dest: /etc/nginx/nginx.conf
-  sudo: true
+  become: true
 
 - name: enable nginx
-  sudo: true
+  become: true
   service:
     name: nginx
     enabled: true
@@ -39,7 +39,7 @@
   template:
     src: "nginx_site.conf"
     dest: "/etc/nginx/sites-available/{{ item.app_name }}.conf"
-  sudo: true
+  become: true
   with_items: nginx_hosts
   notify:
     - restart nginx
@@ -55,11 +55,11 @@
     src: "/etc/nginx/sites-available/{{ item.app_name }}.conf"
     dest: "/etc/nginx/sites-enabled/{{ item.app_name }}.conf"
     state: link
-  sudo: true
+  become: true
   with_items: nginx_hosts
 
 - name: ensure nginx is restarted
-  sudo: true
+  become: true
   service:
     name: nginx
     state: restarted

--- a/ansible/roles/nginx/tasks/ssl.yml
+++ b/ansible/roles/nginx/tasks/ssl.yml
@@ -4,13 +4,13 @@
   file:
     dest: /etc/ssl/certs
     state: directory
-  sudo: true
+  become: true
 
 - name: ensure ssl private directory
   file:
     dest: /etc/ssl/private
     state: directory
-  sudo: true
+  become: true
 
 - name: copy SSL cert
   copy:
@@ -18,7 +18,7 @@
     dest: "/etc/ssl/certs/{{ item.fqdn }}-bundled.crt"
     mode: 0777
     force: no
-  sudo: true
+  become: true
   notify: restart nginx
   when: nginx_hosts is defined
   with_items: nginx_hosts
@@ -28,7 +28,7 @@
     src: "{{ ssl_key_path }}"
     dest: "/etc/ssl/private/{{ item.fqdn }}.key"
     force: no
-  sudo: true
+  become: true
   notify: restart nginx
   when: nginx_hosts is defined
   with_items: nginx_hosts


### PR DESCRIPTION
Since ansible 2.9 sudo statements have been removed and we should use
become instead.

"All previously deprecated sudo/su and module locale global settings have
been removed." [1]

[1] https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>