### PR TITLE
ceph-ansible: play shrink_osd_legacy on 3.2 only

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -32,6 +32,6 @@ rm -rf $HOME/ansible/facts/*
 [[ "$ghprbTargetBranch" == stable-3.1 && "$SCENARIO" =~ lvm_batch|lvm_osds ]] ||
 [[ "$ghprbTargetBranch" != stable-4.0 && "$SCENARIO" == podman ]] ||
 [[ "$ghprbTargetBranch" =~ stable-4.0|stable-3 && "$SCENARIO" =~ cephadm|cephadm_adopt ]] ||
-[[ "$ghprbTargetBranch" == stable-4.0 && "$SCENARIO" == shrink_osd_legacy ]] ||
+[[ "$ghprbTargetBranch" != stable-3.2 && "$SCENARIO" == shrink_osd_legacy ]] ||
 [[ "$ghprbTargetBranch" =~ stable-3 && "$SCENARIO" == filestore_to_bluestore ]] ||
 start_tox


### PR DESCRIPTION
Skip `shrink_osd_legacy` job on all branches but stable-3.2

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>