### PR TITLE
ceph-dev-build: Don't try to cd into tarballs

### DIFF
--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -26,7 +26,7 @@ $SUDO yum install -y redhat-lsb-core
 # unpack the tar.gz that contains the debian dir
 cd dist
 tar xzf *.orig.tar.gz
-cd ceph-*
+cd $(basename *.orig.tar.gz .orig.tar.gz | sed s/_/-/)
 pwd
 
 $SUDO yum install -y yum-utils


### PR DESCRIPTION
Fixes:

```
+ cd dist
+ tar xzf ceph_15.0.0-8623-g8a4458f.orig.tar.gz
+ cd ceph-15.0.0-8623-g8a4458f ceph-15.0.0-8623-g8a4458f.tar.bz2 ceph-15.0.0-8623-g8a4458f.tar.gz
/tmp/jenkins8482303231462049247.sh: line 1064: cd: too many arguments
```

Signed-off-by: David Galloway <dgallowa@redhat.com>