### PR TITLE
ceph-ansible: inject password in scenario job

### DIFF
--- a/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
+++ b/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
@@ -93,3 +93,13 @@
           artifacts: 'logs/**'
           allow-empty: true
           latest-only: false
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: ceph-ansible-upstream-ci
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD


### PR DESCRIPTION
this commit makes this 'individual job scenario testing' using the
`DOCKER_HUB_USERNAME` and `DOCKER_HUB_PASSWORD` environment variable so
the job can run with docker authentication.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>