### PR TITLE
ceph-dev-*build: remove ceph-container after done with it

### DIFF
--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -206,6 +206,7 @@ if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" && $FLAVOR == "default" ]] 
     # avoid failing the build if build-push fails
     sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
     cd $WORKSPACE
+    sudo rm -rf ceph-container
 fi
 
 # update shaman with the completed build status

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -207,6 +207,7 @@ if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $FLAVOR == "default" ]] 
     # avoid failing the build if build-push fails
     sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
     cd $WORKSPACE
+    sudo rm -rf ceph-container
 fi
 
 # update shaman with the completed build status


### PR DESCRIPTION
because `ceph-container` contains the artifacts created using `root`
user after 6090e4d00c82b8aba1d56ed249f29352e7c308d6, for instance, the
`staging` directory is created by
https://github.com/ceph/ceph-container/blob/2f61465f6a91f15470ff4f87844c5fe9c64b9664/maint-lib/stage.py#L102

so we need to remove `ceph-container` after pushing the created image
using `sudo` as well. otherwise, jenkins is not able to cleanup the
workspace using the "jenkins-build" user.

Signed-off-by: Kefu Chai <kchai@redhat.com>