### PR TITLE
ceph-ansible-prs: add lvm_auto_discovery job

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -75,6 +75,7 @@
       - shrink_rgw
       - shrink_mds
       - shrink_rbdmirror
+      - lvm_auto_discovery
     jobs:
         - 'ceph-ansible-prs-common-trigger'
 


### PR DESCRIPTION
Add the possibility to trigger `lvm_auto_discovery` job on ceph-ansible PR

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>