### PR TITLE
ceph-dev*: use quay.ceph.io for CONTAINER_REPO_HOSTNAME

### DIFF
--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -73,7 +73,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
       - string:
           name: CONTAINER_REPO_HOSTNAME
           description: "For CI_CONTAINER: Name of container repo server (i.e. 'quay.io')"
-          default: "quay.io"
+          default: "quay.ceph.io"
 
       - string:
           name: CONTAINER_REPO_ORGANIZATION

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -72,7 +72,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
       - string:
           name: CONTAINER_REPO_HOSTNAME
           description: "For CI_CONTAINER: Name of container repo server (i.e. 'quay.io')"
-          default: "quay.io"
+          default: "quay.ceph.io"
 
       - string:
           name: CONTAINER_REPO_ORGANIZATION

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -6,7 +6,7 @@ import re
 import requests
 import sys
 
-QUAYBASE = "https://quay.io/api/v1"
+QUAYBASE = "https://quay.ceph.io/api/v1"
 REPO = "ceph-ci/ceph"
 
 


### PR DESCRIPTION
this setting is consumed by contrib/build-push-ceph-container-imgs.sh in
ceph-container project.

after this change, the ceph container images will be pushed to our own
quay instance in lab.

Signed-off-by: Kefu Chai <kchai@redhat.com>