### PR TITLE
ceph-ansible: update syntax check

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -21,7 +21,7 @@ fi
 #############
 function syntax_check {
   "$VENV"/ansible-playbook -i "$WORKSPACE"/ceph-ansible/tests/functional/all_daemons/hosts site.yml.sample --syntax-check --list-tasks -vv
-  "$VENV"/ansible-playbook -i "$WORKSPACE"/ceph-ansible/tests/functional/all_daemons/hosts site-docker.yml.sample --syntax-check --list-tasks -vv
+  "$VENV"/ansible-playbook -i "$WORKSPACE"/ceph-ansible/tests/functional/all_daemons/hosts site-container.yml.sample --syntax-check --list-tasks -vv
   "$VENV"/ansible-playbook -i "$WORKSPACE"/ceph-ansible/tests/functional/all_daemons/hosts infrastructure-playbooks/*.yml --syntax-check --list-tasks -vv
 }
 


### PR DESCRIPTION
This commit replaces s/site-docker.yml.sample/site-container.yml.sample

ceph-ansible related PR: ceph/ceph-ansible#5216

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>