### PR TITLE
ceph-perf-pull-requests: remove clang unsupported flags.

### DIFF
--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -62,6 +62,7 @@
               if type -t clang-$i > /dev/null; then
                   cxx_compiler="clang++-$i"
                   c_compiler="clang-$i"
+                  export CFLAGS=$(echo $CFLAGS | (sed -e 's/\-fstack-clash-protection//'))
                   break
               fi
           done


### PR DESCRIPTION
see also: 0b5dd11190d2c3fa9b7161a28f913a2d83e39526
79804b74cea6effc1582391351ab16c92981c13a

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>