### PR TITLE
ceph-volume: don't run simple func tests against PRs

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -16,23 +16,6 @@
       - 'ceph-volume-prs-{subcommand}-{distro}-{objectstore}-{scenario}'
 
 - project:
-    name: ceph-volume-ansible-prs-simple
-    distro:
-      - centos8
-    objectstore:
-      - bluestore
-      - filestore
-    scenario:
-      - activate
-      - dmcrypt_luks
-      - dmcrypt_plain
-    subcommand:
-      - simple
-
-    jobs:
-      - 'ceph-volume-prs-{subcommand}-{distro}-{objectstore}-{scenario}'
-
-- project:
     name: ceph-volume-ansible-prs-batch
     distro:
       - centos8


### PR DESCRIPTION
Since "simple" functional tests are meant to test that ceph-volume
successfully takes over ceph-disk deployed OSDs.