### PR TITLE
teuthology: always test pull requests in sepia

### DIFF
--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -1,6 +1,6 @@
 - job:
     name: teuthology-pull-requests
-    node: bionic && huge && !xenial
+    node: sepia && bionic && huge && !xenial
     project-type: freestyle
     defaults: global
     concurrent: true


### PR DESCRIPTION
Because teuthology has functional and integration tests which
needs a connection to some services running in sepia and
some of the jenkins workers are running far away from the lab,
it takes significantly more time to run tests when using those
nodes. Like 6-7 minutes for running test on nodes in sepia,
and about 55-60 minutes outside.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>