### PR TITLE
ceph*build: Use new gigantic label

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -16,14 +16,9 @@
     axes:
       - axis:
           type: label-expression
-          name: MACHINE_TYPE
-          values:
-            - braggi
-      - axis:
-          type: label-expression
           name: MACHINE_SIZE
           values:
-            - huge
+            - gigantic
       - axis:
           type: label-expression
           name: AVAILABLE_ARCH

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -31,14 +31,9 @@
     axes:
       - axis:
           type: label-expression
-          name: MACHINE_TYPE
-          values:
-            - braggi
-      - axis:
-          type: label-expression
           name: MACHINE_SIZE
           values:
-            - huge
+            - gigantic
       - axis:
           type: label-expression
           name: AVAILABLE_ARCH

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -31,14 +31,9 @@
     axes:
       - axis:
           type: label-expression
-          name: MACHINE_TYPE
-          values:
-            - braggi
-      - axis:
-          type: label-expression
           name: MACHINE_SIZE
           values:
-            - huge
+            - gigantic
       - axis:
           type: label-expression
           name: AVAILABLE_ARCH


### PR DESCRIPTION
By requiring 'braggi', none of the ARM64 builds would start.  It wouldn't be appropriate to give the arm64 builders a "braggi" label so I'm creating a new "gigantic" label that can apply to the braggi and arm64 builders.

There are no nodes in mita that have a 'gigantic' label so that guarantees builds won't run on OVH ephemeral nodes.

Signed-off-by: David Galloway <dgallowa@redhat.com>