### PR TITLE
ceph-pull-requests: Don't fail the job if there are no test reports

### DIFF
--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -95,6 +95,7 @@
           types:
             - ctest:
                 pattern: "build/Testing/**/Test.xml"
+                skip-if-no-test-files: true
     wrappers:
       - ansicolor
       - credentials-binding:


### PR DESCRIPTION
There won't always be test report files like in the case of a doc-only change.  We `exit 0` those jobs.

Signed-off-by: David Galloway <dgallowa@redhat.com>