### PR TITLE
ceph-ansible: split shrink_osd scenario

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -96,7 +96,8 @@
       - rgw_multisite
       - shrink_mon
       - shrink_mgr
-      - shrink_osd
+      - shrink_osd_multiple
+      - shrink_osd_single
       - shrink_osd_legacy
       - shrink_rgw
       - shrink_mds

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -909,6 +909,12 @@ case $SCENARIO in
   cephadm)
     TOX_INI_FILE=tox-cephadm.ini
     ;;
+  shrink_osd_single)
+    TOX_INI_FILE=tox-shrink_osd.ini
+    ;;
+  shrink_osd_multiple)
+    TOX_INI_FILE=tox-shrink_osd.ini
+    ;;
   *)
     TOX_INI_FILE=tox.ini
     ;;


### PR DESCRIPTION
This is for testing in two ways:

1/ shrinking OSDs one by one
2/ shrinking multiple OSDs with a single call of the playbook

Related ceph-ansible PR: ceph/ceph-ansible#5569

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>