### PR TITLE
Revert "ceph-*-build: enable crimson build dependencies"

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -94,11 +94,6 @@ fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 
-if [ "$FLAVOR" = "crimson" ]; then
-    # enable more build depends required by crimson
-    sed -i -e 's/%bcond_with seastar/%bcond_without seastar/g' $DIR/ceph.spec
-esac
-
 # Make sure we have all the rpm macros installed and at the latest version
 # before installing the dependencies, python3-devel requires the
 # python-rpm-macro we use for identifying the python related dependencies

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -95,11 +95,6 @@ fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 
-if [ "$FLAVOR" = "crimson" ]; then
-    # enable more build depends required by crimson
-    sed -i -e 's/%bcond_with seastar/%bcond_without seastar/g' $DIR/ceph.spec
-esac
-
 # before installing the dependencies, python3-devel requires the
 # python-rpm-macro we use for identifying the python related dependencies
 $SUDO yum install -y python3-devel

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -95,11 +95,6 @@ fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
 
-if [ "$FLAVOR" = "crimson" ]; then
-    # enable more build depends required by crimson
-    sed -i -e 's/%bcond_with seastar/%bcond_without seastar/g' $DIR/ceph.spec
-esac
-
 # before installing the dependencies, python3-devel requires the
 # python-rpm-macro we use for identifying the python related dependencies
 $SUDO yum install -y python3-devel


### PR DESCRIPTION
This reverts commit f934188b6cb95a56fd799ff2806a3f4ce30a9c58.

Should fixes:

```
Package centos-release-scl-2-3.el7.centos.noarch already installed and latest version
Nothing to do
+ sed -e s/@//g
/tmp/jenkins2442560490007581402.sh: line 1190: syntax error near unexpected token `esac'
++ rm -fr /tmp/install-deps.119324
```

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

