### PR TITLE
ceph-*: drop autotools support

### DIFF
--- a/ceph-build/build/build_deb
+++ b/ceph-build/build/build_deb
@@ -70,7 +70,6 @@ DEB_BUILD_OPTIONS="parallel=$(get_nr_build_jobs)"
 # pass only those env vars specifically noted
 sudo \
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS" \
-    CEPH_EXTRA_CONFIGURE_ARGS="$CEPH_EXTRA_CONFIGURE_ARGS" \
     DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS" \
     pbuilder build \
     --distribution $DIST \

--- a/ceph-dev-build/build/build_deb
+++ b/ceph-dev-build/build/build_deb
@@ -70,7 +70,6 @@ DEB_BUILD_OPTIONS="parallel=$(get_nr_build_jobs)"
 # pass only those env vars specifically noted
 sudo \
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS" \
-    CEPH_EXTRA_CONFIGURE_ARGS="$CEPH_EXTRA_CONFIGURE_ARGS" \
     DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS" \
     pbuilder build \
     --distribution $DIST \

--- a/ceph-dev-new-build/build/build_deb
+++ b/ceph-dev-new-build/build/build_deb
@@ -70,7 +70,6 @@ DEB_BUILD_OPTIONS="parallel=$(get_nr_build_jobs)"
 # pass only those env vars specifically noted
 sudo \
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS" \
-    CEPH_EXTRA_CONFIGURE_ARGS="$CEPH_EXTRA_CONFIGURE_ARGS" \
     DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS" \
     pbuilder build \
     --distribution $DIST \

--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -74,20 +74,13 @@ fi
 
 # Flavor Builds support
 
-#cryptopp is not default for CMake
-AUTOCONF_FLAVOR_FLAGS="--without-cryptopp"
-
 case "${FLAVOR}" in
     notcmalloc)
-        echo "Detected notcmalloc flavor: will use flag: --without-tcmalloc or -DALLOCATOR=libc"
-        AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --without-tcmalloc"
-        CEPH_EXTRA_CONFIGURE_ARGS="--without-tcmalloc"
+        echo "Detected notcmalloc flavor: will use flag: -DALLOCATOR=libc"
         CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
         CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_CEPH_DEBUG_MUTEX=ON"
         ;;
     default)
-        AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --with-tcmalloc"
-        CEPH_EXTRA_CONFIGURE_ARGS="--with-tcmalloc"
         CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
         CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
         ;;
@@ -99,30 +92,6 @@ case "${FLAVOR}" in
         echo "unknown FLAVOR: ${FLAVOR}" >&2
         exit 1
 esac
-
-# make-dist does not exist for autotools builds
-if [ ! -x make-dist ]; then
-    echo "Using autotools build system"
-    echo "Running autogen.sh ..."
-    ./autogen.sh
-    echo "Running configure ..."
-    ./configure \
-      --disable-option-checking \
-      '--prefix=/usr' \
-      '--sbindir=/sbin' \
-      '--localstatedir=/var' \
-      '--sysconfdir=/etc' \
-      '--with-debug' \
-      '--with-nss' \
-      '--with-radosgw' \
-      '--disable-static' \
-      '--without-lttng' \
-      $AUTOCONF_FLAVOR_FLAGS \
-      'CFLAGS= -Wno-unused-parameter' \
-      'CXXFLAGS=  -Wno-unused-parameter' \
-      --cache-file=/dev/null \
-      --srcdir=.
-fi
 
 mkdir -p release
 
@@ -148,21 +117,11 @@ else
     rm ceph-*.tar.gz || true
     rm ceph-*.tar.bz2 || true
 
-    if [ -x make-dist ]
-    then
-        ./make-dist $cephver
-        vers=`ls ceph-*.tar.bz2 | cut -c 6- | sed 's/.tar.bz2//'`
-        extension="tar.bz2"
-        extract_flags="jxf"
-        compress_flags="jcf"
-    else
-        make dist
-        make dist-bzip2
-        vers=`ls ceph-*.tar.gz | cut -c 6- | sed 's/.tar.gz//'`
-        extension="tar.gz"
-        extract_flags="zxf"
-        compress_flags="zcf"
-    fi
+    ./make-dist $cephver
+    vers=`ls ceph-*.tar.bz2 | cut -c 6- | sed 's/.tar.bz2//'`
+    extension="tar.bz2"
+    extract_flags="jxf"
+    compress_flags="jcf"
 
     echo tarball vers $vers
 
