### PR TITLE
ceph-ansible: remove ooo_collocation

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -18,15 +18,12 @@
       - add_osds
       - rgw_multisite
       - purge
-      - ooo_collocation
       - switch_to_containers
     ceph_ansible_branch:
       - stable-3.2
     jobs:
         - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
     exclude:
-      - deployment: non_container
-        scenario: ooo_collocation
       - deployment: container
         scenario: switch_to_containers
 
@@ -52,15 +49,12 @@
       - rgw_multisite
       - purge
       - lvm_auto_discovery
-      - ooo_collocation
       - switch_to_containers
     ceph_ansible_branch:
       - stable-4.0
     jobs:
         - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
     exclude:
-      - deployment: non_container
-        scenario: ooo_collocation
       - deployment: container
         scenario: switch_to_containers
 
@@ -86,15 +80,12 @@
       - rgw_multisite
       - purge
       - lvm_auto_discovery
-      - ooo_collocation
       - switch_to_containers
     ceph_ansible_branch:
       - stable-5.0
     jobs:
         - 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
     exclude:
-      - deployment: non_container
-        scenario: ooo_collocation
       - deployment: container
         scenario: switch_to_containers
 

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -15,8 +15,6 @@
       - deployment: container
         scenario: switch_to_containers
       - deployment: non_container
-        scenario: ooo_collocation
-      - deployment: non_container
         scenario: podman
     jobs:
       - 'ceph-ansible-prs-auto'
@@ -35,10 +33,6 @@
       - lvm_batch
       - all_in_one
       - external_clients
-      - ooo_collocation
-    exclude:
-      - deployment: non_container
-        scenario: ooo_collocation
     jobs:
       - 'ceph-ansible-prs-auto'
 


### PR DESCRIPTION
This job is not needed anymore, we already have 'collocation' for that.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>