### PR TITLE
ceph-api: rename dasboard-backed-api to ceph-api

### DIFF
--- a/ceph-pr-api/build/build
+++ b/ceph-pr-api/build/build
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+n_build_jobs=$(get_nr_build_jobs)
+n_test_jobs=$(($(nproc) / 4))
+export CHECK_MAKEOPTS="-j${n_test_jobs} -N -Q"
+export BUILD_MAKEOPTS="-j${n_build_jobs}"
+timeout 3h ./run-make-check.sh
+sleep 5
+ps -ef | grep ceph || true

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -1,0 +1,70 @@
+- job:
+    name: ceph-api
+    project-type: freestyle
+    defaults: global
+    concurrent: true
+    node: huge && bionic && x86_64 && !xenial && !trusty
+    display-name: 'ceph: API'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 300
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+      - github:
+          url: https://github.com/ceph/ceph/
+      - rebuild:
+          auto-rebuild: true
+
+    parameters:
+      - string:
+          name: sha1
+          description: "commit id or a refname, like 'origin/pr/72/head'"
+
+    triggers:
+      - github-pull-request:
+          cancel-builds-on-update: true
+          allow-whitelist-orgs-as-admins: true
+          org-list:
+            - ceph
+          white-list-target-branches:
+            - master
+            - octopus
+            - nautilus
+          trigger-phrase: 'jenkins test api'
+          skip-build-phrase: '^jenkins do not test.*'
+          only-trigger-phrase: false
+          github-hooks: true
+          permit-all: true
+          auto-close-on-fail: false
+          status-context: "ceph API tests"
+          started-status: "running API tests"
+          success-status: "ceph API tests succeeded"
+          failure-status: "ceph API tests failed"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph.git
+          branches:
+            - ${sha1}
+          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          shallow-clone: true
+          wipe-workspace: true
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+            - ../../../scripts/dashboard/install-backend-api-test-deps.sh
+      - shell: "cd src/pybind/mgr/dashboard; timeout 7200 ./run-backend-api-tests.sh"
+
+    wrappers:
+      - ansicolor


### PR DESCRIPTION
For the sake of simplicity (ceph-dashboard-backend-api vs. ceph-api) and
for spreading ownership of the Ceph API across teams, rename (currently
just a clone to minimize CI breakages) dashboard-backend-api to just
ceph-api.

- [ ] After this PR gets merged, update Ceph's `.github/pull_request_template.md` with the new trigger phrase (`jenkins test api`)
- [ ] Then, remove the old `ceph-dashboard-pr-backend` dir.

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>