### PR TITLE
ceph-container: inject registry credentials

### DIFF
--- a/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
+++ b/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
@@ -53,6 +53,16 @@
             - ../../../scripts/build_utils.sh
             - ../../build/build
 
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: docker-hub-leseb
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD
+
     publishers:
       - postbuildscript:
           builders:

--- a/ceph-container-prs/config/definitions/ceph-container-prs.yml
+++ b/ceph-container-prs/config/definitions/ceph-container-prs.yml
@@ -69,6 +69,16 @@
             - ../../../scripts/build_utils.sh
             - ../../build/build
 
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: docker-hub-leseb
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD
+
     publishers:
       - postbuildscript:
           builders:
@@ -140,6 +150,16 @@
           !include-raw-escape:
             - ../../../scripts/build_utils.sh
             - ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: docker-hub-leseb
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD
 
     publishers:
       - postbuildscript:


### PR DESCRIPTION
To avoid docker hub rate limit, we should use the authenticate docker
hub user like we're currently using in the build and publish jobs.
This adds the credentials for both ceph-container-prs and
ceph-container-nightly jobs.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>