### PR TITLE
build_utils.sh: add tox-cephadm.ini file

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -906,6 +906,9 @@ case $SCENARIO in
   external_clients)
     TOX_INI_FILE=tox-external_clients.ini
     ;;
+  cephadm)
+    TOX_INI_FILE=tox-cephadm.ini
+    ;;
   *)
     TOX_INI_FILE=tox.ini
     ;;


### PR DESCRIPTION
As a follow up on c9463f5 we also need to declare the dedicated tox
file for the cephadm container scenario.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>