### PR TITLE
ceph-dev-new-build: allow containers on centos 7 or 8

### DIFF
--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -187,7 +187,7 @@ fi
 
 # XXX perhaps use job parameters instead of literals; then
 # later stages can also use them to compare etc.
-if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $RELEASE == "7" && $FLAVOR == "default" ]] ; then
+if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $FLAVOR == "default" ]] ; then
     loop=0
     ready=false
     while ((loop < 15)); do


### PR DESCRIPTION
Signed-off-by: Dan Mick <dan.mick@redhat.com>