### PR TITLE
build_utils: Use network in pbuilder env

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -835,6 +835,7 @@ build_debs() {
         --basetgz $pbuilddir/$DIST.tgz \
         --buildresult $releasedir/$cephver \
         --profiles nocheck \
+        --use-network yes \
         $releasedir/$cephver/ceph_$bpvers.dsc
 
     # do lintian checks


### PR DESCRIPTION
Not sure what happened between 0.229.1 vs 0.230.4 but seems `--use-network no` is now the default.  Discovered on a Focal builder.

Signed-off-by: David Galloway <dgallowa@redhat.com>