### PR TITLE
ceph-dev-new-trigger: disable leap15 for nautilus

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -79,7 +79,7 @@
                     DISTROS=centos7
                     FLAVOR=notcmalloc
       # build nautilus on:
-      # default: bionic xenial centos7 centos8 leap15
+      # default: bionic xenial centos7 centos8
       # notcmalloc: centos7
       - conditional-step:
           condition-kind: regex-match
@@ -96,7 +96,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=bionic xenial centos7 centos8 leap15
+                    DISTROS=bionic xenial centos7 centos8
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -88,7 +88,7 @@
                     DISTROS=centos7
                     FLAVOR=notcmalloc
       # build nautilus on:
-      # default: bionic xenial centos7 centos8 leap15
+      # default: bionic xenial centos7 centos8
       # notcmalloc: centos7
       - conditional-step:
           condition-kind: regex-match
@@ -105,7 +105,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=bionic xenial centos7 centos8 leap15
+                    DISTROS=bionic xenial centos7 centos8
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}


### PR DESCRIPTION
We do not need for now opensuse-15.1 builds, since
support of it is limited.

The current version of Leap is 15.2 and the 15.1
is going to be EOL, thus we are not going to spend
resources on it.

We can disable it back if required in future.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>