### PR TITLE
nfs-ganesha: enable CentOS 8 builds, other fixes

### DIFF
--- a/nfs-ganesha/build/build_rpm
+++ b/nfs-ganesha/build/build_rpm
@@ -9,8 +9,11 @@ fi
 ## Get some basic information about the system and the repository
 RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
 
-# Disable the google-chrome repo, which is not needed
-sudo yum-config-manager --disable google-chrome
+# Disable the google-chrome repo on el7, which is not needed (el8 doesn't have this repo).
+if [ $DIST = centos7 ]
+then
+	sudo yum-config-manager --disable google-chrome
+fi
 
 # Clean up Jenkins slave before each build
 sudo rm -rf /var/cache/yum/*
@@ -58,8 +61,18 @@ librados-devel
 librgw-devel
 libcephfs-devel
 lttng-ust-devel
-lttng-tools-devel
 "
+# Removed "lttng-tools-devel" from above xargs list because it isn't available in el8
+if [ $DIST = centos7 ]
+then
+	sudo yum install -y lttng-tools-devel
+fi
+
+# The libnsl2-devel package is needed on el8 builds, but not el7
+if [ $DIST = centos8 ]
+then
+	sudo yum -y install libnsl2-devel
+fi
 
 sudo yum install -y mock
 
@@ -94,11 +107,20 @@ mkdir build
 cd build
 
 # generate .spec file, edit .spec file for correct versions of libs and make source tarball
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRICT_PACKAGE=ON -DUSE_FSAL_ZFS=OFF -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=ON -DUSE_FSAL_LIZARDFS=OFF -DRADOS_URLS=ON -DUSE_RADOS_RECOV=ON -DUSE_LTTNG=ON $WORKSPACE/nfs-ganesha/src && make dist || exit 1
+if [ $DIST = centos7 ]
+then
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRICT_PACKAGE=ON -DUSE_FSAL_ZFS=OFF -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=ON -DUSE_FSAL_LIZARDFS=OFF -DRADOS_URLS=ON -DUSE_RADOS_RECOV=ON -DUSE_LTTNG=ON -DUSE_ADMIN_TOOLS=ON $WORKSPACE/nfs-ganesha/src && make dist || exit 1
+else
+    # Don't enable LTTNG for el8 builds - the "lttng-tools-devel" package isn't available
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRICT_PACKAGE=ON -DUSE_FSAL_ZFS=OFF -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=ON -DUSE_FSAL_LIZARDFS=OFF -DRADOS_URLS=ON -DUSE_RADOS_RECOV=ON -DUSE_ADMIN_TOOLS=ON $WORKSPACE/nfs-ganesha/src && make dist || exit 1
+fi
 
 sed -i 's/libcephfs1-devel/libcephfs-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 sed -i 's/librgw2-devel/librgw-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 sed -i 's/CMAKE_BUILD_TYPE=Debug/CMAKE_BUILD_TYPE=RelWithDebInfo/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
+
+# libacl-devel needs to be a CephFS BuildRequires in the upstream nfs-ganesha.spec-in.cmake
+sed -i 's/krb5-devel/krb5-devel libacl-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 
 ## Create the source rpm
 echo "Building SRPM"
@@ -111,18 +133,24 @@ rpmbuild \
     --nodeps -bs $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 SRPM=$(readlink -f $WORKSPACE/dist/SRPMS/*.src.rpm)
 
-# add repo file to mock config
-sudo head -n -1 /etc/mock/${MOCK_TARGET}-${RELEASE}-${ARCH}.cfg > temp.cfg
-echo >> temp
-sudo cat temp.cfg $WORKSPACE/shaman.repo > nfs-ganesha.cfg
-echo "\"\"\"" >> nfs-ganesha.cfg
+# Add repo file to mock config. The new version of mock uses templates.
+if [ $DIST = centos7 ]
+then
+    sudo cat /etc/mock/${MOCK_TARGET}-${RELEASE}-${ARCH}.cfg /etc/mock/templates/epel-${RELEASE}.tpl  > nfs-ganesha-mock.temp
+else
+    sudo cat /etc/mock/${MOCK_TARGET}-${RELEASE}-${ARCH}.cfg /etc/mock/templates/centos-${RELEASE}.tpl /etc/mock/templates/epel-${RELEASE}.tpl  > nfs-ganesha-mock.temp
+fi
+sudo head -n -1 nfs-ganesha-mock.temp > nfs-ganesha.cfg
+sudo cat $WORKSPACE/shaman.repo >> nfs-ganesha.cfg
+sudo echo "\"\"\"" >> nfs-ganesha.cfg
 # for debugging
 cat nfs-ganesha.cfg
+
 
 ## Build the binaries with mock
 echo "Building RPMs"
 sudo mock --verbose -r nfs-ganesha.cfg --scrub=all
-sudo mock --verbose -r nfs-ganesha.cfg --define "dist .el7" --resultdir=$WORKSPACE/dist/RPMS/ ${SRPM} || ( tail -n +1 $WORKSPACE/dist/RPMS/{root,build}.log && exit 1 )
+sudo mock --verbose -r nfs-ganesha.cfg --define "dist .el${RELEASE}" --resultdir=$WORKSPACE/dist/RPMS/ ${SRPM} || ( tail -n +1 $WORKSPACE/dist/RPMS/{root,build}.log && exit 1 )
 
 VERSION=`grep -R "#define GANESHA_VERSION \"" $WORKSPACE/nfs-ganesha/build/include/config.h | sed -e 's/#define GANESHA_VERSION "//1; s/"//1;'`
 chacra_endpoint="nfs-ganesha/${NFS_GANESHA_BRANCH}/${GIT_COMMIT}/${DISTRO}/${RELEASE}"

--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -57,8 +57,8 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: bionic, centos7"
-          default: "centos7 bionic"
+          description: "A list of distros to build for. Available options are: bionic, centos7, centos8"
+          default: "centos7 centos8 bionic"
 
       - string:
           name: ARCHS
@@ -102,6 +102,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           name: AVAILABLE_DIST
           values:
             - centos7
+            - centos8
             - xenial
             - bionic
       - axis:


### PR DESCRIPTION
Enable CentOS 8 builds of the "next" branch of nfs-ganesha.

We also needed other fixes to the build script to account for both el8/el7 builds, as well as handling for the newer version of "mock" which now uses templates.