### PR TITLE
scripts/build_utils.sh: use gcc-9 from ppa on bionic

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -598,6 +598,8 @@ use_ppa() {
                     use_ppa=true;;
                 xenial)
                     use_ppa=true;;
+                bionic)
+                    use_ppa=true;;
                 *)
                     use_ppa=false;;
             esac


### PR DESCRIPTION
for using more C++17 compliant compiler

Signed-off-by: Kefu Chai <tchaikov@gmail.com>