### PR TITLE
ceph-perf-pull-requests: install cbt dependencies for el8

### DIFF
--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -128,7 +128,7 @@
           debian|ubuntu)
               sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y python3-yaml python3-lxml python3-prettytable;;
           centos|fedora|rhel)
-              sudo yum install -y python36-PyYAML python36-lxml python36-prettytable;;
+              sudo yum install -y python3-pyyaml python3-lxml python3-prettytable;;
           *)
               echo "unknown distro: $ID"
               exit 1


### PR DESCRIPTION
since all "performance" slaves are now el8, we need to update the
dependencies for cbt accordingly

Signed-off-by: Kefu Chai <kchai@redhat.com>