@@ -229,7 +188,6 @@ EOF
 # CEPH_EXTRA_{CONFIGURE,RPMBUILD}_ARGS are consumed by ceph-build before
 # the switch to cmake; CEPH_EXTRA_CMAKE_ARGS is for after cmake
 cat > dist/other_envvars << EOF
-CEPH_EXTRA_CONFIGURE_ARGS=${CEPH_EXTRA_CONFIGURE_ARGS}
 CEPH_EXTRA_RPMBUILD_ARGS=${CEPH_EXTRA_RPMBUILD_ARGS}
 CEPH_EXTRA_CMAKE_ARGS=${CEPH_EXTRA_CMAKE_ARGS}
 EOF

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -45,19 +45,12 @@ git submodule update --init
 
 # Flavor Builds support
 
-#cryptopp is not default for CMake
-AUTOCONF_FLAVOR_FLAGS="--without-cryptopp"
-
 if [ "${FLAVOR}" == "notcmalloc" ]
 then
-    echo "Detected notcmalloc flavor: will use flag: --without-tcmalloc or -DALLOCATOR=libc"
-    AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --without-tcmalloc"
-    CEPH_EXTRA_CONFIGURE_ARGS="--without-tcmalloc"
+    echo "Detected notcmalloc flavor: will use flag: -DALLOCATOR=libc"
     CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_CEPH_DEBUG_MUTEX=ON"
 else
-    AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --with-tcmalloc"
-    CEPH_EXTRA_CONFIGURE_ARGS="--with-tcmalloc"
     CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
 fi
@@ -80,30 +73,6 @@ else
 	exit 1
     fi
     echo "forcing."
-fi
-
-# make-dist does not exist for autotools builds
-if [ ! -x make-dist ]; then
-    echo "Using autotools build system"
-    echo "Running autogen.sh ..."
-    ./autogen.sh
-    echo "Running configure ..."
-    ./configure \
-      --disable-option-checking \
-      '--prefix=/usr' \
-      '--sbindir=/sbin' \
-      '--localstatedir=/var' \
-      '--sysconfdir=/etc' \
-      '--with-debug' \
-      '--with-nss' \
-      '--with-radosgw' \
-      '--disable-static' \
-      '--without-lttng' \
-      $AUTOCONF_FLAVOR_FLAGS \
-      'CFLAGS= -Wno-unused-parameter' \
-      'CXXFLAGS=  -Wno-unused-parameter' \
-      --cache-file=/dev/null \
-      --srcdir=.
 fi
 
 mkdir -p release
@@ -130,21 +99,11 @@ else
     rm ceph-*.tar.gz || true
     rm ceph-*.tar.bz2 || true
 
-    if [ -x make-dist ]
-    then
-        ./make-dist $cephver
-        vers=`ls ceph-*.tar.bz2 | cut -c 6- | sed 's/.tar.bz2//'`
-        extension="tar.bz2"
-        extract_flags="jxf"
-        compress_flags="jcf"
-    else
-        make dist
-        make dist-bzip2
-        vers=`ls ceph-*.tar.gz | cut -c 6- | sed 's/.tar.gz//'`
-        extension="tar.gz"
-        extract_flags="zxf"
-        compress_flags="zcf"
-    fi
+    ./make-dist $cephver
+    vers=`ls ceph-*.tar.bz2 | cut -c 6- | sed 's/.tar.bz2//'`
+    extension="tar.bz2"
+    extract_flags="jxf"
+    compress_flags="jcf"
 
     echo tarball vers $vers
 
@@ -211,7 +170,6 @@ EOF
 # CEPH_EXTRA_{CONFIGURE,RPMBUILD}_ARGS are consumed by ceph-build before
 # the switch to cmake; CEPH_EXTRA_CMAKE_ARGS is for after cmake
 cat > dist/other_envvars << EOF
