### PR TITLE
ceph-ansible: only use smithi nodes for all_daemons

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,6 +1,6 @@
 - project:
     name: ceph-ansible-prs-smithi
-    slave_labels: 'vagrant && libvirt && (smithi || centos7)'
+    slave_labels: 'vagrant && libvirt && smithi'
     distribution:
       - centos
     deployment:


### PR DESCRIPTION
Using `(smithi || centos7)` allows ovh slave nodes to be used for all
`all_daemons` based scenario which is not what we want since the latest
makes the playbook failing for these scenarios.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>