### PR TITLE
ceph-pr-commits: Stop using junit plugin

### DIFF
--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -74,8 +74,3 @@
           !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
-
-    publishers:
-      - junit:
-          results: report.xml
-          allow-empty-results: true


### PR DESCRIPTION
It's not really useful for this mostly inconsequential job and it's causing job failures.

Signed-off-by: David Galloway <dgallowa@redhat.com>