### PR TITLE
ceph*build: Enable lab-extras repo on CentOS8 builders

### DIFF
--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -88,6 +88,9 @@ if [ "$RELEASE" = 7 ]; then
    fi
 elif [ "$RELEASE" = 8 ]; then
     $SUDO dnf config-manager --set-enabled PowerTools
+    # before EPEL8 and PowerTools provide all dependencies, we use sepia for the dependencies
+    $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
+    $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save
 fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -89,6 +89,9 @@ if [ "$RELEASE" = 7 ]; then
    fi
 elif [ "$RELEASE" = 8 ]; then
     $SUDO dnf config-manager --set-enabled PowerTools
+    # before EPEL8 and PowerTools provide all dependencies, we use sepia for the dependencies
+    $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
+    $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save
 fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -89,6 +89,9 @@ if [ "$RELEASE" = 7 ]; then
    fi
 elif [ "$RELEASE" = 8 ]; then
     $SUDO dnf config-manager --set-enabled PowerTools
+    # before EPEL8 and PowerTools provide all dependencies, we use sepia for the dependencies
+    $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
+    $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save
 fi
 
 sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec


### PR DESCRIPTION
I discovered this was missing by reimaging a CentOS7 builder to CentOS8 and it failed the first build it tried to run.

```
+ sudo yum install -y yum-utils
Last metadata expiration check: 0:00:28 ago on Thu Jul 16 21:05:07 2020.
Package yum-utils-4.0.12-3.el8.noarch is already installed.
Dependencies resolved.
Nothing to do.
Complete!
+ get_rpm_dist
+ LSB_RELEASE=/usr/bin/lsb_release
+ '[' '!' -x /usr/bin/lsb_release ']'
++ /usr/bin/lsb_release --short --id
+ ID=CentOS
+ case $ID in
++ /usr/bin/lsb_release --short --release
++ cut -d. -f1
+ RELEASE=8
+ DIST=el8
+ DISTRO=centos
+ echo el8
el8
+ '[' 8 = 7 ']'
+ '[' 8 = 8 ']'
+ sudo dnf config-manager --set-enabled PowerTools
+ sed -e s/@//g
+ '[' default = crimson ']'
+ sudo yum install -y python3-devel
CentOS-8 - PowerTools                            13 kB/s | 4.3 kB     00:00
Package python36-devel-3.6.8-2.module_el8.1.0+245+c39af44f.x86_64 is already installed.

Dependencies resolved.
Nothing to do.
Complete!
+ sudo yum-builddep -y '--setopt=*.skip_if_unavailable=true' /tmp/install-deps.49348/ceph.spec
Last metadata expiration check: 0:00:01 ago on Thu Jul 16 21:05:36 2020.

Package platform-python-devel-3.6.8-23.el8.x86_64 is already installed.
Package checkpolicy-2.9-1.el8.x86_64 is already installed.
Package cmake-3.11.4-7.el8.x86_64 is already installed.
Package cryptsetup-2.2.0-2.el8.x86_64 is already installed.
Package gcc-c++-8.3.1-5.el8.0.2.x86_64 is already installed.
Package gdbm-1:1.18-1.el8.x86_64 is already installed.
Package keyutils-libs-devel-1.5.10-6.el8.x86_64 is already installed.
No matching package to install: 'libbabeltrace-devel'
```

We're already enabling this repo in `install-deps.sh` but that's obviously not soon enough.

Signed-off-by: David Galloway <dgallowa@redhat.com>