### PR TITLE
ceph-build: apply 604882e9 to ceph-build

### DIFF
--- a/ceph-build/build/setup_deb
+++ b/ceph-build/build/setup_deb
@@ -26,7 +26,7 @@ $SUDO apt-get install -y lsb-release
 # unpack the tar.gz that contains the debian dir
 cd dist
 tar xzf *.orig.tar.gz
-cd ceph-*
+cd $(basename *.orig.tar.gz .orig.tar.gz | sed s/_/-/)
 pwd
 
 BRANCH=`branch_slash_filter $BRANCH`

--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -26,7 +26,7 @@ $SUDO yum install -y redhat-lsb-core
 # unpack the tar.gz that contains the debian dir
 cd dist
 tar xzf *.orig.tar.gz
-cd ceph-*
+cd $(basename *.orig.tar.gz .orig.tar.gz | sed s/_/-/)
 pwd
 
 $SUDO yum install -y yum-utils


### PR DESCRIPTION
to address following failure

+ cd ceph-14.2.6 ceph-14.2.6.tar.bz2 ceph-14.2.6.tar.gz
/tmp/jenkins10747333749307639424.sh: line 1058: cd: too many arguments

Signed-off-by: Kefu Chai <kchai@redhat.com>