### PR TITLE
ceph-dev: Add crimson support

### DIFF
--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -82,6 +82,42 @@ else
     echo "forcing."
 fi
 
+# because autogen+configure will check for dependencies, we are forced to install them
+# and ensure they are present in the current host
+if [ -x install-deps.sh ]; then
+    echo "Ensuring dependencies are installed"
+    [ "${FLAVOR}" == "crimson" ] && WITH_SEASTAR=1
+    WITH_SEASTAR=$WITH_SEASTAR ./install-deps.sh
+fi
+
+# Flavor Builds support
+
+#cryptopp is not default for CMake
+AUTOCONF_FLAVOR_FLAGS="--without-cryptopp"
+
+case "${FLAVOR}" in
+    notcmalloc)
+        echo "Detected notcmalloc flavor: will use flag: --without-tcmalloc or -DALLOCATOR=libc"
+        AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --without-tcmalloc"
+        CEPH_EXTRA_CONFIGURE_ARGS="--without-tcmalloc"
+        CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
+        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_CEPH_DEBUG_MUTEX=ON"
+        ;;
+    default)
+        AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --with-tcmalloc"
+        CEPH_EXTRA_CONFIGURE_ARGS="--with-tcmalloc"
+        CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
+        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
+        ;;
+    crimson)
+        CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
+        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DWITH_SEASTAR=ON"
+        ;;
+    *)
+        echo "unknown FLAVOR: ${FLAVOR}" >&2
+        exit 1
+esac
+
 # make-dist does not exist for autotools builds
 if [ ! -x make-dist ]; then
     echo "Using autotools build system"

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -56,8 +56,9 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           choices:
             - default
             - notcmalloc
+            - crimson
           default: "default"
-          description: "Type of Ceph build, choices are: notcmalloc, default (i.e. with tcmalloc). Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: crimson, notcmalloc, default (i.e. with tcmalloc). Defaults to: 'default'"
 
     builders:
       - multijob:


### PR DESCRIPTION
We weren't previously making crimson builds for ceph.git branches.  I didn't know that when updating the conditionals based on the distro matrix @liewegas provided so `crimson` got added in https://github.com/ceph/ceph-build/pull/1459.  So since it seems like we want them now, support needs to be added.

Signed-off-by: David Galloway <dgallowa@redhat.com>