### PR TITLE
ceph-dashboard-*,ceph-api-nightly: Remove conditional-step; Replaced dir and script name

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -7,8 +7,10 @@
     test_suite:
       - backend:
           test_suite_script: run-backend-api-tests.sh
+          test_deps_script: install-backend-api-test-deps.sh
       - e2e:
           test_suite_script: run-frontend-e2e-tests.sh
+          test_deps_script: install-e2e-test-deps.sh
     jobs:
       - '{name}-{ceph_branch}-{test_suite}'
 
@@ -18,7 +20,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && x86_64 && centos7 && rebootable
+    node: huge && bionic && rebootable && x86_64 && !xenial && !trusty
     quiet-period: 5
     block-downstream: false
     block-upstream: false
@@ -51,13 +53,9 @@
 
     builders:
       - shell: "export NPROC=$(nproc); {ceph_build}"
-      - conditional-step:
-          condition-kind: strings-match
-          condition-string1: '{test_suite}'
-          condition-string2: 'e2e'
-          steps:
-            - shell:
-                !include-raw: ../../../scripts/e2e/install-e2e-tests-deps.sh
+      - shell:
+          !include-raw:
+            -  ../../../scripts/dashboard/{test_deps_script}
       - shell: "cd src/pybind/mgr/dashboard; timeout 2h ./{test_suite_script}"
 
     publishers:

--- a/ceph-dashboard-pr-backend/config/definitions/ceph-dashboard-pr-backend.yml
+++ b/ceph-dashboard-pr-backend/config/definitions/ceph-dashboard-pr-backend.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && x86_64 && centos7 && rebootable
+    node: huge && bionic && rebootable && x86_64 && !xenial && !trusty
     display-name: 'ceph: dashboard Pull Requests backend'
     quiet-period: 5
     block-downstream: false
@@ -61,4 +61,5 @@
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
+            - ../../../scripts/dashboard/install-backend-api-test-deps.sh
       - shell: "cd src/pybind/mgr/dashboard; timeout 7200 ./run-backend-api-tests.sh"

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && x86_64 && centos7 && rebootable
+    node: huge && bionic && rebootable && x86_64 && !xenial && !trusty
     display-name: 'ceph: dashboard Pull Requests'
     quiet-period: 5
     block-downstream: false
@@ -61,5 +61,5 @@
       - shell: "export NPROC=$(nproc) CHECK_MAKEOPTS='-j$(nproc) -N -Q'; timeout 7200 ./run-make-check.sh"
       - shell:
           !include-raw:
-            - ../../../scripts/e2e/install-e2e-tests-deps.sh
+            - ../../../scripts/dashboard/install-e2e-test-deps.sh
       - shell: "cd src/pybind/mgr/dashboard; timeout 7200 ./run-frontend-e2e-tests.sh"

--- a/scripts/dashboard/install-backend-api-test-deps.sh
+++ b/scripts/dashboard/install-backend-api-test-deps.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+if grep -q  debian /etc/*-release; then
+    sudo apt-get install -y python-scipy python3-scipy python-routes python3-routes
+elif grep -q rhel /etc/*-release; then
+    sudo yum install -y scipy python-routes python3-routes
+fi

--- a/scripts/dashboard/install-e2e-test-deps.sh
+++ b/scripts/dashboard/install-e2e-test-deps.sh
@@ -11,7 +11,8 @@ if grep -q  debian /etc/*-release; then
     curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
     sudo apt-get update
     sudo apt-get install -y google-chrome-stable
-    sudo apt-get install -y python-requests python-openssl python-jinja2 python-jwt python-scipy
+    sudo apt-get install -y python-requests python3-requests python-openssl python3-openssl python-jinja2 python3-jinja2 \
+	python-jwt python3-jwt python-scipy python3-scipy python-routes python3-routes
     sudo rm /etc/apt/sources.list.d/google-chrome.list
 elif grep -q rhel /etc/*-release; then
     sudo dd of=/etc/yum.repos.d/google-chrome.repo status=none <<EOF
@@ -24,5 +25,5 @@ gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub
 EOF
     sudo yum install -y google-chrome-stable
     sudo rm /etc/yum.repos.d/google-chrome.repo
-    sudo yum install -y python-requests pyOpenSSL python-jinja2 python-jwt scipy
+    sudo yum install -y python-requests pyOpenSSL python-jinja2 python-jwt scipy python-routes python3-routes
 fi


### PR DESCRIPTION
Make use of the script that installs dependencies for backend API
tests as well, therefore rename the script and dir since "e2e" no longer matches here.
Also remove the conditional step to not only execute the script that installs dependencies
for e2e test environments

Signed-off-by: Laura Paduano <lpaduano@suse.com>