### PR TITLE
ceph-ansible: do not play 'all_daemons' scenarios on braggi

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,6 +1,6 @@
 - project:
-    name: ceph-ansible-prs-smithi-or-braggi
-    slave_labels: '(centos7 && smithi) || (centos8 && braggi) && libvirt && vagrant'
+    name: ceph-ansible-prs-smithi
+    slave_labels: 'vagrant && libvirt && (smithi || centos7)'
     distribution:
       - centos
     deployment:


### PR DESCRIPTION
braggi nodes don't have enough resources to support these scenarios.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>