### PR TITLE
ceph-pr-commits: Allow empty junit results

### DIFF
--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -78,3 +78,4 @@
     publishers:
       - junit:
           results: report.xml
+          allow-empty-results: true


### PR DESCRIPTION
report.xml wasn't getting written for docs-only changes because the job `exit 0`s.  The junit plugin was failing the build in those instances but we don't need or want it to.

Signed-off-by: David Galloway <dgallowa@redhat.com>