### PR TITLE
ceph-dev-new: add Windows build

### DIFF
--- a/ceph-dev-build/build/validate_deb
+++ b/ceph-dev-build/build/validate_deb
@@ -11,3 +11,7 @@ set -ex
       exit 1
       ;;
   esac) || exit 0
+
+if [ "${DIST}" == "windows" ]; then
+  exit 0
+fi

--- a/ceph-dev-build/build/validate_osc
+++ b/ceph-dev-build/build/validate_osc
@@ -11,3 +11,7 @@ set -ex
       exit 1
       ;;
   esac) || exit 0
+
+if [ "${DIST}" == "windows" ]; then
+  exit 0
+fi

--- a/ceph-dev-build/build/validate_rpm
+++ b/ceph-dev-build/build/validate_rpm
@@ -11,3 +11,7 @@ set -ex
       exit 1
       ;;
   esac) || exit 0
+
+if [ "${DIST}" == "windows" ]; then
+  exit 0
+fi

--- a/ceph-dev-new-build/build/build_mingw
+++ b/ceph-dev-new-build/build/build_mingw
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -ex
+
+timeout 3h CMAKE_BUILD_TYPE=Release BUILD_ZIP=1 CLEAN_BUILD=1 ./win32_build.sh
+
+if [ "$THROWAWAY" = false ]; then
+    # push binaries to chacra
+    chacra_binary="$VENV/chacractl binary"
+    chacra_create="$chacra_binary create"
+    [ "$FORCE" = true ] && chacra_binary="$chacra_binary --force"
+
+    find build -name "*.zip" |
+        $chacra_create ${chacra_endpoint}/source/flavors/${FLAVOR}
+
+    # write json file with build info
+    cat > $WORKSPACE/repo-extra.json << EOF
+{
+    "version":"$vers",
+    "package_manager_version":"",
+    "build_url":"$BUILD_URL",
+    "root_build_cause":"$ROOT_BUILD_CAUSE",
+    "node_name":"$NODE_NAME",
+    "job_name":"$JOB_NAME"
+}
+EOF
+    # post the json to repo-extra json to chacra
+    curl -X POST \
+         -H "Content-Type:application/json" \
+         --data "@$WORKSPACE/repo-extra.json" \
+         -u $CHACRACTL_USER:$CHACRACTL_KEY \
+         ${chacra_url}repos/${chacra_repo_endpoint}/extra/
+    # start repo creation
+    $VENV/chacractl repo update ${chacra_repo_endpoint}
+
+    echo Check the status of the repo at: https://shaman.ceph.com/api/repos/${chacra_repo_endpoint}/
+fi
+
+# update shaman with the completed build status
+update_build_status "completed" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH

--- a/ceph-dev-new-build/build/setup_mingw
+++ b/ceph-dev-new-build/build/setup_mingw
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -ex
+HOST=$(hostname --short)
+echo "Building on $(hostname)"
+echo "  DIST=${DIST}"
+echo "  BPTAG=${BPTAG}"
+echo "  KEYID=${KEYID}"
+echo "  WS=$WORKSPACE"
+echo "  PWD=$(pwd)"
+echo "  BUILD SOURCE=$COPYARTIFACT_BUILD_NUMBER_CEPH_SETUP"
+echo "*****"
+env
+echo "*****"
+
+if test $(id -u) != 0 ; then
+    SUDO=sudo
+fi
+export LC_ALL=C # the following is vulnerable to i18n
+
+BRANCH=`branch_slash_filter $BRANCH`
+
+cd $WORKSPACE
+
+vers=$(cat ./dist/version)
+raw_version=`echo $vers | cut -d '-' -f 1`
+RELEASE_BRANCH=$(release_from_version $raw_version)
+
+raw_version_major=$(echo $vers | cut -d '.' -f 1)
+if [ 0${raw_version_major} -lt 16 ]; then
+    echo The following Ceph release does not support Windows: $RELEASE_BRANCH
+    exit 1
+fi
+
+# Normalize variables across rpm/deb builds
+NORMAL_DISTRO=$DIST
+NORMAL_DISTRO_VERSION="1809"
+NORMAL_ARCH=$ARCH
+
+# create build status in shaman
+create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+
+pkgs=( "chacractl>=0.0.21" )
+install_python_packages "pkgs[@]"
+
+chacra_url=https://chacra.ceph.com/
+make_chacractl_config
+
+FLAVOR="default"
+
+chacra_ref="$BRANCH"
+chacra_endpoint="ceph/${chacra_ref}/${SHA1}/${DIST}/${ARCH}"
+chacra_repo_endpoint="${chacra_endpoint}/flavors/${FLAVOR}"
+chacra_check_url="${chacra_endpoint}/ceph.zip"
+
+if [ "$THROWAWAY" = false ] ; then
+    # this exists in scripts/build_utils.sh
+    # TODO if this exits we need to post to shaman a success
+    check_binary_existence $chacra_check_url
+fi

--- a/ceph-dev-new-build/build/validate_mingw
+++ b/ceph-dev-new-build/build/validate_mingw
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+# At the moment, we only support cross compiling Windows binaries using
+# Ubuntu or SUSE distros.
+( source /etc/os-release
+  case $ID in
+    opensuse*|suse|sles)
+      exit 0
+      ;;
+    ubuntu)
+      exit 0
+      ;;
+    *)
+      exit 1
+      ;;
+  esac) || exit 0
+
+if [ "${DIST}" != "windows" ]; then
+  exit 0
+fi

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -54,6 +54,7 @@
             - centos7
             - centos8
             - leap15
+            - windows
       - axis:
           type: dynamic
           name: DIST
@@ -105,6 +106,13 @@
             - ../../../scripts/build_utils.sh
             - ../../build/setup_osc
             - ../../build/build_osc
+      # mingw build scripts (targeting Windows)
+      - shell:
+          !include-raw:
+            - ../../build/validate_mingw
+            - ../../../scripts/build_utils.sh
+            - ../../build/setup_mingw
+            - ../../build/build_mingw
 
     publishers:
       - postbuildscript:

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -25,8 +25,8 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: centos8, centos7, centos6, focal, bionic, xenial, trusty, precise, wheezy, and jessie"
-          default: "focal bionic centos7 centos8"
+          description: "A list of distros to build for. Available options are: centos8, centos7, centos6, focal, bionic, xenial, trusty, precise, wheezy, jessie, and windows"
+          default: "focal bionic centos7 centos8 windows"
 
       - string:
           name: ARCHS


### PR DESCRIPTION
ceph-dev-new: add Windows build

We're going to do a Windows build using Mingw as part of the
ceph-dev-new job.

"windows" is added as a valid distro. The "validate_mingw" script
will ensure that we're running on top of a Linux distro that the
Windows build script supports (currently just Ubuntu and Suse
distros).