### PR TITLE
ceph-pr-commits: Use sha1 instead of GIT_COMMIT

### DIFF
--- a/ceph-pr-commits/build/build
+++ b/ceph-pr-commits/build/build
@@ -6,8 +6,8 @@
 # this job/check is required, it hung with 'Expected — Waiting for status to be reported'
 pushd .
 cd "$WORKSPACE/ceph"
-if git rev-parse --verify ${GIT_COMMIT}^2; then
-     files="$(git diff --name-only ${GIT_COMMIT}^1...${GIT_COMMIT}^2)"
+if git rev-parse --verify ${sha1}^2; then
+     files="$(git diff --name-only ${sha1}^1...${sha1}^2)"
      echo -e "changed files:\n$files"
      if [ $(echo "$files" | grep -v '^doc/' | wc -l) -gt 0 ]; then
          echo "Not a docs only change.  Will proceed with signed commit check."


### PR DESCRIPTION
I think GIT_COMMIT is the merge commit.  Everything Kefu and I could find indicated it should be valid to use here but it doesn't work in some instances.

Switching to ${sha1} works though.

Signed-off-by: David Galloway <dgallowa@redhat.com>