### PR TITLE
ceph-dev-new-build: cross-compile Windows targets using pbuilder

### DIFF
--- a/ceph-dev-new-build/build/build_mingw
+++ b/ceph-dev-new-build/build/build_mingw
@@ -1,7 +1,26 @@
 #!/bin/bash
 set -ex
 
+# We need Ubuntu Focal to cross-compile Ceph for Windows.
+# Previous versions provide broken Mingw packages.
+# "DIST" will be set to "windows", so we're currently overriding it with
+# a hardcoded value.
+tmp_pbuild_script=$(mktemp /tmp/build_mingw_pbuild.XXXXXX)
+cat << EOF > $tmp_pbuild_script
+#!/bin/sh
+# Used by the build script
+apt-get install -y sudo git automake wget
+
+cd /mnt/ceph
 CMAKE_BUILD_TYPE=Release BUILD_ZIP=1 CLEAN_BUILD=1 timeout 3h ./win32_build.sh
+EOF
+chmod a+x $tmp_pbuild_script
+sudo pbuilder execute \
+    --bindmounts "$(pwd):/mnt/ceph" \
+    --distribution "focal" \
+    --basetgz $basedir/focal.tgz \
+    -- $tmp_pbuild_script
+rm $tmp_pbuild_script
 
 if [ "$THROWAWAY" = false ]; then
     # push binaries to chacra

--- a/ceph-dev-new-build/build/setup_mingw
+++ b/ceph-dev-new-build/build/setup_mingw
@@ -65,3 +65,11 @@ if [ "$THROWAWAY" = false ] ; then
     # TODO if this exits we need to post to shaman a success
     check_binary_existence $chacra_check_url
 fi
+
+# We need Ubuntu Focal to cross-compile Ceph for Windows.
+# Previous versions provide broken Mingw packages.
+# "DIST" will be set to "windows", so we're currently overriding it with
+# a hardcoded value.
+DIST="focal"
+setup_pbuilder use_gcc
+DIST="$NORMAL_DISTRO"

--- a/ceph-dev-new-build/build/validate_mingw
+++ b/ceph-dev-new-build/build/validate_mingw
@@ -1,13 +1,9 @@
 #!/bin/bash
 set -ex
 
-# At the moment, we only support cross compiling Windows binaries using
-# Ubuntu or SUSE distros.
+# We're currently using pbuilder.
 ( source /etc/os-release
   case $ID in
-    opensuse*|suse|sles)
-      exit 0
-      ;;
     ubuntu)
       exit 0
       ;;


### PR DESCRIPTION
The Windows builds that are generated right now are unusable due to
known Mingw runtime bugs.

We need Ubuntu Focal or later, for which reason we're going to use
pbuilder.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>