### PR TITLE
ceph-dev-trigger: stop building master on el7

### DIFF
--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -138,7 +138,7 @@
                     DISTROS=centos8
                     FLAVOR=notcmalloc
       # build master on:
-      # default: focal bionic centos7 centos8 leap15
+      # default: focal bionic centos8 leap15
       # notcmalloc: centos8
       - conditional-step:
           condition-kind: regex-match
@@ -155,7 +155,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal bionic centos7 centos8 leap15
+                    DISTROS=focal bionic centos8 leap15
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}


### PR DESCRIPTION
as we already have octopus build for el7, which is suffice for preparing
user of older release on el7 to upgrade to octopus, and laster octopus
on el8 or containerized deployment.

Signed-off-by: Kefu Chai <kchai@redhat.com>