### PR TITLE
ceph-*-setup: do not run install-deps.sh

### DIFF
--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -64,14 +64,6 @@ else
     echo "forcing."
 fi
 
-# because autogen+configure will check for dependencies, we are forced to install them
-# and ensure they are present in the current host
-if [ -x install-deps.sh ]; then
-    echo "Ensuring dependencies are installed"
-    [ "${FLAVOR}" == "crimson" ] && WITH_SEASTAR=1
-    WITH_SEASTAR=$WITH_SEASTAR ./install-deps.sh
-fi
-
 # Flavor Builds support
 
 case "${FLAVOR}" in

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -32,13 +32,6 @@ rm -rf release
 #sed -i 's/^Source0:.*/Source0:        http:\/\/ceph.com\/download\/%{name}-%{version}-rc1.tar.bz2/' ceph.spec.in
 #sed -i 's/^%setup.*/%setup -q -n %{name}-%{version}-rc1/' ceph.spec.in
 
-# because autogen+configure will check for dependencies, we are forced to install them
-# and ensure they are present in the current host
-if [ -x install-deps.sh ]; then
-  echo "Ensuring dependencies are installed"
-  ./install-deps.sh
-fi
-
 # run submodule updates regardless
 echo "Running submodule update ..."
 git submodule update --init

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -27,13 +27,6 @@ rm -rf release
 #sed -i 's/^Source0:.*/Source0:        http:\/\/ceph.com\/download\/%{name}-%{version}-rc1.tar.bz2/' ceph.spec.in
 #sed -i 's/^%setup.*/%setup -q -n %{name}-%{version}-rc1/' ceph.spec.in
 
-# because autogen+configure will check for dependencies, we are forced to install them
-# and ensure they are present in the current host
-if [ -x install-deps.sh ]; then
-  echo "Ensuring dependencies are installed"
-  ./install-deps.sh
-fi
-
 # run submodule updates regardless
 echo "Running submodule update ..."
 git submodule update --init


### PR DESCRIPTION
this is a follow-up change of #1487. since we don't use autotools for
preparing dist tarball, there is no need to run install-deps.sh for
installing the autotools.

Signed-off-by: Kefu Chai <kchai@redhat.com>