### PR TITLE
build_utils: curl docker-mirror insecurely

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1301,7 +1301,7 @@ maybe_reset_ci_container() {
 
 # dockerhub started aggressively rate limiting in November 2020. We can use an internal docker mirror if the builder is in the upstream lab.
 use_internal_container_registry() {
-  if curl -s "https://docker-mirror.front.sepia.ceph.com:5000"; then
+  if curl -s -k "https://docker-mirror.front.sepia.ceph.com:5000"; then
     REGISTRY="docker-mirror.front.sepia.ceph.com:5000/library"
   else
     REGISTRY="docker.io"


### PR DESCRIPTION
I had initially planned on installing the self-signed cert globally but that was not advised.  See https://github.com/ceph/ceph-build/pull/1698#issuecomment-725840305

So we should curl insecurely.

Signed-off-by: David Galloway <dgallowa@redhat.com>