### PR TITLE
ceph-ansible: add back braggi node

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,6 +1,6 @@
 - project:
-    name: ceph-ansible-prs-smithi
-    slave_labels: 'centos7 && libvirt && smithi && vagrant'
+    name: ceph-ansible-prs-smithi-or-braggi
+    slave_labels: '(centos7 && smithi) || (centos8 && braggi) && libvirt && vagrant'
     distribution:
       - centos
     deployment:
@@ -35,6 +35,10 @@
       - lvm_batch
       - all_in_one
       - external_clients
+      - ooo_collocation
+    exclude:
+      - deployment: non_container
+        scenario: ooo_collocation
     jobs:
       - 'ceph-ansible-prs-auto'
 


### PR DESCRIPTION
This adds back braggi nodes for all_daemons based scenario.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>