### PR TITLE
ansible: Pass API key to slave.jar as file

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -725,10 +725,13 @@
             dest: "/home/{{ jenkins_user }}/slave.jar"
             force: yes
 
-        - name: Install the systemd unit file for jenkins
+        - name: Install the systemd unit files for jenkins
           template:
-            src: "templates/systemd/jenkins.service.j2"
-            dest: "/etc/systemd/system/jenkins.service"
+            src: "templates/systemd/jenkins.{{ item }}.j2"
+            dest: "/etc/systemd/system/jenkins.{{ item }}"
+          with_items:
+            - service
+            - secret
 
         - name: Reload systemd unit files (to pick up potential changes)
           systemd:

--- a/ansible/templates/systemd/jenkins.secret.j2
+++ b/ansible/templates/systemd/jenkins.secret.j2
@@ -1,0 +1,1 @@
+{{ api_user }}:{{ token }}

--- a/ansible/templates/systemd/jenkins.service.j2
+++ b/ansible/templates/systemd/jenkins.service.j2
@@ -13,7 +13,7 @@ User={{ jenkins_user }}
 ExecStart=/usr/bin/java \
           -jar /home/{{ jenkins_user }}/slave.jar \
           -jnlpUrl {{ api_uri }}/computer/{{ ansible_default_ipv4.address }}+{{ nodename }}/slave-agent.jnlp \
-          -jnlpCredentials {{ api_user }}:{{ token }}
+          -jnlpCredentials @/etc/systemd/system/jenkins.secret
 StandardOutput=journal
 StandardError=journal
 Restart=always


### PR DESCRIPTION
vstart_runner.py runs 'ps ww' for the jenkins-build user.  This exposes the API key by showing the java.jar process in Jenkins logs.  If we pass the credentials as a file, there's less of a chance of it getting exposed.

Signed-off-by: David Galloway <dgallowa@redhat.com>