### PR TITLE
scripts/build_utils.sh: do not use easy_setup to install pip

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -119,14 +119,8 @@ install_python_packages_no_binary () {
     mkdir -p $PIP_SDIST_INDEX
 
     echo "Ensuring latest pip is installed"
-    # XXX This means we are now pinning to 10.0.0, to prevent issues on pip
-    # mismtaching versions, but also that we need to revisit this when newer
-    # options are needed. ``easy_install`` is a must on systems with ancient
-    # versions of pip that break with newer versions of pkg_resources that come
-    # with the virtualenv. Doing an initial upgrade with easy_install
-    # circumvents the problem
-    $VENV/easy_install --upgrade pip
-    $VENV/pip install "pip==10.0.0"
+
+    $VENV/pip install "pip==20.0.2"
 
     echo "Updating setuptools"
     pip_download setuptools
@@ -158,14 +152,7 @@ install_python_packages () {
     mkdir -p $PIP_SDIST_INDEX
 
     echo "Ensuring latest pip is installed"
-    # XXX This means we are now pinning to 10.0.0, to prevent issues on pip
-    # mismtaching versions, but also that we need to revisit this when newer
-    # options are needed. ``easy_install`` is a must on systems with ancient
-    # versions of pip that break with newer versions of pkg_resources that come
-    # with the virtualenv. Doing an initial upgrade with easy_install
-    # circumvents the problem
-    $VENV/easy_install --upgrade pip
-    $VENV/pip install "pip==10.0.0"
+    $VENV/pip install "pip==20.0.2"
 
     echo "Updating setuptools"
     pip_download setuptools


### PR DESCRIPTION
which leaves us a broken pip,
```
+ /tmp/venv.e69PxjZdWr/bin/pip download --dest=/home/jenkins-build/.cache/pip setuptools
Traceback (most recent call last):
  File "/tmp/venv.e69PxjZdWr/bin/pip", line 5, in <module>
    from pip._internal import main
  File "/tmp/venv.e69PxjZdWr/lib/python2.7/site-packages/pip/_internal/__init__.py", line 42, in <module>
    from pip._internal import cmdoptions
  File "/tmp/venv.e69PxjZdWr/lib/python2.7/site-packages/pip/_internal/cmdoptions.py", line 16, in <module>
    from pip._internal.index import (
ImportError: cannot import name FormatControl
+ /tmp/venv.e69PxjZdWr/bin/pip install --upgrade --exists-action=i --cache-dir=/home/jenkins-build/.cache/pip setuptools
```

Signed-off-by: Kefu Chai <kchai@redhat.com>