### PR TITLE
ceph-pr,api-pr: skip when not needed 2/2

### DIFF
--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -48,25 +48,25 @@
           started-status: "running API tests"
           success-status: "ceph API tests succeeded"
           failure-status: "ceph API tests failed"
-          exclude-region:
-            ^.github/
-            ^admin/
-            ^ceph-menv
-            ^doc/
-            ^etc/
-            ^examples/
-            ^fusetrace/
-            ^keys/
-            ^man/
-            ^mirroring/
-            ^selinux/
-            ^share/
-            ^sudoers.d/
-            ^systemd/
-            ^udev/
-            \.rst$
-            \.txt$
-            \.md$
+          excluded-regions:
+            - ^.github/
+            - ^admin/
+            - ^ceph-menv/
+            - ^doc/
+            - ^etc/
+            - ^examples/
+            - ^fusetrace/
+            - ^keys/
+            - ^man/
+            - ^mirroring/
+            - ^selinux/
+            - ^share/
+            - ^sudoers.d/
+            - ^systemd/
+            - ^udev/
+            - \.rst$
+            - \.txt$
+            - \.md$
 
     scm:
       - git:

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -45,26 +45,25 @@
           started-status: "running make check"
           success-status: "make check succeeded"
           failure-status: "make check failed"
-          exclude-region:
-            ^.github/
-            ^admin/
-            ^ceph-menv
-            ^doc/
-            ^etc/
-            ^examples/
-            ^fusetrace/
-            ^keys/
-            ^man/
-            ^mirroring/
-            ^qa/
-            ^selinux/
-            ^share/
-            ^sudoers.d/
-            ^systemd/
-            ^udev/
-            \.rst$
-            \.txt$
-            \.md$
+          excluded-regions:
+            - ^.github/
+            - ^admin/
+            - ^ceph-menv/
+            - ^doc/
+            - ^etc/
+            - ^examples/
+            - ^fusetrace/
+            - ^keys/
+            - ^man/
+            - ^mirroring/
+            - ^selinux/
+            - ^share/
+            - ^sudoers.d/
+            - ^systemd/
+            - ^udev/
+            - \.rst$
+            - \.txt$
+            - \.md$
 
     scm:
       - git:


### PR DESCRIPTION
...now with proper syntax.

Proof:
`jenkins-jobs --ignore-cache --conf ~/.jenkins_jobs.jenkins.ceph.com.ini update ceph-pull-requests/config/definitions/ceph-pull-requests.yml`

![image](https://user-images.githubusercontent.com/37327689/99300488-f4864d80-284c-11eb-8cca-cc211828898f.png)

Let's see if the regex patterns work as expected!

Fixes: https://github.com/ceph/ceph-build/pull/1705
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>