### PR TITLE
ceph-perf-pull-requests: enable WITH_SEASTAR

### DIFF
--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -53,7 +53,8 @@
           archive_dir={archive_basedir}/$(git rev-parse --short HEAD)
           if ! test -d $archive_dir ; then
               export NPROC=$(nproc)
-              export FOR_MAKE_CHECK=1
+              export FOR_MAKE_CHECK=true
+              export WITH_SEASTAR=true
               timeout 7200 src/script/run-make.sh --cmake-args "-DCMAKE_BUILD_TYPE=Release -DWITH_SEASTAR=ON -DWITH_TESTS=OFF" vstart-base crimson-osd
               src/script/run-cbt.sh --build-dir $PWD/build --source-dir $PWD --cbt ${{WORKSPACE}}/cbt -a $archive_dir src/test/crimson/cbt/radosbench_4K_read.yaml
           fi


### PR DESCRIPTION
as WITH_SEASTAR is now off by default, we need to enable it for testing
crimson-osd

Signed-off-by: Kefu Chai <kchai@redhat.com>