### PR TITLE
ceph-ansible: remove ubuntu on nightlies jobs

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -19,40 +19,17 @@
       - add_osds
       - rgw_multisite
       - purge
-    ceph_ansible_branch:
-      - stable-3.2
-    jobs:
-        - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
-
-- project:
-    name: ceph-ansible-nightly-stable3.2_ooo
-    release:
-      - luminous
-    distribution:
-      - centos
-    deployment:
-      - container
-    scenario:
       - ooo_collocation
-    ceph_ansible_branch:
-      - stable-3.2
-    jobs:
-        - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
-
-- project:
-    name: ceph-ansible-nightly-stable3.2_non_container
-    release:
-      - luminous
-    distribution:
-      - centos
-    deployment:
-      - non_container
-    scenario:
       - switch_to_containers
     ceph_ansible_branch:
       - stable-3.2
     jobs:
         - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
+    exclude:
+      - deployment: non_container
+        scenario: ooo_collocation
+      - deployment: container
+        scenario: switch_to_containers
 
 - project:
     name: ceph-ansible-nightly-stable4.0
@@ -75,40 +52,17 @@
       - rgw_multisite
       - purge
       - lvm_auto_discovery
-    ceph_ansible_branch:
-      - stable-4.0
-    jobs:
-        - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
-
-- project:
-    name: ceph-ansible-nightly-stable4.0_ooo
-    release:
-      - nautilus
-    distribution:
-      - centos
-    deployment:
-      - container
-    scenario:
       - ooo_collocation
-    ceph_ansible_branch:
-      - stable-4.0
-    jobs:
-        - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
-
-- project:
-    name: ceph-ansible-nightly-stable4.0_non_container
-    release:
-      - nautilus
-    distribution:
-      - centos
-    deployment:
-      - non_container
-    scenario:
       - switch_to_containers
     ceph_ansible_branch:
       - stable-4.0
     jobs:
         - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
+    exclude:
+      - deployment: non_container
+        scenario: ooo_collocation
+      - deployment: container
+        scenario: switch_to_containers
 
 - job-template:
     name: 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'

--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -60,7 +60,6 @@
       - nautilus
     distribution:
       - centos
-      - ubuntu
     deployment:
       - container
       - non_container

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -71,7 +71,6 @@
     slave_labels: 'vagrant && libvirt && (smithi || centos7)'
     distribution:
       - centos
-      - ubuntu
     deployment:
       - container
       - non_container
@@ -94,24 +93,6 @@
       - filestore_to_bluestore
     jobs:
         - 'ceph-ansible-prs-common-trigger'
-
-- project:
-    name: ceph-ansible-prs-ubuntu-trigger
-    slave_labels: 'vagrant && libvirt && (smithi || centos7)'
-    distribution:
-      - ubuntu
-    deployment:
-      - container
-      - non_container
-    scenario:
-      - all_daemons
-      - update
-      - purge
-      - lvm_osds
-      - lvm_batch
-      - collocation
-    jobs:
-        - 'ceph-ansible-prs-ubuntu-trigger'
 
 - job-template:
     name: 'ceph-ansible-prs-{distribution}-{deployment}-{scenario}'


### PR DESCRIPTION
This commit removes ubuntu testing on ceph-ansible nightlies jobs (stable-4.0)
    
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>