### PR TITLE
ceph*build: Login to docker.io if needed

### DIFF
--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -137,6 +137,10 @@
               credential-id: dmick-quay
               username: CONTAINER_REPO_USERNAME
               password: CONTAINER_REPO_PASSWORD
+          - username-password-separated:
+              credential-id: dgalloway-docker-hub
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD
       - build-name:
           name: "#${BUILD_NUMBER} ${BRANCH}, ${SHA1}, ${DISTROS}, ${FLAVOR}"
 

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -137,5 +137,9 @@
               credential-id: dmick-quay
               username: CONTAINER_REPO_USERNAME
               password: CONTAINER_REPO_PASSWORD
+          - username-password-separated:
+              credential-id: dgalloway-docker-hub
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD
       - build-name:
           name: "#${BUILD_NUMBER} ${BRANCH}, ${SHA1}, ${DISTROS}, ${FLAVOR}"

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1304,6 +1304,9 @@ use_internal_container_registry() {
   if curl -s "https://docker-mirror.front.sepia.ceph.com:5000"; then
     REGISTRY="docker-mirror.front.sepia.ceph.com:5000/library"
   else
+    if [ -n "${DOCKER_HUB_USERNAME}" ] && [ -n "${DOCKER_HUB_PASSWORD}" ]; then
+      docker login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}" docker.io
+    fi
     REGISTRY="docker.io"
   fi
 }


### PR DESCRIPTION
We ran into an issue today where the internal mirror was temporarily unavailable.  The job fell back to docker.io and despite the fact that we're not using it all that much, we still got rate limited.  I suspect other tenants in the Community Cage are still pulling from docker.io anonymously.

This PR will have us login (with a higher rate-limit).

Signed-off-by: David Galloway <dgallowa@redhat.com>