### PR TITLE
ansible: Set hostname on OpenSUSE

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -409,6 +409,12 @@
     - name: Set Hostname with hostname command
       hostname:
         name: "ceph-builders"
+      when: ansible_os_family != "Suse"
+
+    # https://github.com/ansible/ansible/issues/42726
+    - name: Set Hostname on OpenSUSE Leap
+      command: 'hostname ceph-builders'
+      when: ansible_os_family == "Suse"
 
     - name: ensure that 127.0.1.1 is present with an actual hostname
       lineinfile:

--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -299,6 +299,12 @@
       become: yes
       hostname:
         name: "{{ ansible_hostname }}"
+      when: ansible_os_family != "Suse"
+
+    # https://github.com/ansible/ansible/issues/42726
+    - name: Set Hostname on OpenSUSE Leap
+      command: 'hostname ceph-builders'
+      when: ansible_os_family == "Suse"
 
     - name: ensure that the current host is in /etc/hosts. Yes this is a thing.
       become: true


### PR DESCRIPTION
Now that we're using system-provided ansible packages (https://github.com/ceph/mita/pull/135), we're at the mercy of the version provided.

OpenSUSE Leap 15.1 gives us ansible 2.8.1 which has this bug: https://github.com/ansible/ansible/issues/42726

Signed-off-by: David Galloway <dgallowa@redhat.com>