### PR TITLE
ceph-website: Support GIT_BRANCH with multiple slashes

### DIFF
--- a/ceph-website/build/build
+++ b/ceph-website/build/build
@@ -4,7 +4,7 @@ set -ex
 ## TODO: Check if only the src/ dir changed and `exit 0` if only the ceph.io.git README or something else inconsequential changed.
 env
 
-BRANCH=`branch_slash_filter ${GIT_BRANCH}`
+BRANCH=$(echo $GIT_BRANCH | sed 's:.*/::')
 
 # Don't think this is even necessary
 #git checkout ${BRANCH}


### PR DESCRIPTION
The SoftIron folks like to use branch names like 'origin/feature/multingual' so let's support that.

Signed-off-by: David Galloway <dgallowa@redhat.com>