### PR TITLE
ceph-pull-requests: Don't require rebootable label

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -20,7 +20,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && bionic && rebootable && x86_64 && !xenial && !trusty
+    node: huge && bionic && x86_64 && !xenial && !trusty
     quiet-period: 5
     block-downstream: false
     block-upstream: false

--- a/ceph-dashboard-pr-backend/config/definitions/ceph-dashboard-pr-backend.yml
+++ b/ceph-dashboard-pr-backend/config/definitions/ceph-dashboard-pr-backend.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && bionic && rebootable && x86_64 && !xenial && !trusty
+    node: huge && bionic && x86_64 && !xenial && !trusty
     display-name: 'ceph: dashboard Pull Requests backend'
     quiet-period: 5
     block-downstream: false

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && bionic && rebootable && x86_64 && !xenial && !trusty
+    node: huge && bionic && x86_64 && !xenial && !trusty
     display-name: 'ceph: dashboard Pull Requests'
     quiet-period: 5
     block-downstream: false

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -4,7 +4,7 @@
     defaults: global
     concurrent: true
     # We want make check to only run on Bionic b/c it has python2 and python3 and b/c all builds should build on Bionic
-    node: huge && bionic && rebootable && x86_64 && !xenial && !trusty
+    node: huge && bionic && x86_64 && !xenial && !trusty
     display-name: 'ceph: Pull Requests'
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
We got rid of slave reboots in https://github.com/ceph/ceph-build/pull/1508

Signed-off-by: David Galloway <dgallowa@redhat.com>