### PR TITLE
ceph-ansible: add docker hub credentials

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -168,3 +168,13 @@
           artifacts: 'logs/**'
           allow-empty: true
           latest-only: false
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: ceph-ansible-upstream-ci
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -192,6 +192,16 @@
           allow-empty: true
           latest-only: false
 
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: ceph-ansible-upstream-ci
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD
+
 - job-template:
     name: 'ceph-ansible-prs-{distribution}-{deployment}-{scenario}'
     id: 'ceph-ansible-prs-common-trigger'
@@ -289,3 +299,13 @@
           artifacts: 'logs/**'
           allow-empty: true
           latest-only: false
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: ceph-ansible-upstream-ci
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD


### PR DESCRIPTION
To avoid to be rated limited by the docker.io registry when pulling the
ceph container image, we need to use an authenticated user.

https://docs.docker.com/docker-hub/download-rate-limit/

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>