### PR TITLE
ceph-dev-new-trigger: do not build master on bionic anymore

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -143,7 +143,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal bionic centos8 windows
+                    DISTROS=focal centos8 windows
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |


### PR DESCRIPTION
since we've replaced the bionic facet with the focal one in master,
there is no need to build bionic packages.

Signed-off-by: Kefu Chai <kchai@redhat.com>