### PR TITLE
ceph-dev*build: Pull centos images from our registry mirror

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -24,6 +24,7 @@
     - grant_sudo: true
     - osc_user: 'username'
     - osc_pass: 'password'
+    - insecure_registry: 'docker-mirror.front.sepia.ceph.com:5000'
 
   tasks:
     ## DEFINE PACKAGE LISTS BELOW
@@ -167,6 +168,7 @@
           - python-devel
           - python-virtualenv
           - mock
+          - docker
       when:
         - ansible_os_family == "RedHat"
         - ansible_distribution_major_version|int <= 7
@@ -179,6 +181,7 @@
           - python3-devel
           - python3-virtualenv
           - mock
+          - podman
       when:
         - ansible_os_family == "RedHat"
         - ansible_distribution_major_version|int >= 8
@@ -681,6 +684,42 @@
       when:
         - libvirt|bool
         - ansible_os_family == "RedHat"
+
+    ## CONTAINER SERVICE TASKS
+    - name: Container Tasks
+      block:
+        - name: Allow nodes to use an insecure registry - docker
+          copy:
+            dest: /etc/docker/daemon.json
+            content: |
+              {
+                "insecure-registries": ["{{ insecure_registry }}"]
+              }
+          when: ansible_distribution_major_version|int <= 7
+
+        - name: Restart docker service
+          service:
+            name: docker
+            state: restarted
+          when: ansible_distribution_major_version|int <= 7
+
+        - name: allow nodes to use an insecure registry - podman | location
+          ini_file:
+            path: /etc/containers/registries.conf
+            section: "[registry]"
+            option: location
+            value: "\"{{ insecure_registry }}\""
+          when: ansible_distribution_major_version|int >= 8
+
+        - name: allow nodes to use an insecure registry - podman | insecure
+          ini_file:
+            path: /etc/containers/registries.conf
+            section: "[registry]"
+            option: insecure
+            value: "true"
+          when: ansible_distribution_major_version|int >= 8
+      when: ansible_os_family == "RedHat"
+      tags: container
 
     ## JENKINS SLAVE AGENT TASKS
     # We use SSH for ephemeral slaves

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -90,8 +90,10 @@ if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" && $FLAVOR != "notcmalloc" 
       # exit 1
     fi
 
+    use_internal_container_registry
+
     cd $WORKSPACE/ceph-container
-    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} OSD_FLAVOR=${FLAVOR} CONTAINER_FLAVOR=${BRANCH},${DISTRO},${RELEASE} \
+    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} OSD_FLAVOR=${FLAVOR} CONTAINER_FLAVOR=${BRANCH},${DISTRO},${RELEASE} BASEOS_REGISTRY=${REGISTRY} \
       /bin/bash ./contrib/build-push-ceph-container-imgs.sh
     cd $WORKSPACE
     sudo rm -rf ceph-container

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -92,8 +92,10 @@ if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $FLAVOR != "notcmalloc" 
       # exit 1
     fi
 
+    use_internal_container_registry
+
     cd $WORKSPACE/ceph-container
-    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} OSD_FLAVOR=${FLAVOR} CONTAINER_FLAVOR=${BRANCH},${DISTRO},${RELEASE} \
+    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} OSD_FLAVOR=${FLAVOR} CONTAINER_FLAVOR=${BRANCH},${DISTRO},${RELEASE} BASEOS_REGISTRY=${REGISTRY} \
       /bin/bash ./contrib/build-push-ceph-container-imgs.sh
     cd $WORKSPACE
     sudo rm -rf ceph-container

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1287,3 +1287,12 @@ EOF
                  ${build_area}/SPECS/ceph-release.spec
     fi
 }
+
+# dockerhub started aggressively rate limiting in November 2020. We can use an internal docker mirror if the builder is in the upstream lab.
+use_internal_container_registry() {
+  if ping -c 1 docker-mirror.front.sepia.ceph.com; then
+    REGISTRY="docker-mirror.front.sepia.ceph.com:5000/library"
+  else
+    REGISTRY="docker.io"
+  fi
+}


### PR DESCRIPTION
Since docker started rate limiting on Nov2, we've often seen errors that we hit our `pull` limit.  This should greatly reduce the number of times we're going to docker.io.  Only ephemeral builders would pull from docker.io once this is merged and those builders' IP changes when they're spun up so we don't really need to worry about maxing out that IP's `pull` limit.

Signed-off-by: David Galloway <dgallowa@redhat.com>