### PR TITLE
Fixes to builder playbook

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -239,6 +239,12 @@
       with_items: "{{ ansible_all_ipv4_addresses }}"
       when: "item.startswith('172.21.')"
 
+    ## Let's make sure nodename gets set using our Sepia hostnames if the builder's in Sepia
+    - set_fact:
+        nodename: "{{ ansible_hostname }}"
+      with_items: "{{ ansible_all_ipv4_addresses }}"
+      when: "item.startswith('172.21.')"
+
     ## EPHEMERAL SLAVE TASKS
     # We would occasionally have issues with name resolution on the Ephemeral slaves
     # so we force them to use Google's DNS servers. This has to be done before

--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -659,8 +659,8 @@
         executable: "{{ pip_version }}"
 
     ## JENKINS SLAVE AGENT TASKS
-    # We use jnlp on ephemeral non-permanent slaves because ???
-    - name: Register the new slave to jenkins master with jnlp
+    # We use SSH for ephemeral slaves
+    - name: Register ephemeral slave using SSH
       jenkins_node:
         username: "{{ api_user }}"
         uri: "{{ api_uri }}"
@@ -672,7 +672,6 @@
         labels: "{{ labels }}"
         host: "{{ ansible_default_ipv4.address }}"
         credentialsId: "{{ jenkins_credentials_uuid }}"
-        launcher: 'hudson.slaves.JNLPLauncher'
         remoteFS: '/home/{{ jenkins_user }}/build'
         executors: '{{ executors|default(1) }}'
         exclusive: true
@@ -680,7 +679,7 @@
 
     - name: Register Permanent Slave
       block:
-        - name: Register the new slave to jenkins master with ssh
+        - name: Register permenant slave using JNLP
           jenkins_node:
             username: "{{ api_user }}"
             uri: "{{ api_uri }}"
@@ -692,6 +691,7 @@
             labels: "{{ labels }}"
             host: "{{ ansible_default_ipv4.address }}"
             credentialsId: "{{ jenkins_credentials_uuid }}"
+            launcher: 'hudson.slaves.JNLPLauncher'
             remoteFS: '/home/{{ jenkins_user }}/build'
             executors: '{{ executors|default(1) }}'
             exclusive: true


### PR DESCRIPTION
I think these are just leftover mistakes from when I combined all the playbooks.

They were working despite the JNLP/SSH flip-flop because I was only re-adding slaves.  I just tried adding net-new slaves and it tried to register builders in Sepia using SSH which obviously isn't going to work.