### PR TITLE
ceph-ansible-prs: run podman on stable-4.0 only

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -30,6 +30,6 @@ rm -rf $HOME/ansible/facts/*
 
 # Skip these scenarios, they don't exist.
 [[ "$ghprbTargetBranch" == stable-3.1 && "$SCENARIO" =~ lvm_batch|lvm_osds ]] ||
-[[ "$ghprbTargetBranch" =~ stable-3 && "$SCENARIO" == podman ]] ||
+[[ "$ghprbTargetBranch" != stable-4.0 && "$SCENARIO" == podman ]] ||
 [[ "$ghprbTargetBranch" =~ stable-3 && "$SCENARIO" == filestore_to_bluestore ]] ||
 start_tox


### PR DESCRIPTION
We don't need to run an extra podman scenario job on newer branches than
stable-4.0 because we're already using podman by default (CentOS 8) for
all container scenarios.
For older branches we don't support podman.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>