### PR TITLE
multiple PR jobs: Run on any Ubuntu node

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -22,7 +22,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && bionic && x86_64 && !xenial && !trusty
+    node: huge && bionic && x86_64
     quiet-period: 5
     block-downstream: false
     block-upstream: false

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && bionic && x86_64 && !xenial && !trusty
+    node: huge && bionic && x86_64
     display-name: 'ceph: dashboard Pull Requests'
     quiet-period: 5
     block-downstream: false

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && bionic && x86_64 && !xenial && !trusty
+    node: huge && bionic && x86_64
     display-name: 'ceph: API'
     quiet-period: 5
     block-downstream: false

--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -2,7 +2,7 @@
     name: ceph-pr-docs
     display-name: 'ceph: Pull Requests Docs Check'
     concurrent: true
-    node: bionic && x86_64 && !xenial && !trusty
+    node: bionic && x86_64
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -4,7 +4,7 @@
     defaults: global
     concurrent: true
     # We want make check to only run on Bionic b/c it has python2 and python3 and b/c all builds should build on Bionic
-    node: huge && bionic && x86_64 && !xenial && !trusty
+    node: huge && bionic && x86_64
     display-name: 'ceph: Pull Requests'
     quiet-period: 5
     block-downstream: false

--- a/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
+++ b/teuthology-pull-requests/config/definitions/teuthology-pull-requests.yml
@@ -1,6 +1,6 @@
 - job:
     name: teuthology-pull-requests
-    node: sepia && bionic && huge && !xenial && !arm64
+    node: sepia && bionic && huge
     project-type: freestyle
     defaults: global
     concurrent: true


### PR DESCRIPTION
All of Jenkins builders are running Ubuntu Focal.  They all have the bionic label.  They also have the xenial label but that's only because we're still building packages *for* Xenial.  But not *on* Xenial.

Signed-off-by: David Galloway <dgallowa@redhat.com>