### PR TITLE
ceph-deploy-pull-requests: s/installed/present/

### DIFF
--- a/ceph-deploy-pull-requests/setup/playbooks/tasks/ubuntu.yml
+++ b/ceph-deploy-pull-requests/setup/playbooks/tasks/ubuntu.yml
@@ -3,7 +3,7 @@
     action: apt update_cache=yes
 
   - name: install python requirements
-    action: apt pkg={{ item }} state=installed
+    action: apt pkg={{ item }}
     with_items:
       - python-software-properties
       - python-dev


### PR DESCRIPTION
see
https://docs.ansible.com/ansible/latest/modules/apt_module.html#parameters

the desired package state should be "present" instead of "installed".

Signed-off-by: Kefu Chai <kchai@redhat.com>