### PR TITLE
ceph-pull-requests: Do NOT run on pbuilder hosts

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -3,7 +3,8 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && bionic && rebootable && x86_64
+    # We want make check to only run on Bionic b/c it has python2 and python3 and b/c all builds should build on Bionic
+    node: huge && bionic && rebootable && x86_64 && !xenial && !trusty
     display-name: 'ceph: Pull Requests'
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
pbuilder hosts are running Xenial.  We still want to be able to build Bionic packages on Xenial but we do not want make check to run on *all* slaves with the "bionic" label.

Signed-off-by: David Galloway <dgallowa@redhat.com>