### PR TITLE
ansible: Install software-properties-common on deb builders

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -48,6 +48,7 @@
           - default-jre
           - debian-keyring
           - debian-archive-keyring
+          - software-properties-common
           # jenkins-job-builder job:
           - libyaml-dev
           - jq


### PR DESCRIPTION
Provides `add-apt-repository`

Signed-off-by: David Galloway <dgallowa@redhat.com>