### PR TITLE
ceph-*-build: enable crimson build dependencies

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -94,6 +94,11 @@ fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 
+if [ "$FLAVOR" = "crimson" ]; then
+    # enable more build depends required by crimson
+    sed -i -e 's/%bcond_with seastar/%bcond_without seastar/g' $DIR/ceph.spec
+esac
+
 # Make sure we have all the rpm macros installed and at the latest version
 # before installing the dependencies, python3-devel requires the
 # python-rpm-macro we use for identifying the python related dependencies

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -95,6 +95,11 @@ fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 
+if [ "$FLAVOR" = "crimson" ]; then
+    # enable more build depends required by crimson
+    sed -i -e 's/%bcond_with seastar/%bcond_without seastar/g' $DIR/ceph.spec
+esac
+
 # before installing the dependencies, python3-devel requires the
 # python-rpm-macro we use for identifying the python related dependencies
 $SUDO yum install -y python3-devel

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -95,6 +95,11 @@ fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 
+if [ "$FLAVOR" = "crimson" ]; then
+    # enable more build depends required by crimson
+    sed -i -e 's/%bcond_with seastar/%bcond_without seastar/g' $DIR/ceph.spec
+esac
+
 # before installing the dependencies, python3-devel requires the
 # python-rpm-macro we use for identifying the python related dependencies
 $SUDO yum install -y python3-devel


### PR DESCRIPTION
if $FLAVOR is crimson, crimson specific build dependencies should be
installed, otherwise we could have following failure when trying to
build crimson flavor of ceph packages:

error: Failed build dependencies:
	fmt-devel is needed by ceph-2:16.0.0-1456.g311da94.el8.x86_64

Signed-off-by: Kefu Chai <kchai@redhat.com>