### PR TITLE
ceph-ansible-docs: build doc for stable-4.0

### DIFF
--- a/ceph-ansible-docs/config/definitions/ceph-ansible-docs.yml
+++ b/ceph-ansible-docs/config/definitions/ceph-ansible-docs.yml
@@ -30,6 +30,7 @@
             - stable-3.0
             - stable-3.1
             - stable-3.2
+            - stable-4.0
           browser: auto
           skip-tag: true
           timeout: 20


### PR DESCRIPTION
Let's build the upstream documentation for stable-4.0

Closes: https://github.com/ceph/ceph-ansible/issues/4794

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>