### PR TITLE
ceph-ansible: add a nightly job

### DIFF
--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -21,6 +21,7 @@
       - purge
       - lvm_auto_discovery
       - switch_to_containers
+      - filestore_to_bluestore
     ceph_ansible_branch:
       - stable-4.0
     jobs:
@@ -51,6 +52,7 @@
       - purge
       - lvm_auto_discovery
       - switch_to_containers
+      - filestore_to_bluestore
     ceph_ansible_branch:
       - stable-6.0
     jobs:


### PR DESCRIPTION
This adds a missing nightly job 'filestore_to_bluestore'

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>