### PR TITLE
ceph-dashboard-pull-requests: install python3 packages only

### DIFF
--- a/scripts/dashboard/install-e2e-test-deps.sh
+++ b/scripts/dashboard/install-e2e-test-deps.sh
@@ -11,8 +11,8 @@ if grep -q  debian /etc/*-release; then
     curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
     sudo apt-get update
     sudo apt-get install -y google-chrome-stable
-    sudo apt-get install -y python-requests python3-requests python-openssl python3-openssl python-jinja2 python3-jinja2 \
-	python-jwt python3-jwt python-scipy python3-scipy python-routes python3-routes
+    sudo apt-get install -y python3-requests python3-openssl python3-jinja2 \
+        python3-jwt python3-scipy python3-routes
     sudo apt-get install -y xvfb libxss1
     sudo rm /etc/apt/sources.list.d/google-chrome.list
 elif grep -q rhel /etc/*-release; then


### PR DESCRIPTION
since we've moved to ubuntu focal for running "make check", "ceph-dashboard-pull-requests"
and "ceph-pr-api" tests. and ubuntu focal does not package python2 packages
for python-scipy or python-routes. let's just install the python3
packages.

this change is related to nautilus builds. because nautilus is the last
release which supports python2.

Signed-off-by: Kefu Chai <kchai@redhat.com>