### PR TITLE
Fix intermittent error with last copyartifacts change

### DIFF
--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -15,7 +15,7 @@
       - github:
           url: https://github.com/ceph/ceph-ci
       - copyartifact:
-          projects: ceph-dev-new-build, ceph-dev-new
+          projects: /ceph-dev-new-build, /ceph-dev-new
 
     parameters:
       - string:

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -15,7 +15,7 @@
       - github:
           url: https://github.com/ceph/ceph
       - copyartifact:
-          projects: ceph-dev-build, ceph-dev
+          projects: /ceph-dev-build, /ceph-dev
 
     parameters:
       - string:


### PR DESCRIPTION
Apparently, sometimes, Jenkins can't find a toplevel job by "name", and
one must specify an "absolute path" to the job by prefixing "/".  This
was causing ceph-dev builds to fail to find ceph-dev-setup, but changing
to /ceph-dev-setup fixed the failure-to-find.  It didn't affect ceph-dev-new.
I've no idea why it affected one and not the other.

Signed-off-by: Dan Mick <dmick@redhat.com>