### PR TITLE
container: update devel nightly list

### DIFF
--- a/ceph-container-build-push-imgs-devel-nightly/build/build
+++ b/ceph-container-build-push-imgs-devel-nightly/build/build
@@ -3,4 +3,5 @@ set -e
 
 
 cd "$WORKSPACE"/ceph-container/ || exit
+sed -i -e 's/master luminous mimic nautilus octopus/master nautilus octopus/' contrib/build-push-ceph-container-imgs.sh
 bash -x contrib/build-push-ceph-container-imgs.sh


### PR DESCRIPTION
We don't need to build luminous and mimic devel anymore.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>