### PR TITLE
ceph-dev-new-build/build/build_rpm: passing FLAVOR parmeter to ceph-container script

### DIFF
--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -206,7 +206,7 @@ if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $FLAVOR != "notcmalloc" 
 
     cd $WORKSPACE/ceph-container
     # avoid failing the build if build-push fails
-    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
+    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} OSD_FLAVOR=${FLAVOR} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
     cd $WORKSPACE
     sudo rm -rf ceph-container
 fi


### PR DESCRIPTION
Since we now have two FLAVOR for containerization(default & crimson)
Propogate which flavor is being used for to build-push-ceph-container-imgs.sh

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>