### PR TITLE
ceph-ansible-nightly: parametrize centos release

### DIFF
--- a/ceph-ansible-nightly/build/build
+++ b/ceph-ansible-nightly/build/build
@@ -25,8 +25,12 @@ function count_tag_pages {
 
 function find_latest_tag {
   release="$1"
+  el="7"
+  if [ "${release}" == "octopus" ]; then
+    el="8"
+  fi
   for page in $(seq 1 $total_pages); do
-    tag=$(curl -s "https://registry.hub.docker.com/v2/repositories/ceph/daemon/tags/?page=$page&page_size=${page_size}" | jq ".\"results\"[] | select((.name | contains(\"stable\")) and (.name | contains(\"${release}-centos-7-x86_64\"))) | .name")
+    tag=$(curl -s "https://registry.hub.docker.com/v2/repositories/ceph/daemon/tags/?page=$page&page_size=${page_size}" | jq ".\"results\"[] | select((.name | contains(\"stable\")) and (.name | contains(\"${release}-centos-${el}-x86_64\"))) | .name")
     if [ -n "$tag" ]; then
       echo "$tag" | head -n 1 | cut -d '"' -f 2
       return


### PR DESCRIPTION
Since octopus the container image are based on CentOS 8 instead of 7 for
the previous Ceph releases.
The current regex to find the latest stable container image per Ceph
releases is hardcoding 7.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>