### PR TITLE
nfs-ganesha: do not build el7 rpm by default

### DIFF
--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -57,8 +57,8 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: bionic, centos7, centos8"
-          default: "centos7 centos8 bionic"
+          description: "A list of distros to build for. Available options are: bionic, centos8"
+          default: "centos8 bionic"
 
       - string:
           name: ARCHS
@@ -84,7 +84,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           default: "/tmp/"
 
     execution-strategy:
-       combination-filter: DIST==AVAILABLE_DIST && ARCH==AVAILABLE_ARCH && (ARCH=="x86_64" || (ARCH == "arm64" && (DIST == "xenial" || DIST == "centos7")))
+       combination-filter: DIST==AVAILABLE_DIST && ARCH==AVAILABLE_ARCH && (ARCH=="x86_64" || (ARCH == "arm64" && (DIST == "xenial")))
     axes:
       - axis:
           type: label-expression
@@ -101,7 +101,6 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           type: label-expression
           name: AVAILABLE_DIST
           values:
-            - centos7
             - centos8
             - xenial
             - bionic


### PR DESCRIPTION
building el7 nfs-ganesha rpm for the branch 'next' is not possible at
the moment because it tries to use ceph@master el7 builds.
This is not worth building this package at the moment so let's remove it
from default.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>