### PR TITLE
ceph-pull-requests: use XUnit for publishing the test result of ctest

### DIFF
--- a/ceph-pr-commits/build/build
+++ b/ceph-pr-commits/build/build
@@ -2,7 +2,7 @@
 
 # Don't require signed commits if only docs changed.
 # I tried using the excluded-regions parameter for the ghprb plugin but since
-# this job/check is required, it hung with 'Expected — Waiting for status to be reported'
+# this job/check is required, it hung with 'Expected - Waiting for status to be reported'
 docs_pr_only
 if [ "$DOCS_ONLY" = false ]; then
     echo "Not a docs only change.  Will proceed with signed commit check."

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -91,7 +91,10 @@
                 - shell:
                     !include-raw:
                       - ../../build/kill-tests
-
+      - xunit:
+          types:
+            - ctest:
+                pattern: "build/Testing/**/Test.xml"
     wrappers:
       - ansicolor
       - credentials-binding:


### PR DESCRIPTION
for better developer experience

Signed-off-by: Kefu Chai <kchai@redhat.com>