### PR TITLE
ceph-volume-prs: use ceph-ansible@stable-6.0 for pacific

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -31,7 +31,7 @@ elif [[ "$ghprbTargetBranch" == "nautilus" ]]; then
 elif [[ "$ghprbTargetBranch" == "octopus" ]]; then
     CEPH_ANSIBLE_BRANCH="stable-5.0"
 elif [[ "$ghprbTargetBranch" == "pacific" ]]; then
-    CEPH_ANSIBLE_BRANCH="v6.0.0alpha6"
+    CEPH_ANSIBLE_BRANCH="stable-6.0"
 else
     CEPH_ANSIBLE_BRANCH="master"
 fi


### PR DESCRIPTION
Since, ceph-ansible stable-6.0 has been branched for deploying pacific,
we should use this branch in ceph-volume testing.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>