### PR TITLE
ceph-ansible-pr-syntax-check: pin ansible-lint

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -9,7 +9,11 @@ set -e
 virtualenv $TEMPVENV
 "$VENV"/pip install --upgrade pip
 "$VENV"/pip install -r "$WORKSPACE"/ceph-ansible/requirements.txt
-"$VENV"/pip install ansible-lint
+if [[ "$ghprbTargetBranch" == "stable-3.2" ]]; then
+  "$VENV"/pip install 'ansible-lint<4.2'
+else
+  "$VENV"/pip install ansible-lint
+fi
 
 
 #############


### PR DESCRIPTION
Latest ansible-lint release (4.2.0) drops ansible 2.6 support so the
syntax-check job isn't compatible with the ceph-ansible stable-3.2
branch which uses ansible 2.6.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>