### PR TITLE
scripts/build_utils: do not add tchaikov/gcc-toolset-9 copr repo anymore

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1238,9 +1238,6 @@ setup_rpm_build_deps() {
     if [ "$FLAVOR" = "crimson" ]; then
         # enable more build depends required by crimson
         sed -i -e 's/%bcond_with seastar/%bcond_without seastar/g' $DIR/ceph.spec
-        # use gcc-toolset-9 for the better support of C++17 from GCC
-        # see also https://bugzilla.redhat.com/show_bug.cgi?id=1853900
-        $SUDO dnf copr enable -y tchaikov/gcc-toolset-9 centos-stream-x86_64
     fi
 
     # Make sure we have all the rpm macros installed and at the latest version


### PR DESCRIPTION
since both CentOS and RHEL now include the updated
gcc-toolset-9-gcc-9.2.1-2.3.el8.

see also https://bugzilla.redhat.com/show_bug.cgi?id=1853900

Signed-off-by: Kefu Chai <kchai@redhat.com>