### PR TITLE
ansible: replace sudo by become

### DIFF
--- a/ceph-deploy-pull-requests/setup/playbooks/setup.yml
+++ b/ceph-deploy-pull-requests/setup/playbooks/setup.yml
@@ -2,7 +2,7 @@
 
 - hosts: localhost
   user: jenkins-build
-  sudo: True
+  become: yes
 
   tasks:
      - include: tasks/ubuntu.yml


### PR DESCRIPTION
sudo has be deprecated since Ansible 1.9 [0] and was removed in 2.9 [1], let's
use "become" instead.

---
[0]
https://github.com/ansible/ansible/blob/stable-2.0/CHANGELOG.md#19-dancing-in-the-street---mar-25-2015
[1] https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst

Signed-off-by: Kefu Chai <kchai@redhat.com>