### PR TITLE
ceph-dev-trigger: do not build crimson flavor on master branch

### DIFF
--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -163,12 +163,6 @@
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=notcmalloc
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=bionic
-                    FLAVOR=crimson
 
     wrappers:
       - inject-passwords:


### PR DESCRIPTION
no need to do so at this moment, we just need to build it for wip-*
branches to make sure crimson does not fail to build.

Signed-off-by: Kefu Chai <kchai@redhat.com>