### PR TITLE
nfs-ganesha: Disable LizardFS FSAL for debian

### DIFF
--- a/nfs-ganesha/build/build_deb
+++ b/nfs-ganesha/build/build_deb
@@ -85,6 +85,15 @@ cd $WORKSPACE/nfs-ganesha
 # add debian directory next to src
 mv $WORKSPACE/nfs-ganesha-debian/debian $WORKSPACE/nfs-ganesha/
 
+# create and apply a patch to disable LizardFS FSAL
+echo "LS0tIGEvZGViaWFuL3J1bGVzCisrKyBiL2RlYmlhbi9ydWxlcwpAQCAtMjgsNiArMjgsNyBAQCBv
+dmVycmlkZV9kaF9hdXRvX2NvbmZpZ3VyZToKIAkJLURVU0VfRlNBTF9YRlM9T0ZGIFwKIAkJLURV
+U0VfRlNBTF9DRVBIPU9OIFwKIAkJLURVU0VfRlNBTF9SR1c9T04gXAorCQktRFVTRV9GU0FMX0xJ
+WkFSREZTPU9GRiBcCiAJCS1EVVNFX0ZTQUxfR1BGUz1PRkYgXAogCQktRFVTRV9GU0FMX1BBTkZT
+PU9GRiBcCiAJCS1EVVNFX0ZTQUxfR0xVU1RFUj1PRkYgXAo="|base64 -d > disable-lizardfs-fsal.patch
+
+patch -p1 < disable-lizardfs-fsal.patch
+
 ## Get some basic information about the system and the repository
 DEB_ARCH=$(dpkg-architecture -qDEB_BUILD_ARCH)
 


### PR DESCRIPTION
LizardFS FSAL has been added in [1] and it's enabled by default. This
is currently failing in the CI for Bionic. 338d18e resolved this for rpm
builds, but not for debs.

CMake Error at CMakeLists.txt:595 (message):
    STRICT_PACKAGE: Cannot find LizardFS client lib.  Disabling lizardfs
    fsal

This patch configures the USE_FSAL_LIZARDFS option to OFF.

[1] nfs-ganesha/nfs-ganesha@884ec97

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>