-CEPH_EXTRA_CONFIGURE_ARGS=${CEPH_EXTRA_CONFIGURE_ARGS}
 CEPH_EXTRA_RPMBUILD_ARGS=${CEPH_EXTRA_RPMBUILD_ARGS}
 CEPH_EXTRA_CMAKE_ARGS=${CEPH_EXTRA_CMAKE_ARGS}
 EOF

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -40,19 +40,12 @@ git submodule update --init
 
 # Flavor Builds support
 
-#cryptopp is not default for CMake
-AUTOCONF_FLAVOR_FLAGS="--without-cryptopp"
-
 if [ "${FLAVOR}" == "notcmalloc" ]
 then
-    echo "Detected notcmalloc flavor: will use flag: --without-tcmalloc or -DALLOCATOR=libc"
-    AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --without-tcmalloc"
-    CEPH_EXTRA_CONFIGURE_ARGS="--without-tcmalloc"
+    echo "Detected notcmalloc flavor: will use flag: -DALLOCATOR=libc"
     CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
 else
-    AUTOCONF_FLAVOR_FLAGS="$AUTOCONF_FLAVOR_FLAGS --with-tcmalloc"
-    CEPH_EXTRA_CONFIGURE_ARGS="--with-tcmalloc"
     CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
 fi
@@ -78,31 +71,6 @@ else
     echo "forcing."
 fi
 
-
-# make-dist does not exist for autotools builds
-if [ ! -x make-dist ]; then
-    echo "Using autotools build system"
-    echo "Running autogen.sh ..."
-    ./autogen.sh
-    echo "Running configure ..."
-    ./configure \
-      --disable-option-checking \
-      '--prefix=/usr' \
-      '--sbindir=/sbin' \
-      '--localstatedir=/var' \
-      '--sysconfdir=/etc' \
-      '--with-debug' \
-      '--with-nss' \
-      '--with-radosgw' \
-      '--disable-static' \
-      '--without-lttng' \
-      $AUTOCONF_FLAVOR_FLAGS \
-      'CFLAGS= -Wno-unused-parameter' \
-      'CXXFLAGS=  -Wno-unused-parameter' \
-      --cache-file=/dev/null \
-      --srcdir=.
-fi
-
 mkdir -p release
 
 # Contents below used to come from /srv/release_tarball.sh and
@@ -124,21 +92,12 @@ else
     echo building tarball
     rm ceph-*.tar.gz || true
     rm ceph-*.tar.bz2 || true
-    if [ -x make-dist ]
-    then
-        ./make-dist $cephver
-        vers=`ls ceph-*.tar.bz2 | cut -c 6- | sed 's/.tar.bz2//'`
-        extension="tar.bz2"
-        extract_flags="jxf"
-        compress_flags="jcf"
-    else
-        make dist
-        make dist-bzip2
-        vers=`ls ceph-*.tar.gz | cut -c 6- | sed 's/.tar.gz//'`
-        extension="tar.gz"
-        extract_flags="zxf"
-        compress_flags="zcf"
-    fi
+
+    ./make-dist $cephver
+    vers=`ls ceph-*.tar.bz2 | cut -c 6- | sed 's/.tar.bz2//'`
+    extension="tar.bz2"
+    extract_flags="jxf"
+    compress_flags="jcf"
 
     echo tarball vers $vers
 
@@ -199,7 +158,6 @@ EOF
 # CEPH_EXTRA_{CONFIGURE,RPMBUILD}_ARGS are consumed by ceph-build before
 # the switch to cmake; CEPH_EXTRA_CMAKE_ARGS is for after cmake
 cat > dist/other_envvars << EOF
-CEPH_EXTRA_CONFIGURE_ARGS=${CEPH_EXTRA_CONFIGURE_ARGS}
 CEPH_EXTRA_RPMBUILD_ARGS=${CEPH_EXTRA_RPMBUILD_ARGS}
 CEPH_EXTRA_CMAKE_ARGS=${CEPH_EXTRA_CMAKE_ARGS}
 EOF


### PR DESCRIPTION
we don't build ceph with autotools anymore. we switched to cmake since
luminous. see https://github.com/ceph/ceph/pull/9995.

so there is no need to support autotools anymore. also, this avoids
running install-deps.sh simply for running "make dist". as we use
`make-dist` script after switching over to cmake.

Signed-off-by: Kefu Chai <kchai@redhat.com>