### PR TITLE
scripts/build_utils.sh: should not quote --mirror option

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -556,7 +556,7 @@ setup_pbuilder() {
     local opts
     opts+=" --basetgz $basedir/$DIST.tgz"
     opts+=" --distribution $DIST"
-    opts+=" --mirror \"$mirror\""
+    opts+=" --mirror $mirror"
     if [ -n "$use_gcc" ]; then
         # Newer pbuilder versions set $HOME to /nonexistent which breaks all kinds of
         # things that rely on a proper (writable) path. Setting this to the system user's $HOME is not enough


### PR DESCRIPTION
otherwise the URL is not reachable with quotes in it.

Signed-off-by: Kefu Chai <kchai@redhat.com>