### PR TITLE
add package dependency for jaegertracing

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -532,8 +532,15 @@ setup_pbuilder() {
 
     # gcc 7.4.0 will come from bionic-updates, those need to be added as well
     if [ $DIST = "bionic" ]; then
+        extrapackages='EXTRAPACKAGES="nlohmann-json-dev"'
         other_mirror="OTHERMIRROR=\"deb $mirror $DIST-updates main universe\""
+        echo "$extrapackages" >> ~/.pbuilderrc
         echo "$other_mirror" >> ~/.pbuilderrc
+    fi
+
+    if [ $DIST = "focal" ]; then
+        extrapackages='EXTRAPACKAGES="nlohmann-json3-dev"'
+        echo "$extrapackages" >> ~/.pbuilderrc
     fi
 
     if [ $FLAVOR = "crimson" ]; then


### PR DESCRIPTION
since the package dependency for jaegertracing has diverged from
nlhomann-json-dev to nlhomann-json3-dev; it cannot be accomadated in
debian/control, hence using them as specification for extrapackage
similar to the way we do for crimson project.

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>