### PR TITLE
Grab SHA1 into parent job's environment for human or program

### DIFF
--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -15,7 +15,7 @@
       - github:
           url: https://github.com/ceph/ceph-ci
       - copyartifact:
-          projects: ceph-dev-new-build
+          projects: ceph-dev-new-build, ceph-dev-new
 
     parameters:
       - string:

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -88,6 +88,12 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - name: ceph-dev-new-setup
               current-parameters: true
               exposed-scm: false
+      - copyartifact:
+          project: ceph-dev-new-setup
+          filter: dist/sha1
+          which-build: multijob-build
+      - inject:
+          properties-file: ${WORKSPACE}/dist/sha1
       - multijob:
           name: 'ceph dev build phase'
           condition: SUCCESSFUL

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -15,7 +15,7 @@
       - github:
           url: https://github.com/ceph/ceph
       - copyartifact:
-          projects: ceph-dev-build
+          projects: ceph-dev-build, ceph-dev
 
     parameters:
       - string:

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -88,6 +88,12 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - name: ceph-dev-setup
               current-parameters: true
               exposed-scm: false
+      - copyartifact:
+          project: ceph-dev-setup
+          filter: dist/sha1
+          which-build: multijob-build
+      - inject:
+          properties-file: ${WORKSPACE}/dist/sha1
       - multijob:
           name: 'ceph dev build phase'
           condition: SUCCESSFUL


### PR DESCRIPTION
The Ceph SHA1 is divined by the -setup job, and not available in the
parent job.  That's easily fixed by the same method it's passed to the
-build job: grab the file artifact and use it to inject SHA1 into the
environment.  This means the parent job can show the SHA1 in its build
label for humans, and can also be searched by Jenkins API calls.

Signed-off-by: Dan Mick <dmick@redhat.com>