### PR TITLE
ceph-*pull-requests*: cancel job on PR update

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -27,6 +27,7 @@
 
     triggers:
       - github-pull-request:
+          cancel-builds-on-update: true
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph

--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -52,6 +52,7 @@
         wipe-workspace: true
     triggers:
     - github-pull-request:
+        cancel-builds-on-update: true
         allow-whitelist-orgs-as-admins: true
         org-list:
         - ceph

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -28,6 +28,7 @@
 
     triggers:
       - github-pull-request:
+          cancel-builds-on-update: true
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph


### PR DESCRIPTION
This should save quite a few resources, as right now if a PR is updated several times in a short lapse of time (typical case when the submitted realizes that they missed some files/changes...), the already started jobs will continue until finishing.

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>