### PR TITLE
ceph-{api,dashboard}-pr: fix source branch ref

### DIFF
--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -53,7 +53,7 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - ${sha1}
+            - origin/pr/${ghprbPullId}/merge
           refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
           browser: auto
           timeout: 20

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -72,7 +72,7 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - ${sha1}
+            - origin/pr/${ghprbPullId}/merge
           refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
           browser: auto
           timeout: 20


### PR DESCRIPTION
Applying same change as already applied by
https://github.com/ceph/ceph-build/pull/1426. A divergence has been
observed between `make check` job (ceph-pull-request) and the `make` in
ceph-pr-api job. For the same PR:

* ceph-pull-request `make check` passes
* ceph-pr-api `make` fails

This fix has been suggested by @sebastian-philipp

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>