### PR TITLE
ceph-api-nightly: Clean up after yourself

### DIFF
--- a/ceph-api-nightly/build/cleanup
+++ b/ceph-api-nightly/build/cleanup
@@ -1,0 +1,15 @@
+#!/bin/bash
+use_percentage=$(df -m ~ | grep -v Filesystem | awk '{ print $5 }' | cut -d '%' -f1)
+if [ $use_percentage -gt 90 ]; then
+  rm -rf ~/.ccache
+  for dir in $(ls ~/build/workspace/); do
+    # Used "${var}" instead of ${var+x} here because I also want to check if the string is empty
+    if [ -z "${dir}" ] || [ -z "${JOB_NAME}" ]; then
+      echo "Either \$dir or \$JOB_NAME aren't set.  Not cleaning up job directories."
+    else
+      if [ "$dir" != "$JOB_NAME" ]; then
+        rm -rf ~/build/workspace/$dir
+      fi
+    fi
+  done
+fi

--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -56,6 +56,9 @@
           wipe-workspace: true
 
     builders:
+      - shell:
+          !include-raw-escape:
+            - ../../build/cleanup
       - shell: "export NPROC=$(nproc); {ceph_build}"
       - shell:
           !include-raw:


### PR DESCRIPTION
This job has a bunch of templates.  Each one reaches 30-50GB in size which quickly fills up our builder home dirs.

Signed-off-by: David Galloway <dgallowa@redhat.com>