### PR TITLE
ceph-*-setup: use default allocator for crimson flavor

### DIFF
--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -79,7 +79,7 @@ case "${FLAVOR}" in
     crimson)
         echo "Detected crimson flavor: will use flag: -DWITH_SEASTAR=ON"
         CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
-        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DWITH_SEASTAR=ON -DSeastar_CXX_FLAGS=-DSEASTAR_DEFAULT_ALLOCATOR"
+        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DWITH_SEASTAR=ON"
         ;;
     *)
         echo "unknown FLAVOR: ${FLAVOR}" >&2

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -50,7 +50,7 @@ case "${FLAVOR}" in
         ;;
     crimson)
         CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
-        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DWITH_SEASTAR=ON -DSeastar_CXX_FLAGS=-DSEASTAR_DEFAULT_ALLOCATOR"
+        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DWITH_SEASTAR=ON"
         ;;
     *)
         echo "unknown FLAVOR: ${FLAVOR}" >&2


### PR DESCRIPTION
since we've merged https://github.com/ceph/ceph/pull/37887

This reverts commit 3aa35a92b466212c0c3c715781a8aab8a5e0136c.