### PR TITLE
ceph-dashboard-prs: Change order of install dep script

### DIFF
--- a/scripts/dashboard/install-e2e-test-deps.sh
+++ b/scripts/dashboard/install-e2e-test-deps.sh
@@ -11,9 +11,9 @@ if grep -q  debian /etc/*-release; then
     curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
     sudo apt-get update
     sudo apt-get install -y google-chrome-stable
+    sudo apt-get install -y xvfb
     sudo apt-get install -y python-requests python3-requests python-openssl python3-openssl python-jinja2 python3-jinja2 \
 	python-jwt python3-jwt python-scipy python3-scipy python-routes python3-routes
-    sudo apt-get install -y xvfb
     sudo rm /etc/apt/sources.list.d/google-chrome.list
 elif grep -q rhel /etc/*-release; then
     sudo dd of=/etc/yum.repos.d/google-chrome.repo status=none <<EOF


### PR DESCRIPTION
Not sure if it is related to the way the previous two lines
of dependency installation is formatted, but the install line
for xvfb was never executed in Jenkins.
But it does not really make sense to me since the line `sudo rm /etc/apt/sources.list.d/google-chrome.list` that was previously right after the splitted `sudo apt-get install -y [...]` line was always executed.
Could it be that the job was never updated with the changes of PR #1552?

Signed-off-by: Laura Paduano <lpaduano@suse.com>