### PR TITLE
ceph-ansible: disable update scenario on octopus

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -34,4 +34,7 @@ rm -rf $HOME/ansible/facts/*
 [[ "$ghprbTargetBranch" =~ stable-4.0|stable-3 && "$SCENARIO" =~ cephadm|cephadm_adopt ]] ||
 [[ "$ghprbTargetBranch" != stable-3.2 && "$SCENARIO" == shrink_osd_legacy ]] ||
 [[ "$ghprbTargetBranch" =~ stable-3 && "$SCENARIO" == filestore_to_bluestore ]] ||
+[[ "$ghprbTargetBranch" == stable-5.0 && "$SCENARIO" == update ]] ||
 start_tox
+
+# Update scenario on stable-5.0 must be enabled back once 15.2.8 is out


### PR DESCRIPTION
`ceph-volume simple scan` in octopus is broken and make the upgrade
testing scenario failing.
Until 15.2.8 is out, which will be the next release including the fix
for this. We can't make this scenario passing the CI.
Let's disable it temporarily.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>