### PR TITLE
tcmu-runner: fix for arm64/aarch64

### DIFF
--- a/tcmu-runner/build/build_rpm
+++ b/tcmu-runner/build/build_rpm
@@ -72,8 +72,13 @@ rpmbuild \
     --nodeps -bs $WORKSPACE/${PROJECT}.spec
 SRPM=$(readlink -f $WORKSPACE/dist/SRPMS/*.src.rpm)
 
+DISTRO_ARCH=${ARCH}
+if [[ "${ARCH}" = "arm64" ]] ; then
+	DISTRO_ARCH="aarch64"
+fi
+
 # add shaman repo file to mock config
-cat /etc/mock/${MOCK_TARGET}-${RELEASE}-${ARCH}.cfg > tcmu-runner.cfg
+cat /etc/mock/${MOCK_TARGET}-${RELEASE}-${DISTRO_ARCH}.cfg > tcmu-runner.cfg
 echo "" >> tcmu-runner.cfg
 echo "config_opts['yum.conf'] += \"\"\"" >> tcmu-runner.cfg
 cat $WORKSPACE/shaman.repo >> tcmu-runner.cfg
@@ -92,8 +97,8 @@ chacra_endpoint="tcmu-runner/${BRANCH}/${GIT_COMMIT}/${DISTRO}/${RELEASE}"
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 
 # push binaries to chacra
-find $WORKSPACE/dist/RPMS/ | egrep "\.$ARCH\.rpm" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/$ARCH/
-PACKAGE_MANAGER_VERSION=$(rpm --queryformat '%{VERSION}-%{RELEASE}\n' -qp $(find $WORKSPACE/dist/RPMS/ | egrep "\.$ARCH\.rpm" | head -1))
+find $WORKSPACE/dist/RPMS/ | egrep "\.$DISTRO_ARCH\.rpm" | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/$DISTRO_ARCH/
+PACKAGE_MANAGER_VERSION=$(rpm --queryformat '%{VERSION}-%{RELEASE}\n' -qp $(find $WORKSPACE/dist/RPMS/ | egrep "\.$DISTRO_ARCH\.rpm" | head -1))
 
 # write json file with build info
 cat > $WORKSPACE/repo-extra.json << EOF

--- a/tcmu-runner/config/definitions/tcmu-runner.yml
+++ b/tcmu-runner/config/definitions/tcmu-runner.yml
@@ -47,7 +47,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
     execution-strategy:
        combination-filter: |
          DIST == AVAILABLE_DIST && ARCH == AVAILABLE_ARCH &&
-         (ARCH == "x86_64" || (ARCH == "arm64" && ["centos7", "centos8"].contains(DIST)))
+         (ARCH == "x86_64" || (ARCH == "arm64" && DIST == "centos8"))
     axes:
       - axis:
           type: label-expression
@@ -59,6 +59,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           name: AVAILABLE_ARCH
           values:
             - x86_64
+            - arm64
       - axis:
           type: label-expression
           name: AVAILABLE_DIST


### PR DESCRIPTION
Add "available arch" arm64, and fix build_rpm script to use aarch64
Also limit aarch64 build to CentOS 8

Signed-off-by: Dan Mick <dmick@redhat.com>