### PR TITLE
ceph-dev: Disable arm64 notcmalloc and crimson builds

### DIFF
--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -63,6 +63,7 @@
                     FORCE=True
                     FLAVOR=notcmalloc
                     DISTROS=centos7
+                    ARCHS=x86_64
       # build nautilus on:
       # default: bionic xenial centos7 centos8
       # notcmalloc: centos7
@@ -88,6 +89,7 @@
                     FORCE=True
                     DISTROS=centos7
                     FLAVOR=notcmalloc
+                    ARCHS=x86_64
       # build octopus on:
       # default: focal bionic centos7 centos8 leap15
       # notcmalloc: centos8
@@ -113,6 +115,7 @@
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=notcmalloc
+                    ARCHS=x86_64
       # build pacific on:
       # default: focal bionic centos8 leap15
       # notcmalloc: centos8
@@ -139,12 +142,14 @@
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=notcmalloc
+                    ARCHS=x86_64
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=crimson
+                    ARCHS=x86_64
       # build master on:
       # default: focal bionic centos8 leap15
       # notcmalloc: centos8
@@ -171,12 +176,14 @@
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=notcmalloc
+                    ARCHS=x86_64
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=crimson
+                    ARCHS=x86_64
 
     wrappers:
       - inject-passwords:

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -53,6 +53,7 @@
                     FORCE=True
                     FLAVOR=notcmalloc
                     DISTROS=centos7
+                    ARCHS=x86_64
       # build mimic on:
       # default: bionic xenial centos7
       # notcmalloc: centos7
@@ -78,6 +79,7 @@
                     FORCE=True
                     DISTROS=centos7
                     FLAVOR=notcmalloc
+                    ARCHS=x86_64
       # build nautilus on:
       # default: bionic xenial centos7 centos8
       # notcmalloc: centos7
@@ -103,6 +105,7 @@
                     FORCE=True
                     DISTROS=centos7
                     FLAVOR=notcmalloc
+                    ARCHS=x86_64
       # build octopus on:
       # default: focal bionic centos7 centos8 leap15
       # notcmalloc: centos8
@@ -128,6 +131,7 @@
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=notcmalloc
+                    ARCHS=x86_64
       # build pacific on:
       # default: focal bionic centos8 leap15
       # notcmalloc: centos8
@@ -154,12 +158,14 @@
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=notcmalloc
+                    ARCHS=x86_64
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=crimson
+                    ARCHS=x86_64
       # If no release name is found in branch, build on all possible distro/flavor combos (except xenial).
       # regex matching and 'on-evaluation-failure: run' doesn't work here so triple negative it is.
       - conditional-step:
@@ -185,6 +191,7 @@
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=notcmalloc
+                    ARCHS=x86_64
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
@@ -192,6 +199,7 @@
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=crimson
+                    ARCHS=x86_64
 
     wrappers:
       - inject-passwords:


### PR DESCRIPTION
Nobody will use them and crimson is failing anyway

Signed-off-by: David Galloway <dgallowa@redhat.com>