### PR TITLE
ceph-dev-new-build: fixed windows build environment variables

### DIFF
--- a/ceph-dev-new-build/build/build_mingw
+++ b/ceph-dev-new-build/build/build_mingw
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-timeout 3h CMAKE_BUILD_TYPE=Release BUILD_ZIP=1 CLEAN_BUILD=1 ./win32_build.sh
+CMAKE_BUILD_TYPE=Release BUILD_ZIP=1 CLEAN_BUILD=1 timeout 3h ./win32_build.sh
 
 if [ "$THROWAWAY" = false ]; then
     # push binaries to chacra


### PR DESCRIPTION
The environment variables should be placed before the command.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>