### PR TITLE
Revert "build_utils.sh: Prefer python3 instead of python2 for virtual envs

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -96,12 +96,10 @@ create_virtualenv () {
     if [ "$(ls -A $path)" ]; then
         echo "Will reuse existing virtual env: $path"
     else
-        if [ $(command -v python3) ]; then
-            virtualenv -p python3 $path
-        elif [ $(command -v python2.7) ]; then
+        if [ $(command -v python2.7) ]; then
             virtualenv -p python2.7 $path
         else
-            virtualenv -p python $path
+            virtualenv -p python3 $path
         fi
     fi
 }


### PR DESCRIPTION
This reverts commit 58afbde0aead09adc1f7af06e8491670e1acd614.

See https://github.com/ceph/ceph-build/issues/1770