### PR TITLE
ceph-*-build: remove focal for crimson flavor

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -158,7 +158,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal centos8
+                    DISTROS=centos8
                     FLAVOR=crimson
 
     wrappers:


### PR DESCRIPTION
we have now shifted to using centos 8 as base for building crimson
instead of using focal.

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>