### PR TITLE
ceph-volume-nightly: remove luminous

### DIFF
--- a/ceph-volume-nightly/build/build
+++ b/ceph-volume-nightly/build/build
@@ -14,11 +14,7 @@ update_vagrant_boxes
 
 cd src/ceph-volume/ceph_volume/tests/functional/$SUBCOMMAND
 
-if [ "$CEPH_BRANCH" = "mimic" ]; then
-    CEPH_ANSIBLE_BRANCH="stable-3.2"
-elif [ "$CEPH_BRANCH" = "luminous" ]; then
-    CEPH_ANSIBLE_BRANCH="stable-3.2"
-elif [ "$CEPH_BRANCH" = "nautilus" ]; then
+if [ "$CEPH_BRANCH" = "nautilus" ]; then
     CEPH_ANSIBLE_BRANCH="stable-4.0"
 else
     CEPH_ANSIBLE_BRANCH="master"

--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -14,7 +14,6 @@
       - lvm
     ceph_branch:
       - master
-      - luminous
       - nautilus
     exclude:
       - ceph_branch: master
@@ -25,28 +24,6 @@
         distro: xenial
       - ceph_branch: nautilus
         distro: xenial
-      - ceph_branch: luminous
-        distro: centos8
-
-    jobs:
-      - 'ceph-volume-nightly-{ceph_branch}-{subcommand}-{distro}-{objectstore}-{scenario}'
-
-- project:
-    name: ceph-volume-nightly-simple
-    distro:
-      - xenial
-      - centos7
-    objectstore:
-      - bluestore
-      - filestore
-    scenario:
-      - activate
-      - dmcrypt_luks
-      - dmcrypt_plain
-    subcommand:
-      - simple
-    ceph_branch:
-      - luminous
 
     jobs:
       - 'ceph-volume-nightly-{ceph_branch}-{subcommand}-{distro}-{objectstore}-{scenario}'
@@ -67,7 +44,6 @@
       - batch
     ceph_branch:
       - master
-      - luminous
       - nautilus
     exclude:
       - ceph_branch: master
@@ -78,8 +54,6 @@
         distro: xenial
       - ceph_branch: nautilus
         distro: xenial
-      - ceph_branch: luminous
-        distro: centos8
 
     jobs:
       - 'ceph-volume-nightly-{ceph_branch}-{subcommand}-{distro}-{objectstore}-{scenario}'
@@ -102,7 +76,6 @@
     ceph_branch:
       - master
       - nautilus
-      - luminous
     exclude:
       - ceph_branch: master
         distro: centos7
@@ -112,8 +85,6 @@
         distro: xenial
       - ceph_branch: nautilus
         distro: xenial
-      - ceph_branch: luminous
-        distro: centos8
 
     jobs:
       - 'ceph-volume-nightly-{ceph_branch}-{subcommand}-{distro}-{objectstore}-{scenario}'


### PR DESCRIPTION
Mimic was already removed and Luminous is EOL so no need to keep jobs
for this release.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>