### PR TITLE
ceph-dev-new-trigger: build centos8 from ceph-ci

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -85,7 +85,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=bionic centos7 leap15
+                    DISTROS=bionic centos7 leap15 centos8
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}


### PR DESCRIPTION
This fixes a problem where CentOS8 was not being built on ceph-ci.git branches.