### PR TITLE
ceph-pull-requests: skip xunit publisher if no test files present

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -95,6 +95,7 @@
           types:
             - ctest:
                 pattern: "build/Testing/**/Test.xml"
+                skip-if-no-test-files: true
     wrappers:
       - ansicolor
       - credentials-binding:


### PR DESCRIPTION
otherwise make check, at least, fails

Signed-off-by: Dan Mick <dmick@redhat.com>