### PR TITLE
ceph-medic-release: Bind CHACRACTL_KEY credential

### DIFF
--- a/ceph-medic-release/config/definitions/ceph-medic-release.yml
+++ b/ceph-medic-release/config/definitions/ceph-medic-release.yml
@@ -93,3 +93,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
       - inject-passwords:
           global: true
           mask-password-params: true
+      - credentials-binding:
+          - text:
+              credential-id: chacractl-key
+              variable: CHACRACTL_KEY


### PR DESCRIPTION
This job was writing an incomplete .chacractl config file.

Signed-off-by: Zack Cerza <zack@redhat.com>