### PR TITLE
teuthology-pull-requests: whitelist red-hat-storage gh group

### DIFF
--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -36,6 +36,7 @@
             - smithfarm
           org-list:
             - ceph
+            - red-hat-storage
           white-list:
             - jcsp
             - GregMeno


### PR DESCRIPTION
Most of Ceph QE is in this group but may not necessarily be in (or need to be in) the 'ceph' group.

Signed-off-by: David Galloway <dgallowa@redhat.com>