### PR TITLE
Disable notcmalloc builds!

### DIFF
--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -76,7 +76,7 @@ fi
 
 # XXX perhaps use job parameters instead of literals; then
 # later stages can also use them to compare etc.
-if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" && $FLAVOR != "notcmalloc" ]] ; then
+if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" ]] ; then
     loop=0
     ready=false
     while ((loop < 15)); do

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -40,7 +40,6 @@
     builders:
       # Build luminous on:
       # default: centos7 bionic xenial trusty
-      # notcmalloc: centos7
       - conditional-step:
           condition-kind: regex-match
           regex: .*luminous.*
@@ -57,16 +56,8 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=centos7 bionic xenial trusty
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    FLAVOR=notcmalloc
-                    DISTROS=centos7
-                    ARCHS=x86_64
       # build nautilus on:
       # default: bionic xenial centos7 centos8
-      # notcmalloc: centos7
       - conditional-step:
           condition-kind: regex-match
           regex: .*nautilus.*
@@ -83,16 +74,8 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=bionic xenial centos7 centos8
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos7
-                    FLAVOR=notcmalloc
-                    ARCHS=x86_64
       # build octopus on:
       # default: focal bionic centos7 centos8 leap15
-      # notcmalloc: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*octopus.*
@@ -109,16 +92,8 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal bionic centos7 centos8 leap15
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=notcmalloc
-                    ARCHS=x86_64
       # build pacific on:
       # default: focal bionic centos8 leap15
-      # notcmalloc: centos8
       # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
@@ -141,18 +116,10 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=centos8
-                    FLAVOR=notcmalloc
-                    ARCHS=x86_64
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build master on:
       # default: focal bionic centos8 leap15
-      # notcmalloc: centos8
       # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
@@ -170,13 +137,6 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal bionic centos8
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=notcmalloc
-                    ARCHS=x86_64
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -78,7 +78,7 @@ fi
 # XXX perhaps use job parameters instead of literals; then
 # later stages can also use them to compare etc.
 # build container image that supports building crimson-osd
-if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $FLAVOR != "notcmalloc" ]] ; then
+if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" ]] ; then
     loop=0
     ready=false
     while ((loop < 15)); do

--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -67,11 +67,6 @@ fi
 # Flavor Builds support
 
 case "${FLAVOR}" in
-    notcmalloc)
-        echo "Detected notcmalloc flavor: will use flag: -DALLOCATOR=libc"
-        CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
-        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_CEPH_DEBUG_MUTEX=ON -DWITH_BOOST_VALGRIND=ON"
-        ;;
     default)
         CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
         CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -30,7 +30,6 @@
     builders:
       # Build luminous on:
       # default: centos7 bionic xenial trusty
-      # notcmalloc: centos7
       - conditional-step:
           condition-kind: regex-match
           regex: .*luminous.*
@@ -47,16 +46,8 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=centos7 bionic xenial trusty
-                - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    FLAVOR=notcmalloc
-                    DISTROS=centos7
-                    ARCHS=x86_64
       # build mimic on:
       # default: bionic xenial centos7
-      # notcmalloc: centos7
       - conditional-step:
           condition-kind: regex-match
           regex: .*mimic.*
@@ -73,16 +64,8 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=bionic xenial centos7
-                - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos7
-                    FLAVOR=notcmalloc
-                    ARCHS=x86_64
       # build nautilus on:
       # default: bionic xenial centos7 centos8
-      # notcmalloc: centos7
       - conditional-step:
           condition-kind: regex-match
           regex: .*nautilus.*
@@ -99,16 +82,8 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=bionic xenial centos7 centos8
-                - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos7
-                    FLAVOR=notcmalloc
-                    ARCHS=x86_64
       # build octopus on:
       # default: focal bionic centos7 centos8 leap15
-      # notcmalloc: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*octopus.*
@@ -125,16 +100,8 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal bionic centos7 centos8 leap15
-                - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=notcmalloc
-                    ARCHS=x86_64
       # build pacific on:
       # default: focal bionic centos8 leap15
-      # notcmalloc: centos8
       # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
@@ -152,13 +119,6 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal bionic centos8
-                - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=notcmalloc
-                    ARCHS=x86_64
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
@@ -184,14 +144,6 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal bionic centos8
-            - trigger-builds:
-                - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=notcmalloc
-                    ARCHS=x86_64
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -55,10 +55,9 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           name: FLAVOR
           choices:
             - default
-            - notcmalloc
             - crimson
           default: "default"
-          description: "Type of Ceph build, choices are: crimson, notcmalloc, default (i.e. with tcmalloc). Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: crimson, default. Defaults to: 'default'"
 
       - string:
           name: CI_CONTAINER

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -39,11 +39,6 @@ git submodule update --init
 # Flavor Builds support
 
 case "${FLAVOR}" in
-    notcmalloc)
-        echo "Detected notcmalloc flavor: will use flag: -DALLOCATOR=libc"
-        CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
-        CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_CEPH_DEBUG_MUTEX=ON -DWITH_BOOST_VALGRIND=ON"
-        ;;
     default)
         CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
         CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -41,7 +41,6 @@
     builders:
       # build nautilus on:
       # default: bionic xenial centos7 centos8
-      # notcmalloc: centos7
       - conditional-step:
           condition-kind: regex-match
           regex: .*nautilus.*
@@ -58,15 +57,8 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=bionic xenial centos7 centos8
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos7
-                    FLAVOR=notcmalloc
       # build octopus on:
       # default: focal bionic centos7 centos8 leap15
-      # notcmalloc: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*octopus.*
@@ -83,15 +75,8 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal bionic centos7 centos8 leap15
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=notcmalloc
       # build pacific on:
       # default: focal bionic centos8 leap15
-      # notcmalloc: centos8
       # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
@@ -114,16 +99,9 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=centos8
-                    FLAVOR=notcmalloc
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
                     FLAVOR=crimson
       # build master on:
       # default: focal bionic centos8 leap15
-      # notcmalloc: centos8
       # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
@@ -141,12 +119,6 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal bionic centos8
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=notcmalloc
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -55,10 +55,9 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           name: FLAVOR
           choices:
             - default
-            - notcmalloc
             - crimson
           default: "default"
-          description: "Type of Ceph build, choices are: crimson, notcmalloc, default (i.e. with tcmalloc). Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: crimson, default. Defaults to: 'default'"
 
       - bool:
           name: CI_CONTAINER

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -31,17 +31,8 @@ rm -rf release
 echo "Running submodule update ..."
 git submodule update --init
 
-# Flavor Builds support
-
-if [ "${FLAVOR}" == "notcmalloc" ]
-then
-    echo "Detected notcmalloc flavor: will use flag: -DALLOCATOR=libc"
-    CEPH_EXTRA_RPMBUILD_ARGS="--without tcmalloc"
-    CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=libc -DWITH_BOOST_VALGRIND=ON"
-else
-    CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
-    CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
-fi
+CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
+CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"
 
 
 # When using autotools/autoconf it is possible to see output from `git diff`


### PR DESCRIPTION
We no longer need notmcalloc packages.  Vagrant works now.

Signed-off-by: David Galloway <dgallowa@redhat.com>