### PR TITLE
ceph-deploy-tag: use ceph-build:origin/master

### DIFF
--- a/ceph-deploy-build/build/build
+++ b/ceph-deploy-build/build/build
@@ -54,7 +54,11 @@ then
         fi
 
         # Create Tarball
-        python setup.py sdist --formats=bztar
+        if [ "$RELEASE" = 7 ]; then
+            python setup.py sdist --formats=bztar
+        else
+            python3 setup.py sdist --formats=bztar
+        fi
 
         # Build RPM
         mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}

--- a/ceph-deploy-build/build/build
+++ b/ceph-deploy-build/build/build
@@ -17,8 +17,8 @@ echo "  SHA1=$GIT_COMMIT"
 
 # FIXME A very naive way to just list the RPM $DIST that we currently support.
 # We should be a bit more lenient to allow any rhel/centos/sles/suse
-rpm_dists="rhel centos6 centos7 centos"
-deb_dists="precise wheezy squeeze trusty jessie"
+rpm_dists="rhel el7 centos7 el8 centos8 centos"
+deb_dists="xenial bionic focal stretch buster"
 
 # A helper to match an item in a list of items, like python's `if item in list`
 listcontains() {
@@ -79,13 +79,13 @@ then
 
     REPO=debian-repo
     COMPONENT=main
-    DEB_DIST="sid wheezy squeeze jessie precise raring trusty"
+    DEB_DIST="sid xenial bionic focal stretch buster"
     DEB_BUILD=$(lsb_release -s -c)
     #XXX only releases until we fix this
     RELEASE=1
     DISTRO=""
     case $DIST in
-        jessie|wheezy)
+        jessie|buster)
             DISTRO="debian"
             ;;
         *)

--- a/ceph-deploy-build/build/setup
+++ b/ceph-deploy-build/build/setup
@@ -11,9 +11,13 @@ set -e
 
 # TODO: use Mock to build ceph-deploy rpm's and avoid this
 
-rpm_deps="python-devel python-virtualenv python-mock python-tox pytest"
-
 if test -f /etc/redhat-release ; then
+    get_rpm_dist
+    if [ "$RELEASE" = 7 ]; then
+        rpm_deps="python-devel python-virtualenv python-mock python-tox pytest"
+    else
+        rpm_deps="python3-devel python3-virtualenv python3-mock python3-tox python3-pytest"
+    fi
     sudo yum install -y $rpm_deps
 fi
 

--- a/ceph-deploy-build/build/setup
+++ b/ceph-deploy-build/build/setup
@@ -24,5 +24,7 @@ fi
 pkgs=( "chacractl>=0.0.21" )
 install_python_packages "pkgs[@]"
 
+# ask shaman which chacra instance to use
+chacra_url=`curl -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
 # create the .chacractl config file using global variables
-make_chacractl_config
+make_chacractl_config $chacra_url

--- a/ceph-deploy-build/config/definitions/ceph-deploy-build.yml
+++ b/ceph-deploy-build/config/definitions/ceph-deploy-build.yml
@@ -30,8 +30,9 @@
           type: label-expression
           name: DIST
           values:
-            - xenial
+            - bionic
             - centos7
+            - centos8
 
     builders:
       - shell:

--- a/ceph-deploy-build/config/definitions/ceph-deploy-build.yml
+++ b/ceph-deploy-build/config/definitions/ceph-deploy-build.yml
@@ -45,3 +45,10 @@
       - inject-passwords:
           global: true
           mask-password-params: true
+      - credentials-binding:
+          - text:
+              credential-id: chacractl-key
+              variable: CHACRACTL_KEY
+          - text:
+              credential-id: shaman-api-key
+              variable: SHAMAN_API_KEY

--- a/ceph-deploy-tag/config/definitions/ceph-tag.yml
+++ b/ceph-deploy-tag/config/definitions/ceph-tag.yml
@@ -8,6 +8,8 @@
           skip-tag: true
           wipe-workspace: true
           basedir: "ceph-build"
+          branches:
+            - origin/master
 
 - job:
     name: ceph-deploy-tag

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -239,25 +239,29 @@ get_rpm_dist() {
 
     case $ID in
     RedHatEnterpriseServer)
-        DISTRO_VERSION=`$LSB_RELEASE --short --release | cut -d. -f1`
+        RELEASE=`$LSB_RELEASE --short --release | cut -d. -f1`
+        DIST=rhel$RELEASE
         DISTRO=rhel
         ;;
     CentOS)
-        DISTRO_VERSION=`$LSB_RELEASE --short --release | cut -d. -f1`
+        RELEASE=`$LSB_RELEASE --short --release | cut -d. -f1`
+        DIST=el$RELEASE
         DISTRO=centos
         ;;
     Fedora)
-        DISTRO_VERSION=`$LSB_RELEASE --short --release`
+        RELEASE=`$LSB_RELEASE --short --release`
         DISTRO=fedora
         ;;
     SUSE\ LINUX|openSUSE)
         DESC=`$LSB_RELEASE --short --description`
-        DISTRO_VERSION=`$LSB_RELEASE --short --release`
+        RELEASE=`$LSB_RELEASE --short --release`
         case $DESC in
         *openSUSE*)
+                DIST=opensuse$RELEASE
                 DISTRO=opensuse
             ;;
         *Enterprise*)
+                DIST=sles$RELEASE
                 DISTRO=sles
                 ;;
             esac
@@ -267,7 +271,8 @@ get_rpm_dist() {
         DISTRO=unknown
         ;;
     esac
-
+    DISTRO_VERSION=$RELEASE
+    echo $DIST
 }
 
 check_binary_existence () {
@@ -1086,51 +1091,6 @@ maybe_reset_ci_container() {
         echo "disabling CI container build for $BRANCH"
         CI_CONTAINER=false
     fi
-}
-
-get_rpm_dist() {
-    LSB_RELEASE=/usr/bin/lsb_release
-    [ ! -x $LSB_RELEASE ] && echo unknown && exit
-
-    ID=`$LSB_RELEASE --short --id`
-
-    case $ID in
-    RedHatEnterpriseServer)
-        RELEASE=`$LSB_RELEASE --short --release | cut -d. -f1`
-        DIST=rhel$RELEASE
-        DISTRO=rhel
-        ;;
-    CentOS)
-        RELEASE=`$LSB_RELEASE --short --release | cut -d. -f1`
-        DIST=el$RELEASE
-        DISTRO=centos
-        ;;
-    Fedora)
-        RELEASE=`$LSB_RELEASE --short --release`
-        DIST=fc$RELEASE
-        DISTRO=fedora
-        ;;
-    SUSE\ LINUX)
-        DESC=`$LSB_RELEASE --short --description`
-        RELEASE=`$LSB_RELEASE --short --release`
-        case $DESC in
-        *openSUSE*)
-                DIST=opensuse$RELEASE
-                DISTRO=opensuse
-            ;;
-        *Enterprise*)
-                DIST=sles$RELEASE
-                DISTRO=sles
-                ;;
-            esac
-        ;;
-    *)
-        DIST=unknown
-        DISTRO=unknown
-        ;;
-    esac
-
-    echo $DIST
 }
 
 setup_rpm_build_deps() {


### PR DESCRIPTION
otherwise it fails when trying to use the release.yml playbook:

ERROR! the playbook: release.yml could not be found
Build step 'Execute shell' marked build as failure

Signed-off-by: Kefu Chai <kchai@redhat.com>