### PR TITLE
osc: Build octopus on openSUSE Leap 15.2

### DIFF
--- a/ceph-dev-build/build/setup_osc
+++ b/ceph-dev-build/build/setup_osc
@@ -38,7 +38,11 @@ raw_version=`echo $vers | cut -d '-' -f 1`
 
 RELEASE_BRANCH=$(release_from_version $raw_version)
 case $RELEASE_BRANCH in
-nautilus|octopus)
+octopus)
+    DISTRO=opensuse
+    RELEASE="15.2"
+    ;;
+nautilus)
     DISTRO=opensuse
     RELEASE="15.1"
     ;;


### PR DESCRIPTION
We want to test with the upcoming openSUSE release (15.2) instead of
15.1.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>