### PR TITLE
ceph*setup: Give ceph*build jobs permission to copy artifacts

### DIFF
--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -14,6 +14,8 @@
           artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph-ci
+      - copyartifact:
+          projects: ceph-dev-new-build
 
     parameters:
       - string:

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -14,6 +14,8 @@
           artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph
+      - copyartifact:
+          projects: ceph-dev-build
 
     parameters:
       - string:

--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -14,6 +14,8 @@
           artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph
+      - copyartifact:
+          projects: ceph-build
 
     parameters:
       - string:


### PR DESCRIPTION
This is a new setting in the newest CopyArtifact plugin.

https://stackoverflow.com/a/32084538/6225562

Signed-off-by: David Galloway <dgallowa@redhat.com>