### PR TITLE
ceph-dev{,-new}: remove duplicated copyartifact actions

### DIFF
--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -88,12 +88,6 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - name: ceph-dev-new-setup
               current-parameters: true
               exposed-scm: false
-      - copyartifact:
-          project: ceph-dev-new-setup
-          filter: dist/sha1
-          which-build: multijob-build
-      - inject:
-          properties-file: ${WORKSPACE}/dist/sha1
       - multijob:
           name: 'ceph dev build phase'
           condition: SUCCESSFUL

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -88,12 +88,6 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - name: ceph-dev-setup
               current-parameters: true
               exposed-scm: false
-      - copyartifact:
-          project: ceph-dev-setup
-          filter: dist/sha1
-          which-build: multijob-build
-      - inject:
-          properties-file: ${WORKSPACE}/dist/sha1
       - multijob:
           name: 'ceph dev build phase'
           condition: SUCCESSFUL


### PR DESCRIPTION
they are already included by corresponding ceph-dev-build and
ceph-dev-new-build jobs.

Signed-off-by: Kefu Chai <kchai@redhat.com>