### PR TITLE
jenkins-job-builder: Use latest pip

### DIFF
--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -10,7 +10,7 @@ set -euxo pipefail
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "jenkins-job-builder==2.0.3" )
-install_python_packages "pkgs[@]"
+install_python_packages "pkgs[@]" latest
 
 # Wipe out JJB's cache if $FORCE is set.
 [ "$FORCE" = true ] && rm -rf "$HOME/.cache/jenkins_jobs/"


### PR DESCRIPTION
I guess jjb needs a newer pip.  This job broke a few weeks ago after https://github.com/ceph/ceph-build/commit/21e7a7b2d3aa4d49b3a38c8eab494adb8f928a4b

Signed-off-by: David Galloway <dgallowa@redhat.com>