### PR TITLE
ceph-dev-build: update {build,setup}_osc for quincy

### DIFF
--- a/ceph-dev-build/build/build_osc
+++ b/ceph-dev-build/build/build_osc
@@ -2,6 +2,9 @@
 set -ex
 
 case $RELEASE_BRANCH in
+quincy)
+    OBSREPO="openSUSE_Leap_15.2"
+    ;;
 pacific)
     OBSREPO="openSUSE_Leap_15.2"
     ;;

--- a/ceph-dev-build/build/setup_osc
+++ b/ceph-dev-build/build/setup_osc
@@ -38,6 +38,10 @@ raw_version=`echo $vers | cut -d '-' -f 1`
 
 RELEASE_BRANCH=$(release_from_version $raw_version)
 case $RELEASE_BRANCH in
+quincy)
+    DISTRO=opensuse
+    RELEASE="15.2"
+    ;;
 pacific)
     DISTRO=opensuse
     RELEASE="15.2"


### PR DESCRIPTION
this change should address the failure like
```
+ RELEASE_BRANCH=quincy
+ case $RELEASE_BRANCH in
+ echo Not supported release '$RELEASE_BRANCH' by openSUSE
Not supported release $RELEASE_BRANCH by openSUSE
+ exit 1
```
see also https://shaman.ceph.com/builds/ceph/wip-yuval-fix-48963/6ae6c340188bb4cda209cbc795db104d877b4516/default/250831/