### PR TITLE
ceph-dev, ceph-dev-new: copyartifact permission: no spaces

### DIFF
--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -15,7 +15,7 @@
       - github:
           url: https://github.com/ceph/ceph-ci
       - copyartifact:
-          projects: /ceph-dev-new-build, /ceph-dev-new
+          projects: ceph-dev-new-build,ceph-dev-new
 
     parameters:
       - string:

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -15,7 +15,7 @@
       - github:
           url: https://github.com/ceph/ceph
       - copyartifact:
-          projects: /ceph-dev-build, /ceph-dev
+          projects: ceph-dev-build,ceph-dev
 
     parameters:
       - string:


### PR DESCRIPTION
I don't see why from examining the plugin source, but it appears
that if you use both a comma and a space, the second entry will not
be found (as though the space is becoming part of the string for
comparison inside the plugin).  Stopping fighting and just letting it happen.

Signed-off-by: Dan Mick <dmick@redhat.com>