### PR TITLE
build: notcmalloc builds enable WITH_BOOST_VALGRIND

### DIFF
--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -70,7 +70,7 @@ case "${FLAVOR}" in
     notcmalloc)
         echo "Detected notcmalloc flavor: will use flag: -DALLOCATOR=libc"
         CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
-        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_CEPH_DEBUG_MUTEX=ON"
+        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_CEPH_DEBUG_MUTEX=ON -DWITH_BOOST_VALGRIND=ON"
         ;;
     default)
         CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -42,7 +42,7 @@ case "${FLAVOR}" in
     notcmalloc)
         echo "Detected notcmalloc flavor: will use flag: -DALLOCATOR=libc"
         CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
-        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_CEPH_DEBUG_MUTEX=ON"
+        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_CEPH_DEBUG_MUTEX=ON -DWITH_BOOST_VALGRIND=ON"
         ;;
     default)
         CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -37,7 +37,7 @@ if [ "${FLAVOR}" == "notcmalloc" ]
 then
     echo "Detected notcmalloc flavor: will use flag: -DALLOCATOR=libc"
     CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
-    CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc"
+    CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_BOOST_VALGRIND=ON"
 else
     CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"


### PR DESCRIPTION
this flag silences a false-positive from valgrind in boost::context:
```
<error>
  <unique>0x0</unique>
  <tid>124</tid>
  <kind>InvalidRead</kind>
  <what>Invalid read of size 8</what>
  <stack>
    <frame>
      <ip>0x52FF7E7</ip>
      <obj>/usr/lib64/libradosgw.so.2.0.0</obj>
      <fn>spawn::detail::continuation_context::resume()</fn>
    </frame>
  </stack>
  <auxwhat>Address 0x57f65728 is in a rw- anonymous segment</auxwhat>
</error>
```

Fixes: https://tracker.ceph.com/issues/48963