### PR TITLE
ceph-*-setup: use libc allocator for crimson flavor

### DIFF
--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -79,7 +79,7 @@ case "${FLAVOR}" in
     crimson)
         echo "Detected crimson flavor: will use flag: -DWITH_SEASTAR=ON"
         CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
-        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DWITH_SEASTAR=ON"
+        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DWITH_SEASTAR=ON -DSeastar_CXX_FLAGS=-DSEASTAR_DEFAULT_ALLOCATOR"
         ;;
     *)
         echo "unknown FLAVOR: ${FLAVOR}" >&2

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -50,7 +50,7 @@ case "${FLAVOR}" in
         ;;
     crimson)
         CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
-        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DWITH_SEASTAR=ON"
+        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DWITH_SEASTAR=ON -DSeastar_CXX_FLAGS=-DSEASTAR_DEFAULT_ALLOCATOR"
         ;;
     *)
         echo "unknown FLAVOR: ${FLAVOR}" >&2


### PR DESCRIPTION
to avoid the issues caused by allocator. we cannot use seastar allocator
in non-seastar thread or threads not managed by ThreadPool.

Signed-off-by: Kefu Chai <kchai@redhat.com>