### PR TITLE
ceph-dev*-build: do not unpack source tar ball

### DIFF
--- a/ceph-dev-build/build/setup_deb
+++ b/ceph-dev-build/build/setup_deb
@@ -23,12 +23,6 @@ export LC_ALL=C # the following is vulnerable to i18n
 
 $SUDO apt-get install -y lsb-release
 
-# unpack the tar.gz that contains the debian dir
-cd dist
-tar xzf *.orig.tar.gz
-cd ceph-*
-pwd
-
 BRANCH=`branch_slash_filter $BRANCH`
 
 cd $WORKSPACE

--- a/ceph-dev-new-build/build/setup_deb
+++ b/ceph-dev-new-build/build/setup_deb
@@ -23,12 +23,6 @@ export LC_ALL=C # the following is vulnerable to i18n
 
 $SUDO apt-get install -y lsb-release
 
-# unpack the tar.gz that contains the debian dir
-cd dist
-tar xzf *.orig.tar.gz
-cd $(basename *.orig.tar.gz .orig.tar.gz | sed s/_/-/)
-pwd
-
 BRANCH=`branch_slash_filter $BRANCH`
 
 cd $WORKSPACE


### PR DESCRIPTION
the uncompressed tarball is not used, moreover, the build fails on
bionic when `dpkg-source -x` the source package. because we've been
relying on a bug on xenial. see
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=826334;msg=31

and on bionic, the bug was fixed. so `dpkg-source -x` started to
fail.

Signed-off-by: Kefu Chai <kchai@redhat.com>