### PR TITLE
ceph-pull-requests: Behave like arm64 job

### DIFF
--- a/ceph-pull-requests-arm64/build/build
+++ b/ceph-pull-requests-arm64/build/build
@@ -5,4 +5,4 @@ export CHECK_MAKEOPTS="-j${n_test_jobs}"
 export BUILD_MAKEOPTS="-j${n_build_jobs}"
 timeout 3h ./run-make-check.sh
 sleep 5
-ps -ef | grep ceph || true
+ps -ef | grep -v jnlp | grep ceph || true

--- a/ceph-pull-requests/build/build
+++ b/ceph-pull-requests/build/build
@@ -2,4 +2,4 @@
 export NPROC=$(nproc)
 timeout 3h ./run-make-check.sh
 sleep 5
-ps -ef | grep ceph || true
+ps -ef | grep -v jnlp | grep ceph || true

--- a/ceph-pull-requests/build/build
+++ b/ceph-pull-requests/build/build
@@ -1,0 +1,5 @@
+#!/bin/bash -ex
+export NPROC=$(nproc)
+timeout 3h ./run-make-check.sh
+sleep 5
+ps -ef | grep ceph || true

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -56,17 +56,12 @@
           wipe-workspace: true
 
     builders:
-      - shell: "export NPROC=$(nproc); timeout 7200 ./run-make-check.sh"
+    - shell:
+        !include-raw:
+          - ../../../scripts/build_utils.sh
+          - ../../build/build
 
     publishers:
-      - postbuildscript:
-          builders:
-            - role: SLAVE
-              build-on:
-                  - FAILURE
-                  - ABORTED
-              build-steps:
-                - shell: "sudo reboot"
       - cobertura:
           report-file: "src/pybind/mgr/dashboard/frontend/coverage/cobertura-coverage.xml"
           only-stable: "true"


### PR DESCRIPTION
Debugging unit test failures was difficult on x86 jobs because the slave got rebooted right away.

Signed-off-by: David Galloway <dgallowa@redhat.com>