### PR TITLE
ceph-volume-nightly: fix a typo

### DIFF
--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -18,17 +18,17 @@
       - luminous
       - nautilus
     exclude:
-      - ceph-branch: master
+      - ceph_branch: master
         distro: centos7
-      - ceph-branch: nautilus
+      - ceph_branch: nautilus
         distro: centos8
-      - ceph-branch: master
+      - ceph_branch: master
         distro: xenial
-      - ceph-branch: nautilus
+      - ceph_branch: nautilus
         distro: xenial
-      - ceph-branch: mimic
+      - ceph_branch: mimic
         distro: centos8
-      - ceph-branch: luminous
+      - ceph_branch: luminous
         distro: centos8
 
     jobs:
@@ -75,17 +75,17 @@
       - luminous
       - nautilus
     exclude:
-      - ceph-branch: master
+      - ceph_branch: master
         distro: centos7
-      - ceph-branch: nautilus
+      - ceph_branch: nautilus
         distro: centos8
-      - ceph-branch: master
+      - ceph_branch: master
         distro: xenial
-      - ceph-branch: nautilus
+      - ceph_branch: nautilus
         distro: xenial
-      - ceph-branch: mimic
+      - ceph_branch: mimic
         distro: centos8
-      - ceph-branch: luminous
+      - ceph_branch: luminous
         distro: centos8
 
     jobs:
@@ -110,17 +110,17 @@
       - mimic
       - luminous
     exclude:
-      - ceph-branch: master
+      - ceph_branch: master
         distro: centos7
-      - ceph-branch: nautilus
+      - ceph_branch: nautilus
         distro: centos8
-      - ceph-branch: master
+      - ceph_branch: master
         distro: xenial
-      - ceph-branch: nautilus
+      - ceph_branch: nautilus
         distro: xenial
-      - ceph-branch: mimic
+      - ceph_branch: mimic
         distro: centos8
-      - ceph-branch: luminous
+      - ceph_branch: luminous
         distro: centos8
 
     jobs:


### PR DESCRIPTION
This fixes a quick typo introduced by e70982ce09a712f1182bc66d381de43a9076ec5f

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>