### PR TITLE
ceph-ansible: refact write_collect_logs_playbook

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1119,6 +1119,41 @@ write_collect_logs_playbook() {
 - hosts: all
   become: yes
   tasks:
+    - name: import_role ceph-defaults
+      import_role:
+        name: ceph-defaults
+
+    - name: import_role ceph-facts
+      import_role:
+        name: ceph-facts
+        tasks_from: container_binary.yml
+
+    - name: set_fact ceph_cmd
+      set_fact:
+        ceph_cmd: "{{ container_binary + ' run --rm --net=host -v /etc/ceph:/etc/ceph:z -v /var/lib/ceph:/var/lib/ceph:z -v /var/run/ceph:/var/run/ceph:z --entrypoint=ceph ' + ceph_docker_registry + '/' + ceph_docker_image + ':' + ceph_docker_image_tag if containerized_deployment | bool else 'ceph' }}"
+
+    - name: get some ceph status outputs
+      command: "{{ ceph_cmd }} --connect-timeout 10 --cluster {{ cluster }} {{ item }}"
+      register: ceph_status
+      run_once: True
+      delegate_to: mon0
+      failed_when: false
+      changed_when: false
+      with_items:
+        - "-s -f json"
+        - "osd tree"
+        - "osd dump"
+        - "pg dump"
+        - "versions"
+
+    - name: save ceph status to file
+      copy:
+        content: "{{ item.stdout }}"
+        dest: "{{ archive_path }}/{{ item.item | regex_replace(' ', '_') }}.log"
+      delegate_to: localhost
+      run_once: True
+      with_items: "{{ ceph_status.results }}"
+
     - name: find ceph config file and logs
       find:
         paths:
@@ -1135,13 +1170,6 @@ write_collect_logs_playbook() {
         dest: "{{ archive_path }}/{{ inventory_hostname }}/"
         flat: yes
       with_items: "{{ results.files }}"
-
-    - name: show ceph status
-      command: "ceph --connect-timeout 10 --cluster {{ (item.path | basename | splitext)[0] }} -s -f json"
-      with_items: "{{ results.files }}"
-      when: "'.conf' in item.path"
-      run_once: True
-      delegate_to: mon0
 EOF
 }
 


### PR DESCRIPTION
This playbook doesn't work in containerized context.
Importing ceph-defaults and ceph-facts fixes this issue.

This also adds some output that might be helpful.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>