### PR TITLE
ceph-ansible-nightly: add stable-5.0 branch

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -64,6 +64,39 @@
       - deployment: container
         scenario: switch_to_containers
 
+- project:
+    name: ceph-ansible-nightly-stable5.0
+    release:
+      - octopus
+    distribution:
+      - centos
+    deployment:
+      - container
+      - non_container
+    scenario:
+      - all_daemons
+      - collocation
+      - update
+      - lvm_osds
+      - shrink_mon
+      - shrink_osd
+      - lvm_batch
+      - add_osds
+      - rgw_multisite
+      - purge
+      - lvm_auto_discovery
+      - ooo_collocation
+      - switch_to_containers
+    ceph_ansible_branch:
+      - stable-5.0
+    jobs:
+        - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
+    exclude:
+      - deployment: non_container
+        scenario: ooo_collocation
+      - deployment: container
+        scenario: switch_to_containers
+
 - job-template:
     name: 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
     node: vagrant&&libvirt&&centos7


### PR DESCRIPTION
This adds the ceph-ansible stable-5.0 branch to the nighly jobs which
is used to test the Ceph Octopus release.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>