### PR TITLE
chacra-pull-requests: Replace ansible sudo with become

### DIFF
--- a/chacra-pull-requests/setup/playbooks/setup.yml
+++ b/chacra-pull-requests/setup/playbooks/setup.yml
@@ -2,7 +2,7 @@
 
 - hosts: localhost
   user: jenkins-build
-  sudo: True
+  become: True
 
   tasks:
      - include: tasks/postgresql.yml

--- a/chacra-pull-requests/setup/playbooks/tasks/postgresql.yml
+++ b/chacra-pull-requests/setup/playbooks/tasks/postgresql.yml
@@ -2,7 +2,7 @@
 - name: update apt cache
   apt:
     update_cache: yes
-  sudo: yes
+  become: yes
 
 - name: set postgresql version on trusty
   set_fact:
@@ -15,7 +15,7 @@
   when: ansible_distribution_release == "xenial"
 
 - name: install postgresql requirements
-  sudo: yes
+  become: yes
   apt:
     name: "{{ item }}"
     state: present
@@ -33,10 +33,10 @@
     name: postgresql
     state: started
     enabled: yes
-  sudo: yes
+  become: yes
 
 - name: allow users to connect locally
-  sudo: yes
+  become: yes
   lineinfile:
      dest: "/etc/postgresql/{{ postgresql_version }}/main/pg_hba.conf"
      # allow all ipv4 local connections without a password
@@ -55,4 +55,4 @@
 - service:
     name: postgresql
     state: restarted
-  sudo: true
+  become: true


### PR DESCRIPTION
"become" is the correct ansible keyword for priv escalation in newer
versions. So use that.
This will fix at least the ansible-playbook setup.yml call which
previously failed.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>