### PR TITLE
ceph-{api-nightly,pr-api}: install python3 packages on debian derivat…

### DIFF
--- a/scripts/dashboard/install-backend-api-test-deps.sh
+++ b/scripts/dashboard/install-backend-api-test-deps.sh
@@ -2,7 +2,7 @@
 set -ex
 
 if grep -q  debian /etc/*-release; then
-    sudo apt-get install -y python-scipy python3-scipy python-routes python3-routes
+    sudo apt-get install -y python3-scipy python3-routes
 elif grep -q rhel /etc/*-release; then
     sudo yum install -y scipy python-routes python3-routes
 fi


### PR DESCRIPTION
…ives

since we've moved to ubuntu focal for running "make check" and
"ceph-pr-api" tests. and ubuntu focal does not package python2 packages
for python-scipy or python-routes. let's just install the python3
packages.

this change is related to nautilus builds. because nautilus is the last
release which supports python2.

Signed-off-by: Kefu Chai <kchai@redhat.com>