### PR TITLE
ceph-dev-*build: sudo -E for container build

### DIFF
--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -204,7 +204,7 @@ if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" && $FLAVOR == "default" ]] 
 
     cd $WORKSPACE/ceph-container
     # avoid failing the build if build-push fails
-    sudo CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
+    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
     cd $WORKSPACE
 fi
 

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -205,7 +205,7 @@ if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $FLAVOR == "default" ]] 
 
     cd $WORKSPACE/ceph-container
     # avoid failing the build if build-push fails
-    sudo CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
+    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
     cd $WORKSPACE
 fi
 


### PR DESCRIPTION
We need the environment, or else

+ sudo CI_CONTAINER=true SHA1=ca338cb74a4f503555323a668a2ba5b2e1845057 /bin/bash ./contrib/build-push-ceph-container-imgs.sh
+ CI_CONTAINER=true
+ true
+ CEPH_BRANCH=
+ for v in BRANCH SHA1 CONTAINER_REPO_HOSTNAME CONTAINER_REPO_ORGANIZATION CONTAINER_REPO_USERNAME CONTAINER_REPO_PASSWORD
+ require BRANCH
+ [[ -z '' ]]
+ echo 'Required variable BRANCH not set, exiting'
Required variable BRANCH not set, exiting

Signed-off-by: Sage Weil <sage@redhat.com>