### PR TITLE
build_utils.sh: Prefer python3 instead of python2 for virtualenvs

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -96,10 +96,12 @@ create_virtualenv () {
     if [ "$(ls -A $path)" ]; then
         echo "Will reuse existing virtual env: $path"
     else
-        if [ $(command -v python2.7) ]; then
+        if [ $(command -v python3) ]; then
+            virtualenv -p python3 $path
+        elif [ $(command -v python2.7) ]; then
             virtualenv -p python2.7 $path
         else
-            virtualenv -p python3 $path
+            virtualenv -p python $path
         fi
     fi
 }


### PR DESCRIPTION
Let's try this again.  I updated the few Xenial builders we had to Bionic so we should get better results now.  See https://github.com/ceph/ceph-build/issues/1770#issuecomment-801559246

Signed-off-by: David Galloway <dgallowa@redhat.com>