### PR TITLE
ceph-ansible: remove add_osds jobs

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -76,7 +76,6 @@
       - shrink_osd_multiple
       - shrink_osd_single
       - lvm_batch
-      - add_osds
       - rgw_multisite
       - purge
       - lvm_auto_discovery
@@ -107,7 +106,6 @@
       - shrink_osd_multiple
       - shrink_osd_single
       - lvm_batch
-      - add_osds
       - rgw_multisite
       - purge
       - lvm_auto_discovery


### PR DESCRIPTION
The add-osds.yml playbook was dropped as of 5.0

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>