### PR TITLE
install-e2e-test-deps.sh: Add libxss1 to debian distros

### DIFF
--- a/scripts/dashboard/install-e2e-test-deps.sh
+++ b/scripts/dashboard/install-e2e-test-deps.sh
@@ -13,7 +13,7 @@ if grep -q  debian /etc/*-release; then
     sudo apt-get install -y google-chrome-stable
     sudo apt-get install -y python-requests python3-requests python-openssl python3-openssl python-jinja2 python3-jinja2 \
 	python-jwt python3-jwt python-scipy python3-scipy python-routes python3-routes
-    sudo apt-get install -y xvfb
+    sudo apt-get install -y xvfb libxss1
     sudo rm /etc/apt/sources.list.d/google-chrome.list
 elif grep -q rhel /etc/*-release; then
     sudo dd of=/etc/yum.repos.d/google-chrome.repo status=none <<EOF


### PR DESCRIPTION
Cypress is failing due to a missing package.

Signed-off-by: Tiago Melo <tmelo@suse.com>