### PR TITLE
ceph*setup: Unpin to trusty slaves

### DIFF
--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -1,9 +1,7 @@
 - job:
     name: ceph-dev-new-setup
     description: "This job step checks out the branch and builds the tarballs, diffs, and dsc that are passed to the ceph-dev-build step.\r\n\r\nNotes:\r\nJob needs to run on a releatively recent debian system.  The Restrict where run feature is used to specifiy an appropriate label.\r\nThe clear workspace before checkout box for the git plugin is used."
-    # we do not need to pin this to trusty anymore for the new jenkins instance
-    # FIXME: unpin when this gets ported over
-    node: huge && trusty && x86_64
+    node: huge && bionic && x86_64
     display-name: 'ceph-dev-new-setup'
     block-downstream: false
     block-upstream: false

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -1,9 +1,7 @@
 - job:
     name: ceph-dev-setup
     description: "This job step checks out the branch and builds the tarballs, diffs, and dsc that are passed to the ceph-dev-build step.\r\n\r\nNotes:\r\nJob needs to run on a releatively recent debian system.  The Restrict where run feature is used to specifiy an appropriate label.\r\nThe clear workspace before checkout box for the git plugin is used."
-    # we do not need to pin this to trusty anymore for the new jenkins instance
-    # FIXME: unpin when this gets ported over
-    node: huge && trusty && x86_64
+    node: huge && bionic && x86_64
     display-name: 'ceph-dev-setup'
     block-downstream: false
     block-upstream: false

--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -1,9 +1,7 @@
 - job:
     name: ceph-setup
     description: "This job step checks out the branch and builds the tarballs, diffs, and dsc that are passed to the ceph-build step.\r\n\r\nNotes:\r\nJob needs to run on a releatively recent debian system.  The Restrict where run feature is used to specifiy an appropriate label.\r\nThe clear workspace before checkout box for the git plugin is used."
-    # we do not need to pin this to trusty anymore for the new jenkins instance
-    # FIXME: unpin when this gets ported over
-    node: huge && trusty && x86_64
+    node: huge && bionic && x86_64
     display-name: 'ceph-setup'
     block-downstream: false
     block-upstream: false


### PR DESCRIPTION
Not sure why this was needed in the first place but not only do we not have any actual 'trusty' slaves anymore but there's nothing in creating a tarball that should require Ubuntu 14.04.

Signed-off-by: David Galloway <dgallowa@redhat.com>