### PR TITLE
ceph_ansible_nightly: add pacific centos release

### DIFF
--- a/ceph-ansible-nightly/build/build
+++ b/ceph-ansible-nightly/build/build
@@ -16,7 +16,7 @@ page_size=100
 function find_latest_tag {
   release="$1"
   el="7"
-  if [ "${release}" == "octopus" ]; then
+  if [[ "${release}" =~ octopus|pacific ]]; then
     el="8"
   fi
   page=1


### PR DESCRIPTION
This adds Pacific release based on CentOS 8 like Octopus.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>