### PR TITLE
s/chacractl>=0.0.4/chacractl>=0.0.21/

### DIFF
--- a/calamari-clients-build/build/setup
+++ b/calamari-clients-build/build/setup
@@ -53,7 +53,7 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
         ;;
 esac
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/calamari/build/setup
+++ b/calamari/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-ansible-rpm/build/build
+++ b/ceph-ansible-rpm/build/build
@@ -17,7 +17,7 @@ make rpm || ( tail -n +1 {root,build}.log && exit 1 )
 
 # Chacra time
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-build/build/setup_deb
+++ b/ceph-build/build/setup_deb
@@ -104,7 +104,7 @@ NORMAL_ARCH=$ARCH
 # create build status in shaman
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 make_chacractl_config

--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -88,8 +88,6 @@ if [ "$RELEASE" = 7 ]; then
    fi
 elif [ "$RELEASE" = 8 ]; then
     $SUDO dnf config-manager --set-enabled PowerTools
-    # chacractl is not python3 compatible yet
-    $SUDO dnf -y install python2
 fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
@@ -122,7 +120,7 @@ NORMAL_ARCH=$ARCH
 # create build status in shaman
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # create the .chacractl config file using global variables

--- a/ceph-deploy-build/build/setup
+++ b/ceph-deploy-build/build/setup
@@ -17,7 +17,7 @@ if test -f /etc/redhat-release ; then
     sudo yum install -y $rpm_deps
 fi
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # create the .chacractl config file using global variables

--- a/ceph-dev-build/build/setup_deb
+++ b/ceph-dev-build/build/setup_deb
@@ -100,7 +100,7 @@ NORMAL_ARCH=$ARCH
 # create build status in shaman
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-dev-build/build/setup_osc
+++ b/ceph-dev-build/build/setup_osc
@@ -73,7 +73,7 @@ NORMAL_ARCH=$ARCH
 # create build status in shaman
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -89,8 +89,6 @@ if [ "$RELEASE" = 7 ]; then
    fi
 elif [ "$RELEASE" = 8 ]; then
     $SUDO dnf config-manager --set-enabled PowerTools
-    # chacractl is not python3 compatible yet
-    $SUDO dnf -y install python2
 fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
@@ -122,7 +120,7 @@ NORMAL_ARCH=$ARCH
 # create build status in shaman
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-dev-new-build/build/setup_deb
+++ b/ceph-dev-new-build/build/setup_deb
@@ -100,7 +100,7 @@ NORMAL_ARCH=$ARCH
 # create build status in shaman
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -89,8 +89,6 @@ if [ "$RELEASE" = 7 ]; then
    fi
 elif [ "$RELEASE" = 8 ]; then
     $SUDO dnf config-manager --set-enabled PowerTools
-    # chacractl is not python3 compatible yet
-    $SUDO dnf -y install python2
 fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
@@ -122,7 +120,7 @@ NORMAL_ARCH=$ARCH
 # create build status in shaman
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-iscsi-cli/build/setup
+++ b/ceph-iscsi-cli/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-iscsi-config/build/setup
+++ b/ceph-iscsi-config/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-iscsi-stable/build/setup
+++ b/ceph-iscsi-stable/build/setup
@@ -44,7 +44,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 chacra_url="https://chacra.ceph.com/"

--- a/ceph-iscsi-tools/build/setup
+++ b/ceph-iscsi-tools/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-iscsi/build/setup
+++ b/ceph-iscsi/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-medic-release/build/build_rpm
+++ b/ceph-medic-release/build/build_rpm
@@ -15,7 +15,7 @@ make rpm || ( tail -n +1 {root,build}.log && exit 1 )
 
 # Chacra time
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 make_chacractl_config

--- a/ceph-medic-rpm/build/build
+++ b/ceph-medic-rpm/build/build
@@ -17,7 +17,7 @@ make rpm || ( tail -n +1 {root,build}.log && exit 1 )
 
 # Chacra time
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -12,7 +12,7 @@ echo "Building on Host: $(hostname)"
 rm -rf dist
 rm -rf RPMBUILD
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # create the .chacractl config file using global variables

