### PR TITLE
use ansible 4.0 for nautlius nightlies

### DIFF
--- a/ceph-volume-nightly/build/build
+++ b/ceph-volume-nightly/build/build
@@ -18,6 +18,8 @@ if [ "$CEPH_BRANCH" = "mimic" ]; then
     CEPH_ANSIBLE_BRANCH="stable-3.2"
 elif [ "$CEPH_BRANCH" = "luminous" ]; then
     CEPH_ANSIBLE_BRANCH="stable-3.2"
+elif [ "$CEPH_BRANCH" = "nautilus" ]; then
+    CEPH_ANSIBLE_BRANCH="stable-4.0"
 else
     CEPH_ANSIBLE_BRANCH="master"
 fi


### PR DESCRIPTION
ceph-ansible has dropped centos7 support in master, nautilius however does support it still.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>