### PR TITLE
ceph-container-lint: use --rm docker option

### DIFF
--- a/ceph-container-lint/build/build
+++ b/ceph-container-lint/build/build
@@ -25,7 +25,7 @@ function check(){
     while read -r filename; do
         pushd "$(dirname "$filename")"
         file=$(basename "$filename")
-        sudo docker run -v "$(pwd)"/"$file":/"$file":z koalaman/shellcheck --external-sources --exclude "$IGNORE_THESE_CODES" /"$file"
+        sudo docker run --rm -v "$(pwd)"/"$file":/"$file":z koalaman/shellcheck --external-sources --exclude "$IGNORE_THESE_CODES" /"$file"
         popd
     done
     return $?


### PR DESCRIPTION
The container lint job, which run shellcheck in a docker container,
doesn't use the --rm docker option so the container aren't removed
after their execution.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>