### PR TITLE
Avoid symlink recursion issue

### DIFF
--- a/ansible/examples/slave_static.yml
+++ b/ansible/examples/slave_static.yml
@@ -80,7 +80,7 @@
       file: path=/home/{{ jenkins_user }}/build state=directory owner={{ jenkins_user }}
 
     - name: ensure the home dir has the right owner permissions
-      file: path=/home/{{ jenkins_user }} state=directory owner={{ jenkins_user }} group={{ jenkins_user }} recurse=yes
+      file: path=/home/{{ jenkins_user }} state=directory owner={{ jenkins_user }} group={{ jenkins_user }} recurse=yes follow=no
 
     # smithi nodes do not have epel repos
     - name: install an yum epel repo


### PR DESCRIPTION
Checkouts of the ceph repo contain directories with symlinks that link
to their parent dirs; this causes the file permissions check to fail.
Avoid following symlinks to work around.

Signed-off-by: Zack Cerza <zack@redhat.com>