### PR TITLE
ceph-volume-pr: change nodes for tox testing

### DIFF
--- a/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-volume-pr
     display-name: 'ceph-volume: Pull Request tox tests'
-    node: python3
+    node: small && centos7
     project-type: freestyle
     defaults: global
     quiet-period: 5


### PR DESCRIPTION
We are currently running this job on a ubuntu xenial slave which run
python 3.5 where we need python 3.6.

Switching to these centos7 nodes that use python 3.6 should fix this
issue.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>