### PR TITLE
ceph-dev-new-build: fail, if building containers fail

### DIFF
--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -203,8 +203,7 @@ if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" && $FLAVOR == "default" ]] 
     fi
 
     cd $WORKSPACE/ceph-container
-    # avoid failing the build if build-push fails
-    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
+    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh
     cd $WORKSPACE
     sudo rm -rf ceph-container
 fi

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -205,8 +205,7 @@ if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $FLAVOR != "notcmalloc" 
     fi
 
     cd $WORKSPACE/ceph-container
-    # avoid failing the build if build-push fails
-    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh || /bin/true
+    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} /bin/bash ./contrib/build-push-ceph-container-imgs.sh
     cd $WORKSPACE
     sudo rm -rf ceph-container
 fi


### PR DESCRIPTION
This avoids:

* unnecessary breakages in the master branch
* unnecessary pulpito runs due to failing containers

Let's fail early, instead of later in the pulpilto runs.

See

* https://github.com/ceph/ceph/pull/35767
* http://pulpito.ceph.com/swagner-2020-06-25_11:37:21-rados:cephadm-wip-swagner-testing-2020-06-25-1124-distro-basic-smithi/

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>