--- a/cephmetrics-release/build/setup
+++ b/cephmetrics-release/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # create the .chacractl config file using global variables

--- a/cephmetrics/build/setup
+++ b/cephmetrics/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/configshell-fb/build/setup
+++ b/configshell-fb/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/diamond-build/build/setup
+++ b/diamond-build/build/setup
@@ -53,7 +53,7 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
         ;;
 esac
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/kernel/build/setup
+++ b/kernel/build/setup
@@ -67,7 +67,7 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
         ;;
 esac
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/nfs-ganesha-stable/build/setup
+++ b/nfs-ganesha-stable/build/setup
@@ -44,7 +44,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 NFS_GANESHA_BRANCH=`branch_slash_filter $NFS_GANESHA_BRANCH`

--- a/nfs-ganesha/build/setup
+++ b/nfs-ganesha/build/setup
@@ -41,7 +41,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 NFS_GANESHA_BRANCH=`branch_slash_filter $NFS_GANESHA_BRANCH`

--- a/radosgw-agent/build/build
+++ b/radosgw-agent/build/build
@@ -14,7 +14,7 @@ ls -l
 
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # create the .chacractl config file using global variables

--- a/rtslib-fb/build/setup
+++ b/rtslib-fb/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/samba/build/setup
+++ b/samba/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 SAMBA_BRANCH=$(branch_slash_filter $SAMBA_BRANCH)

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -109,17 +109,17 @@ install_python_packages_no_binary () {
     #
     # Usage (with pip 10.0.0 [the default]):
     #
-    #   to_install=( "ansible" "chacractl>=0.0.4" )
+    #   to_install=( "ansible" "chacractl>=0.0.21" )
     #   install_python_packages_no_binary "to_install[@]"
     #
     # Usage (with pip<X.X.X [can also do ==X.X.X or !=X.X.X]):
     #
-    #   to_install=( "ansible" "chacractl>=0.0.4" )
+    #   to_install=( "ansible" "chacractl>=0.0.21" )
     #   install_python_packages_no_binary "to_install[@]" "pip<X.X.X"
     #
     # Usage (with latest pip):
     #
-    #   to_install=( "ansible" "chacractl>=0.0.4" )
+    #   to_install=( "ansible" "chacractl>=0.0.21" )
     #   install_python_packages_no_binary "to_install[@]" latest
 
     create_virtualenv $TEMPVENV
@@ -164,17 +164,17 @@ install_python_packages () {
     #
     # Usage (with pip 10.0.0 [the default]):
     #
-    #   to_install=( "ansible" "chacractl>=0.0.4" )
+    #   to_install=( "ansible" "chacractl>=0.0.21" )
     #   install_python_packages "to_install[@]"
     #
     # Usage (with pip<X.X.X [can also do ==X.X.X or !=X.X.X]):
     #
-    #   to_install=( "ansible" "chacractl>=0.0.4" )
+    #   to_install=( "ansible" "chacractl>=0.0.21" )
     #   install_python_packages_no_binary "to_install[@]" "pip<X.X.X"
     #
     # Usage (with latest pip):
     #
-    #   to_install=( "ansible" "chacractl>=0.0.4" )
+    #   to_install=( "ansible" "chacractl>=0.0.21" )
     #   install_python_packages "to_install[@]" latest
 
     create_virtualenv $TEMPVENV

--- a/tcmu-runner/build/setup
+++ b/tcmu-runner/build/setup
@@ -35,7 +35,7 @@ echo "*****"
 
 export LC_ALL=C # the following is vulnerable to i18n
 
-pkgs=( "chacractl>=0.0.4" )
+pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
 # ask shaman which chacra instance to use


### PR DESCRIPTION
chacractl v0.0.21 is python3 compatible, let's use chacractl>=0.0.21, so
no need to install python2 just for using chacractl!

Signed-off-by: Kefu Chai <kchai@redhat.com>