### PR TITLE
build_utils.sh: allow using virtualenv with py3

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,7 +1,6 @@
 - project:
     name: ceph-ansible-prs
     slave_labels: 'vagrant && libvirt && (smithi || braggi || centos7)'
-    slave_labels: 'vagrant && libvirt && (smithi || braggi || centos7)'
     distribution:
       - centos
     deployment:

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -90,7 +90,11 @@ create_virtualenv () {
     if [ "$(ls -A $path)" ]; then
         echo "Will reuse existing virtual env: $path"
     else
-        virtualenv -p python2.7 $path
+        if [ $(command -v python2.7) ]; then
+            virtualenv -p python2.7 $path
+        else
+            virtualenv -p python3 $path
+        fi
     fi
 }
 


### PR DESCRIPTION
On braggi nodes (CentOS 8) there's no python2 anymore but only python3 so
the virtualenv command will fail.

```console
+ virtualenv -p python2.7 /tmp/venv.iqvT26vCL8
The path python2.7 (from --python=python2.7) does not exist
Build step 'Conditional step (single)' marked build as failure
```

Instead we should try if test if the python2.7 command exist and then try
python3 if this fails.

This commit also removes a duplicate slave_labels declaration in the
ceph-ansible-prs configuration.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>