### PR TITLE
sync-push: Print releases in order

### DIFF
--- a/scripts/sync-push
+++ b/scripts/sync-push
@@ -12,7 +12,7 @@ releases=${*:-"nautilus octopus pacific"}
 
 ceph_sync() {
   release=$1
-  for path in /opt/repos/ceph/$release*; do
+  for path in $(ls -d /opt/repos/ceph/* | grep $release | sort -t. -k3 -n); do
 
     # We started using the new /opt/repos/ceph/$release-X.X.X format with Octopus.
     # Older releases have all packages in one big $release dir without a trailing "-X.X.X" so we need to adjust paths accordingly.


### PR DESCRIPTION
Previous directory listing behavior:

```
octopus-15.2.10
octopus-15.2.4
octopus-15.2.5
octopus-15.2.6
octopus-15.2.7
octopus-15.2.8
octopus-15.2.9
```

Desired (and current with this PR) listing behavior:

```
octopus-15.2.4
octopus-15.2.5
octopus-15.2.6
octopus-15.2.7
octopus-15.2.8
octopus-15.2.9
octopus-15.2.10
```

This wasn't discovered until now because the `$newgen` stuff I do in this script only applies to Octopus for now.  Octopus only had single digit minor release versions (15.x.{1..9}) until 15.2.10.  The symlink didn't get updated to download.ceph.com/rpm-octopus still pointed to download.ceph.com/rpm-15.2.9 since it was last in the directory listing.

Signed-off-by: David Galloway <dgallowa@redhat.com>