### PR TITLE
ansible: Start libvirt services on slave spinup

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -658,6 +658,29 @@
         version: 0.4.15
         executable: "{{ pip_version }}"
 
+    ## LIBVIRT SERVICE TASKS
+    - name: start DEB libvirt services
+      service:
+        name: "{{ item }}"
+        state: restarted
+      with_items:
+        - libvirt-bin
+        - libvirt-guests
+      when:
+        - libvirt|bool
+        - ansible_os_family == "Debian"
+
+    - name: start RPM libvirt services
+      service:
+        name: "{{ item }}"
+        state: restarted
+      with_items:
+        - libvirtd
+        - libvirt-guests
+      when:
+        - libvirt|bool
+        - ansible_os_family == "RedHat"
+
     ## JENKINS SLAVE AGENT TASKS
     # We use SSH for ephemeral slaves
     - name: Register ephemeral slave using SSH


### PR DESCRIPTION
I accidentally left these out when I combined all the slave playbooks.  It wasn't caught till now because I hadn't actually pulled the latest ceph-build.git on prado

Signed-off-by: David Galloway <dgallowa@redhat.com>