### PR TITLE
ceph-container-flake8: add selinux flag to volume

### DIFF
--- a/ceph-container-flake8/build/build
+++ b/ceph-container-flake8/build/build
@@ -21,7 +21,7 @@ function check(){
     while read -r filename; do
         pushd "$(dirname "$filename")"
         file=$(basename "$filename")
-        sudo docker run --rm -v "$workspace"/ceph-container/tox.ini:/tox.ini -v "$(pwd)"/"$file":/"$file" eeacms/flake8 /"$file"
+        sudo docker run --rm -v "$workspace"/ceph-container/tox.ini:/tox.ini:z -v "$(pwd)"/"$file":/"$file":z eeacms/flake8 /"$file"
         popd
     done
     return $?


### PR DESCRIPTION
Without the selinux flag on the container volume, the flake8 command
fails with:

```console
E902 IOError: [Errno 13] Permission denied: '/envglobals.py'
```

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>