### PR TITLE
ceph-pull-requests-arm64: only build on bionic

### DIFF
--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -9,7 +9,7 @@
     concurrent: true
     disabled: false
     name: ceph-pull-requests-arm64
-    node: 'arm64 && !centos7'
+    node: 'arm64 && !centos7 && !centos8'
     parameters:
     - string:
         name: ghprbPullId


### PR DESCRIPTION
ktdreyer/ceph-el8 is amd64 only, so to avoid failures like:

```
No matching package to install: 'python3-cherrypy'
No matching package to install: 'python3-pecan'
No matching package to install: 'python3-routes'
```

we need to disable the "make check" test on the combination of
"arm64+centos8" until these packages are packaged for arm64 or
provided by centos8.

Signed-off-by: Kefu Chai <kchai@redhat.com>