### PR TITLE
ceph-dev*build: Tell shaman the build passed before container build

### DIFF
--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -184,6 +184,9 @@ EOF
     echo Check the status of the repo at: https://shaman.ceph.com/api/repos/${chacra_endpoint}/flavors/${FLAVOR}/
 fi
 
+# update shaman with the completed build status
+update_build_status "completed" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+
 # XXX perhaps use job parameters instead of literals; then
 # later stages can also use them to compare etc.
 if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" && $FLAVOR == "default" ]] ; then
@@ -207,6 +210,3 @@ if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" && $FLAVOR == "default" ]] 
     cd $WORKSPACE
     sudo rm -rf ceph-container
 fi
-
-# update shaman with the completed build status
-update_build_status "completed" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -185,6 +185,9 @@ EOF
     echo Check the status of the repo at: https://shaman.ceph.com/api/repos/${chacra_endpoint}/flavors/${FLAVOR}/
 fi
 
+# update shaman with the completed build status
+update_build_status "completed" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+
 # XXX perhaps use job parameters instead of literals; then
 # later stages can also use them to compare etc.
 # build container image that supports building crimson-osd
@@ -209,6 +212,3 @@ if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $FLAVOR != "notcmalloc" 
     cd $WORKSPACE
     sudo rm -rf ceph-container
 fi
-
-# update shaman with the completed build status
-update_build_status "completed" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH


### PR DESCRIPTION
Another follow-up to https://github.com/ceph/ceph-build/pull/1603.  If the build passed and a repo got created, we can tell shaman.

If we want shaman to have information about failed/passed container builds, then that should be coded into shaman as an additional field.

Signed-off-by: David Galloway <dgallowa@redhat.com>