### PR TITLE
ceph-pull-requests*: enable seastar explicitly

### DIFF
--- a/ceph-pull-requests-arm64/build/build
+++ b/ceph-pull-requests-arm64/build/build
@@ -3,6 +3,7 @@ n_build_jobs=$(get_nr_build_jobs)
 n_test_jobs=$(($(nproc) / 4))
 export CHECK_MAKEOPTS="-j${n_test_jobs}"
 export BUILD_MAKEOPTS="-j${n_build_jobs}"
+export WITH_SEASTAR=true
 timeout 3h ./run-make-check.sh
 sleep 5
 ps -ef | grep -v jnlp | grep ceph || true

--- a/ceph-pull-requests/build/build
+++ b/ceph-pull-requests/build/build
@@ -1,5 +1,6 @@
 #!/bin/bash -ex
 export NPROC=$(nproc)
+export WITH_SEASTAR=true
 timeout 3h ./run-make-check.sh
 sleep 5
 ps -ef | grep -v jnlp | grep ceph || true


### PR DESCRIPTION
the next step is to disable it by default in ceph/ceph, so it's only
compiled and tested when explictly enabled.

Signed-off-by: Kefu Chai <kchai@redhat.com>