### PR TITLE
ansible: Disable timeout on tmp{watch,reaper}

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -665,7 +665,7 @@
           cron:
             name: "Delete /tmp files that have not been accessed in 30 days"
             special_time: daily
-            job: "{{ tmp_cleaner_name }} 30d /tmp/"
+            job: "{{ tmp_cleaner_name }} --runtime=0 30d /tmp/"
       when: permanent|bool
       tags: tmp
 


### PR DESCRIPTION
From the man page:

```
       -T x, --runtime=x
              Execution of tmpreaper will aborted after x seconds; this is to prevent attacks that create many, many files.  By default the timeout is set to 55 seconds.  A value of 0 will disable this feature, which is not advised as this feature prevents possible
              race-conditions between different instances of tmpreaper.
```

So tmpreaper wasn't running for the past week since I set this up because there was so much to clean up that it'd time out.  These are Jenkins builders where the primary user already has sudo access so there's no real use to locking down tmpreaper.

Signed-off-by: David Galloway <dgallowa@redhat.com>