### PR TITLE
build_utils.sh: fix regressions introduced by bac3e963a56

### DIFF
--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -25,7 +25,7 @@ RPM_VERSION=`grep Version ceph.spec | sed 's/Version:[ \t]*//g'`
 PACKAGE_MANAGER_VERSION="$RPM_VERSION-$RPM_RELEASE"
 
 BUILDAREA=$(setup_rpm_build_area ./rpm/$dist)
-build_rpms $BUILDAREA ${CEPH_EXTRA_RPMBUILD_ARGS}
+build_rpms $BUILDAREA "${CEPH_EXTRA_RPMBUILD_ARGS}"
 
 # Make sure we execute at the top level directory
 cd "$WORKSPACE"

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -42,7 +42,7 @@ RPM_VERSION=`grep Version ceph.spec | sed 's/Version:[ \t]*//g'`
 PACKAGE_MANAGER_VERSION="$RPM_VERSION-$RPM_RELEASE"
 
 BUILDAREA=$(setup_rpm_build_area ./rpm/$dist)
-build_rpms $BUILDAREA ${CEPH_EXTRA_RPMBUILD_ARGS}
+build_rpms $BUILDAREA "${CEPH_EXTRA_RPMBUILD_ARGS}"
 build_ceph_release_rpm $BUILDAREA true
 
 # Make sure we execute at the top level directory

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1093,7 +1093,7 @@ setup_rpm_build_area() {
     mkdir -p ${build_area}/{SOURCES,SRPMS,SPECS,RPMS,BUILD}
     cp -a ceph-*.tar.bz2 ${build_area}/SOURCES/.
     cp -a ceph.spec ${build_area}/SPECS/.
-    for f in rpm/*.patch; do
+    for f in $(find rpm -maxdepth 1 -name '*.patch'); do
         cp -a $f ${build_area}/SOURCES/.
     done
     ### rpm wants absolute path
@@ -1107,7 +1107,7 @@ build_rpms() {
     shift
 
     # Build RPMs
-    cd ${build_area_path}/SPECS
+    cd ${build_area}/SPECS
     rpmbuild -ba --define "_topdir ${build_area}" ${extra_rpm_build_args} ceph.spec
     echo done
 }
@@ -1225,7 +1225,7 @@ gpgkey=https://download.ceph.com/keys/${gpgkey}
 
 [Ceph-noarch]
 name=Ceph noarch packages
-baseurl=${repo_base_url/noarch
+baseurl=${repo_base_url}/noarch
 enabled=1
 gpgcheck=${gpgcheck}
 type=rpm-md


### PR DESCRIPTION
* quote parameter with spaces in it with ""
* fix the variable name
* use `find` for collecting the patches, because if glob fails
  the patten won't be replaced by the matched file names by shell

Signed-off-by: Kefu Chai <kchai@redhat.com>