### PR TITLE
ceph-perf-pull-requests: s/source/./

### DIFF
--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -85,7 +85,7 @@
           archive_dir_master={archive-master}/$(git rev-parse --short HEAD)
           cd ${{WORKSPACE}}/{src-dir-pr}
           archive_dir_pr={archive-pr}/$(git rev-parse --short HEAD)
-          source ${{WORKSPACE}}/gh-venv/bin/activate
+          . ${{WORKSPACE}}/gh-venv/bin/activate
           ${{WORKSPACE}}/cbt/compare.py -v \
             -a $archive_dir_pr             \
             -b $archive_dir_master         \


### PR DESCRIPTION
turns out we have ubuntu test nodes labeled with "performance", and
they use dash for "sh", and jenkins use "sh" for running the embedded
scripts.

let's avoid bashism, and use "." instead.

this change is a follow-up of 4e0a8987c7d19004d33c153b107057f684b547de

Signed-off-by: Kefu Chai <kchai@redhat.com>