### PR TITLE
ceph-ansible-nightly: add new shrink_osd scenarios

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -45,7 +45,8 @@
       - update
       - lvm_osds
       - shrink_mon
-      - shrink_osd
+      - shrink_osd_multiple
+      - shrink_osd_single
       - lvm_batch
       - add_osds
       - rgw_multisite
@@ -78,7 +79,8 @@
       - update
       - lvm_osds
       - shrink_mon
-      - shrink_osd
+      - shrink_osd_multiple
+      - shrink_osd_single
       - lvm_batch
       - add_osds
       - rgw_multisite


### PR DESCRIPTION
This replaces the shrink_osd scenario by shrink_osd_multiple and
shrink_osd_single.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>