### PR TITLE
ceph*setup: Abbreviate the tag

### DIFF
--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -26,7 +26,7 @@ if [ -x "$BRANCH" ] ; then
     exit 1
 fi
 
-echo "Building version $(git describe) Branch $BRANCH"
+echo "Building version $(git describe --abbrev=8) Branch $BRANCH"
 
 rm -rf dist
 rm -rf release
@@ -96,7 +96,7 @@ mkdir -p release
 releasedir='release'
 versionfile='release/version'
 
-cephver=`git describe --match "v*" | sed s/^v//`
+cephver=`git describe --abbrev=8 --match "v*" | sed s/^v//`
 echo current version $cephver
 
 srcdir=`pwd`

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -19,7 +19,7 @@ if [ -x "$BRANCH" ] ; then
     exit 1
 fi
 
-echo "Building version $(git describe) Branch $BRANCH"
+echo "Building version $(git describe --abbrev=8) Branch $BRANCH"
 
 rm -rf dist
 rm -rf release
@@ -87,7 +87,7 @@ mkdir -p release
 releasedir='release'
 versionfile='release/version'
 
-cephver=`git describe --match "v*" | sed s/^v//`
+cephver=`git describe --abbrev=8 --match "v*" | sed s/^v//`
 echo current version $cephver
 
 srcdir=`pwd`

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -14,7 +14,7 @@ if [ -x "$BRANCH" ] ; then
     exit 1
 fi
 
-echo "Building version $(git describe) Branch $BRANCH"
+echo "Building version $(git describe --abbrev=8) Branch $BRANCH"
 
 rm -rf dist
 rm -rf release
@@ -74,7 +74,7 @@ mkdir -p release
 releasedir='release'
 versionfile='release/version'
 
-cephver=`git describe --match "v*" | sed s/^v//`
+cephver=`git describe --abbrev=8 --match "v*" | sed s/^v//`
 echo current version $cephver
 
 srcdir=`pwd`


### PR DESCRIPTION
I don't know what changed or when but `git describe` started returning a longer string *sometimes*.  Our tooling relies on there only being 8 characters in the last portion of the version so we need to keep naming our packages that way.

Signed-off-by: David Galloway <dgallowa@redhat.com>