### PR TITLE
ceph-ansible-prs: add docker2podman scenario

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -53,6 +53,18 @@
         - 'ceph-ansible-prs-auto'
 
 - project:
+    name: ceph-ansible-prs-docker2podman
+    slave_labels: 'vagrant && libvirt && (smithi || centos7)'
+    distribution:
+      - centos
+    deployment:
+      - container
+    scenario:
+      - docker_to_podman
+    jobs:
+        - 'ceph-ansible-prs-common-trigger'
+
+- project:
     name: ceph-ansible-prs-common-trigger
     slave_labels: 'vagrant && libvirt && (smithi || centos7)'
     distribution:


### PR DESCRIPTION
This commit adds a new 'docker2podman' job for the ceph-ansible CI.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>