### PR TITLE
ansible: fix osc build-root typo for opensuse worker

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -498,7 +498,7 @@
         block: |
           [general]
           apiurl = https://api.opensuse.org
-          build-root = /home/{{ jenkins_user }}/osc/%(repo)s-%{arch)s
+          build-root = /home/{{ jenkins_user }}/osc/%(repo)s-%(arch)s
           [https://api.opensuse.org]
           user = {{ osc_user }}
           pass = {{ osc_pass }}


### PR DESCRIPTION
This PR fixes unfortunate typo which I missed during review of the #1685