### PR TITLE
ceph-pull-requests-arm64: only build on centos8 and bionic

### DIFF
--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -9,7 +9,7 @@
     concurrent: true
     disabled: false
     name: ceph-pull-requests-arm64
-    node: 'arm64 && !centos8'
+    node: 'arm64 && !centos7'
     parameters:
     - string:
         name: ghprbPullId


### PR DESCRIPTION
since we've labeled the slaves correctly. and centos8 is able to build
ceph on arm64. the only pending issue is
https://bugzilla.redhat.com/show_bug.cgi?id=1673990 . but we can fix it
manually.

Signed-off-by: Kefu Chai <kchai@redhat.com>