### PR TITLE
ceph-dev-build: Change build path for Leap builds

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -498,7 +498,7 @@
         block: |
           [general]
           apiurl = https://api.opensuse.org
-          #build-root = /var/tmp/build-root/%(repo)s-%{arch)s
+          build-root = /home/{{ jenkins_user }}/osc/%(repo)s-%{arch)s
           [https://api.opensuse.org]
           user = {{ osc_user }}
           pass = {{ osc_pass }}

--- a/ceph-dev-build/build/build_osc
+++ b/ceph-dev-build/build/build_osc
@@ -25,7 +25,7 @@ esac
 
 OBSPROJ="filesystems:ceph:$RELEASE_BRANCH:upstream"
 OBSARCH="x86_64"
-BUILDHOME=/var/tmp/build-root/$OBSREPO-$OBSARCH/home/abuild
+BUILDHOME=$HOME/osc/$OBSREPO-$OBSARCH/home/abuild
 
 rm -rf $OBSPROJ
 osc co $OBSPROJ


### PR DESCRIPTION
Previously, packages were being written to `/var/tmp` which does not live on the intended 1TB SSD.

Signed-off-by: David Galloway <dgallowa@redhat.com>