### PR TITLE
ceph-dashboard-pr-backend: do not build/run tests for api tests

### DIFF
--- a/ceph-dashboard-pr-backend/build/build
+++ b/ceph-dashboard-pr-backend/build/build
@@ -3,6 +3,8 @@ n_build_jobs=$(get_nr_build_jobs)
 n_test_jobs=$(($(nproc) / 4))
 export CHECK_MAKEOPTS="-j${n_test_jobs} -N -Q"
 export BUILD_MAKEOPTS="-j${n_build_jobs}"
-timeout 3h ./run-make-check.sh
+export FOR_MAKE_CHECK=1
+timeout 2h ./src/script/run-make.sh \
+        --cmake-args '-DWITH_TESTS=OFF -DENABLE_GIT_VERSION=OFF'
 sleep 5
 ps -ef | grep ceph || true


### PR DESCRIPTION
as ceph-pull-requests already covers them.

Signed-off-by: Kefu Chai <kchai@redhat.com>