### PR TITLE
ceph-volume: fix nautilus PRs job

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -30,6 +30,10 @@ else
     CEPH_ANSIBLE_BRANCH="master"
 fi
 
+if [[ "$ghprbTargetBranch" == "nautilus" ]]; then
+    DISTRO="centos7"
+fi
+
 CEPH_ANSIBLE_BRANCH=$CEPH_ANSIBLE_BRANCH CEPH_DEV_BRANCH=$ghprbTargetBranch $VENV/tox --workdir=$WORKDIR -vre $DISTRO-$OBJECTSTORE-$SCENARIO -- --provider=libvirt
 
 GITHUB_STATUS_STATE="success" $VENV/github-status create


### PR DESCRIPTION
ceph-volume PRs against nautilus are failing for a while because it
tries to run against centos8 while the tox environment only defines
centos7 environments.

Let's enforce `DISTRO` environment variable when `ghprbTargetBranch` is
`nautilus` so we override the environment variable injected by Jenkins.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>