### PR TITLE
ceph-pr,api-pr: skip when not needed

### DIFF
--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -48,6 +48,25 @@
           started-status: "running API tests"
           success-status: "ceph API tests succeeded"
           failure-status: "ceph API tests failed"
+          exclude-region:
+            ^.github/
+            ^admin/
+            ^ceph-menv
+            ^doc/
+            ^etc/
+            ^examples/
+            ^fusetrace/
+            ^keys/
+            ^man/
+            ^mirroring/
+            ^selinux/
+            ^share/
+            ^sudoers.d/
+            ^systemd/
+            ^udev/
+            \.rst$
+            \.txt$
+            \.md$
 
     scm:
       - git:

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -45,6 +45,26 @@
           started-status: "running make check"
           success-status: "make check succeeded"
           failure-status: "make check failed"
+          exclude-region:
+            ^.github/
+            ^admin/
+            ^ceph-menv
+            ^doc/
+            ^etc/
+            ^examples/
+            ^fusetrace/
+            ^keys/
+            ^man/
+            ^mirroring/
+            ^qa/
+            ^selinux/
+            ^share/
+            ^sudoers.d/
+            ^systemd/
+            ^udev/
+            \.rst$
+            \.txt$
+            \.md$
 
     scm:
       - git:


### PR DESCRIPTION
Skip running make-check and ceph-api tests when the PR only contains
changes in certain dirs (doc/, .github/) or certain extensions (.rst,
.md, .txt). In any case, a Jenkins job can still be manually triggered
(`jenkins test...`).

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>