### PR TITLE
build_utils.sh: add pacific

### DIFF
--- a/ceph-dev-build/build/build_osc
+++ b/ceph-dev-build/build/build_osc
@@ -2,6 +2,9 @@
 set -ex
 
 case $RELEASE_BRANCH in
+pacific)
+    OBSREPO="openSUSE_Leap_15.2"
+    ;;
 octopus)
     OBSREPO="openSUSE_Leap_15.2"
     ;;

--- a/ceph-dev-build/build/setup_osc
+++ b/ceph-dev-build/build/setup_osc
@@ -38,6 +38,10 @@ raw_version=`echo $vers | cut -d '-' -f 1`
 
 RELEASE_BRANCH=$(release_from_version $raw_version)
 case $RELEASE_BRANCH in
+pacific)
+    DISTRO=opensuse
+    RELEASE="15.2"
+    ;;
 octopus)
     DISTRO=opensuse
     RELEASE="15.2"

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -8,6 +8,9 @@ VENV="$TEMPVENV/bin"
 function release_from_version() {
     local ver=$1
     case $ver in
+    16.*)
+        rel="pacific"
+        ;;
     15.*)
         rel="octopus"
         ;;


### PR DESCRIPTION
I hope this will fix the FTBFS currently seen in Shaman on openSUSE Leap
15.2 builds of "master" branch:

```
++ case $ver in
++ rel=unknown
++ echo 'ERROR: Unknown release for version '\''16.0.0'\'''
ERROR: Unknown release for version '16.0.0'
++ echo unknown
++ exit 1
+ RELEASE_BRANCH=unknown
```

Signed-off-by: Nathan Cutler <ncutler@suse.com>