### PR TITLE
ceph-dev-build: Use correct OBS repo octopus on openSUSE Leap

### DIFF
--- a/ceph-dev-build/build/build_osc
+++ b/ceph-dev-build/build/build_osc
@@ -2,7 +2,10 @@
 set -ex
 
 case $RELEASE_BRANCH in
-nautilus|octopus)
+octopus)
+    OBSREPO="openSUSE_Leap_15.2"
+    ;;
+nautilus)
     OBSREPO="openSUSE_Leap_15.1"
     ;;
 mimic)


### PR DESCRIPTION
We want to build against openSUSE Leap 15.2 for octopus. So use the
correct repo.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>