### PR TITLE
ansible: Don't follow symlinks

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -513,6 +513,7 @@
         owner: "{{ jenkins_user }}"
         group: "{{ jenkins_user }}"
         recurse: yes
+        follow: no
 
     ## DEBIAN GPG KEY TASKS
     - name: Install Debian GPG Keys on Ubuntu


### PR DESCRIPTION
Something in ceph.git creates an infinite loop that this task gets stuck on

Signed-off-by: David Galloway <dgallowa@redhat.com>