### PR TITLE
kernel: turn on ubuntu focal builds

### DIFF
--- a/kernel/config/definitions/kernel.yml
+++ b/kernel/config/definitions/kernel.yml
@@ -65,6 +65,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - trusty
             - xenial
             - bionic
+            - focal
       - axis:
           type: dynamic
           name: DIST


### PR DESCRIPTION
Commit 458332be6244 ("Add support for Ubuntu Focal Fossa globally")
added support for focal builds but didn't turn them on.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>