### PR TITLE
collect-logs: set connect timeout value

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -944,7 +944,7 @@ write_collect_logs_playbook() {
       with_items: "{{ results.files }}"
 
     - name: show ceph status
-      command: "ceph --cluster {{ (item.path | basename | splitext)[0] }} -s -f json"
+      command: "ceph --connect-timeout 10 --cluster {{ (item.path | basename | splitext)[0] }} -s -f json"
       with_items: "{{ results.files }}"
       when: "'.conf' in item.path"
       run_once: True


### PR DESCRIPTION
If a job fails and the ceph cluster doesn't respond then the ceph status
task in the collect-logs.yml playbook will wait around 50 mins before
timed out.
```console
  "cmd": [
      "ceph",
      "--cluster",
      "ceph",
      "-s",
      "-f",
      "json"
  ],
  "delta": "0:50:00.197544"
  "end": "2020-01-16 19:45:06.932819"
  "rc": 1,
  "start": "2020-01-16 18:55:06.735275"

  STDERR: [errno 110] RADOS timed out (error connecting to the cluster)
```
Instead we can use the --connect-timeout paramater to fail after 10s.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>