### PR TITLE
ceph: enable multibranch pipeline

### DIFF
--- a/ceph-multibranch-pipeline/config/definitions/ceph-multibranch-pipeline.yml
+++ b/ceph-multibranch-pipeline/config/definitions/ceph-multibranch-pipeline.yml
@@ -1,0 +1,18 @@
+---
+- job:
+    name: ceph-multibranch-pipeline
+    project-type: multibranch
+    number-to-keep: 300
+    days-to-keep: 30
+    scm:
+      - github:
+          repo: ceph
+          repo-owner: ceph
+          ssh-checkout:
+            credentials: 'jenkins-build'
+          credentials-id: 8cffdeb4-283c-4d96-a190-05d5645bcc2f
+          clean:
+            before: true
+          shallow-clone: true
+          do-not-fetch-tags: true
+          discover-pr-forks-trust: permission


### PR DESCRIPTION
* [Jenkins Job Builder Multibranch Pipeline](https://docs.openstack.org/infra/jenkins-job-builder/project_workflow_multibranch.html)

This change only enables the `Jenkinsfile` detection. For this to work, a `Jenkinsfile` needs to be added to `ceph/ceph`: https://github.com/ceph/ceph/pull/37425

So, it basically means that this change alone doesn't work. `Jenkinsfile` needs to propagate across branches & PRs to start seeing it (basically as soon as it hits a major branch, `master`/`octopus`/etc...).

## TODO
- [ ] Install [Jenkins Timeout Plugin](https://plugins.jenkins.io/build-timeout/) for [Timeout config](https://docs.openstack.org/infra/jenkins-job-builder/wrappers.html?highlight=timeout#wrappers.timeout). Timeouts could also be [set at different levels in `Jenkinsfile`s](https://www.jenkins.io/doc/book/pipeline/syntax/), but a max. global timeout should be set as a safeguard. 

## How it looks

### Main Jenkins page

#### BlueOcean

![image](https://user-images.githubusercontent.com/37327689/94458956-fcaffe00-01b6-11eb-8e27-7d974a6edecb.png)

#### Classic

Unlike regular jobs, Multibranch rather looks like a folder of jobs:

![image](https://user-images.githubusercontent.com/37327689/94458690-90cd9580-01b6-11eb-943f-eb37c30f9eab.png)

### Run details

#### BlueOcean

![image](https://user-images.githubusercontent.com/37327689/94459308-70eaa180-01b7-11eb-9cb2-c81dbeea5ebc.png)

#### Classic

![image](https://user-images.githubusercontent.com/37327689/94459460-a8594e00-01b7-11eb-847d-f559ad1d21d5.png)


Signed-off-by: Ernesto Puerta <epuertat@redhat.com>