### PR TITLE
ceph-dev-*-build: reset CI_CONTAINER when building octopus for el7

### DIFF
--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -6,6 +6,8 @@ set -ex
 # set of shell scripts and repos involved.
 CI_CONTAINER=${CI_CONTAINER:-false}
 
+maybe_reset_ci_container
+
 # create a release directory for ceph-build tools
 mkdir -p release
 cp -a dist release/${vers}

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -7,6 +7,8 @@ set -ex
 # set of shell scripts and repos involved.
 CI_CONTAINER=${CI_CONTAINER:-false}
 
+maybe_reset_ci_container
+
 # create a release directory for ceph-build tools
 mkdir -p release
 cp -a dist release/${vers}

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1287,3 +1287,13 @@ EOF
                  ${build_area}/SPECS/ceph-release.spec
     fi
 }
+
+maybe_reset_ci_container() {
+    if ! "$CI_CONTAINER"; then
+        return
+    fi
+    if [[ "$BRANCH" =~ octopus && "$DIST" == centos7 ]]; then
+        echo "disabling CI container build for $BRANCH"
+        CI_CONTAINER=false
+    fi
+}


### PR DESCRIPTION
because the consumers of ceph container images are referencing the
required images using
"${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/ceph:${SHA1}".
see ceph-container/contrib/build-push-ceph-container-imgs.sh.

but in a recent change, we push both the images built for el7 and for
el8 with the same tag. and the last one wins. this breaks the tests
which expect the cephadm and other tools included in an image built for
el8. but these tools are not included by el7 because of the missing
dependencies.

so we have at least two options

- stop building octopus+el7 container images
- use a different tag for octopus+el7 to avoid the racing and name collision.

before the 2nd change lands on ceph-container, we should have the 1st
one in ceph-build to unblock the builds of octopus.

Fixes: https://tracker.ceph.com/issues/48162
Signed-off-by: Kefu Chai <kchai@redhat.com>