### PR TITLE
ceph-dev-build: update {build,setup}_osc

### DIFF
--- a/ceph-dev-build/build/build_osc
+++ b/ceph-dev-build/build/build_osc
@@ -3,10 +3,10 @@ set -ex
 
 case $RELEASE_BRANCH in
 quincy)
-    OBSREPO="openSUSE_Leap_15.2"
+    OBSREPO="openSUSE_Leap_15.3"
     ;;
 pacific)
-    OBSREPO="openSUSE_Leap_15.2"
+    OBSREPO="openSUSE_Leap_15.3"
     ;;
 octopus)
     OBSREPO="openSUSE_Leap_15.2"

--- a/ceph-dev-build/build/setup_osc
+++ b/ceph-dev-build/build/setup_osc
@@ -40,11 +40,11 @@ RELEASE_BRANCH=$(release_from_version $raw_version)
 case $RELEASE_BRANCH in
 quincy)
     DISTRO=opensuse
-    RELEASE="15.2"
+    RELEASE="15.3"
     ;;
 pacific)
     DISTRO=opensuse
-    RELEASE="15.2"
+    RELEASE="15.3"
     ;;
 octopus)
     DISTRO=opensuse


### PR DESCRIPTION
use openSUSE Leap 15.3 repository for pacific and quincy

Fixes: https://tracker.ceph.com/issues/50563
Signed-off-by: Michael Fritch <mfritch@suse.com>