### PR TITLE
ceph-dev{-new}: add build names

### DIFF
--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -137,3 +137,6 @@
               credential-id: dmick-quay
               username: CONTAINER_REPO_USERNAME
               password: CONTAINER_REPO_PASSWORD
+      - build-name:
+          name: "#${BUILD_NUMBER} ${BRANCH}, ${DISTROS}, ${FLAVOR}"
+

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -137,3 +137,5 @@
               credential-id: dmick-quay
               username: CONTAINER_REPO_USERNAME
               password: CONTAINER_REPO_PASSWORD
+      - build-name:
+          name: "#${BUILD_NUMBER} ${BRANCH}, ${DISTROS}, ${FLAVOR}"

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -100,3 +100,5 @@ If this is checked, then the binaries will be built and pushed to chacra even if
       - inject-passwords:
           global: true
           mask-password-params: true
+      - build-name:
+          name: "#${BUILD_NUMBER} ${BRANCH}, ${DISTROS}, ${FLAVOR}"

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -100,3 +100,5 @@ If this is checked, then the binaries will be built and pushed to chacra even if
       - inject-passwords:
           global: true
           mask-password-params: true
+      - build-name:
+          name: "#${BUILD_NUMBER} ${BRANCH}, ${DISTROS}, ${FLAVOR}"


### PR DESCRIPTION
Name builds by their build number as well as branch, distros, and flavor,
for easier viewing on the Jenkins UI.  Uses a new-to-us jenkins plugin.

Signed-off-by: Dan Mick <dmick@redhat.com>