### PR TITLE
support crimson flavor for centos 8

### DIFF
--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -187,7 +187,8 @@ fi
 
 # XXX perhaps use job parameters instead of literals; then
 # later stages can also use them to compare etc.
-if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $FLAVOR == "default" ]] ; then
+# build container image that supports building crimson-osd
+if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $FLAVOR != "notcmalloc" ]] ; then
     loop=0
     ready=false
     while ((loop < 15)); do

--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -77,6 +77,7 @@ case "${FLAVOR}" in
         CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
         ;;
     crimson)
+        echo "Detected crimson flavor: will use flag: -DWITH_SEASTAR=ON"
         CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
         CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DWITH_SEASTAR=ON"
         ;;

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -158,7 +158,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal
+                    DISTROS=focal centos8
                     FLAVOR=crimson
 
     wrappers:


### PR DESCRIPTION
    supports crimson flavor for centos 8    
    add crimson flavor build for octopus and master

See Also: https://github.com/ceph/ceph-build/pull/1334/