### PR TITLE
ceph-pr-docs: use bionic for building docs

### DIFF
--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -2,7 +2,7 @@
     name: ceph-pr-docs
     display-name: 'ceph: Pull Requests Docs Check'
     concurrent: true
-    node: trusty && x86_64
+    node: bionic && x86_64 && !xenial && !trusty
     project-type: freestyle
     defaults: global
     quiet-period: 5


### PR DESCRIPTION
xenial comes with python3.5, and our document is renders with a python3
venv created on the builder, also, the python code is also parsed by
the python3 env, so using python3.5 pratically prevents us from using
python3.6 features.

so we can use python3.6 which is offered by bionic.

Signed-off-by: Kefu Chai <kchai@redhat.com>