### PR TITLE
scripts/build_utils.sh: use correct DIST value for el7

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1292,7 +1292,7 @@ maybe_reset_ci_container() {
     if ! "$CI_CONTAINER"; then
         return
     fi
-    if [[ "$BRANCH" =~ octopus && "$DIST" == centos7 ]]; then
+    if [[ "$BRANCH" =~ octopus && "$DIST" == el7 ]]; then
         echo "disabling CI container build for $BRANCH"
         CI_CONTAINER=false
     fi


### PR DESCRIPTION
Fixes a3f26c8ab781a5ffe54aedf45be9e373bede4d6c, which ended up
comparing [[ el7 == centos7 ]].

Follow-on fix for: https://tracker.ceph.com/issues/48162
Signed-off-by: Neha Ojha <nojha@redhat.com>