### PR TITLE
multiple: Use --no-run-if-empty flag with `xargs dirname`

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -18,7 +18,7 @@ update_vagrant_boxes
 # crashes before teardown is executed, it means we keep leftofver from previous build.
 # We ensure before the test is launched that no fetch directory from previous build is present.
 pushd $WORKSPACE/tests
-scenarios=$(find . -name Vagrantfile | xargs dirname)
+scenarios=$(find . -name Vagrantfile | xargs -r dirname)
 for scenario in $scenarios; do
   pushd $scenario
   rm -rf fetch/

--- a/ceph-container-nighlity/build/teardown
+++ b/ceph-container-nighlity/build/teardown
@@ -4,7 +4,7 @@
 
 cd $WORKSPACE/ceph-ansible/tests/functional
 
-scenarios=$(find . | grep Vagrantfile | xargs dirname)
+scenarios=$(find . | grep Vagrantfile | xargs -r dirname)
 
 for scenario in $scenarios; do
     cd $scenario

--- a/ceph-container-prs/build/teardown
+++ b/ceph-container-prs/build/teardown
@@ -4,7 +4,7 @@
 
 cd $WORKSPACE/ceph-ansible/tests/functional
 
-scenarios=$(find . | grep Vagrantfile | xargs dirname)
+scenarios=$(find . | grep Vagrantfile | xargs -r dirname)
 
 for scenario in $scenarios; do
     cd $scenario

--- a/ceph-volume-nightly/build/teardown
+++ b/ceph-volume-nightly/build/teardown
@@ -5,7 +5,7 @@
 
 cd $WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
 
-scenarios=$(find . | grep vagrant_ssh_config | xargs dirname)
+scenarios=$(find . | grep vagrant_ssh_config | xargs -r dirname)
 
 # the method exists in scripts/build_utils.sh
 teardown_vagrant_tests

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -985,7 +985,7 @@ collect_ceph_logs() {
 teardown_vagrant_tests() {
     # collect ceph logs and teardown any running vagrant vms
     # this also cleans up any lingering livirt networks
-    scenarios=$(find . | grep vagrant_ssh_config | xargs dirname)
+    scenarios=$(find . | grep vagrant_ssh_config | xargs -r dirname)
 
     for scenario in $scenarios; do
         cd $scenario


### PR DESCRIPTION
I was seeing `dirname: missing operand` when there was no output from the `find | grep`

We want the output to just be empty instead of throwing an error

Signed-off-by: David Galloway <dgallowa@redhat.com>