### PR TITLE
cephadm-ansible: add initial job

### DIFF
--- a/cephadm-ansible-prs/build/build
+++ b/cephadm-ansible-prs/build/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# placeholder for now
+/bin/true

--- a/cephadm-ansible-prs/build/teardown
+++ b/cephadm-ansible-prs/build/teardown
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# placeholder for now
+/bin/true

--- a/cephadm-ansible-prs/config/JENKINS_URL
+++ b/cephadm-ansible-prs/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/cephadm-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/cephadm-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,0 +1,114 @@
+- project:
+    name: cephadm-ansible-prs-smithi
+    worker_labels: 'vagrant && libvirt && smithi'
+    scenario:
+      - all_daemons
+    jobs:
+      - 'cephadm-ansible-prs-auto'
+
+- job-template:
+    name: 'cephadm-ansible-prs-{scenario}'
+    id: 'cephadm-ansible-prs-auto'
+    node: '{worker_labels}'
+    concurrent: true
+    defaults: global
+    display-name: 'cephadm-ansible: Pull Requests [{scenario}]'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - github:
+          url: https://github.com/ceph/cephadm-ansible
+      - build-discarder:
+          days-to-keep: 90
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+
+    parameters:
+      - string:
+          name: sha1
+          description: "A pull request ID, like 'origin/pr/72/head'"
+
+    triggers:
+      - github-pull-request:
+          cancel-builds-on-update: true
+          allow-whitelist-orgs-as-admins: true
+          org-list:
+            - ceph
+          skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
+          trigger-phrase: '^jenkins test {scenario}|jenkins test all.*'
+          only-trigger-phrase: false
+          github-hooks: true
+          permit-all: true
+          auto-close-on-fail: false
+          status-context: "Testing: {scenario}"
+          started-status: "Running: {scenario}"
+          success-status: "OK - {scenario}"
+          failure-status: "FAIL - {scenario}"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/cephadm-ansible.git
+          branches:
+            - ${{sha1}}
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: false
+
+    builders:
+      - inject:
+          properties-content: |
+            SCENARIO={scenario}
+      - conditional-step:
+          condition-kind: shell
+          condition-command: |
+            #!/bin/bash
+            # Returns 1 if only .rst and README files were modified
+            echo "Checking if only rst and READMEs were modified"
+            git show HEAD | grep -qo ^Merge:
+            if [ $? -eq 0 ]; then
+              git diff --name-only $(git show HEAD | grep ^Merge: | cut -d ':' -f2) | grep -v '\.rst\|README'
+              if [ $? -eq 1 ]; then
+                echo "Only docs were modified.  Skipping the rest of the job."
+                exit 1
+              fi
+            fi
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw-escape:
+                  - ../../../scripts/build_utils.sh
+                  - ../../build/build
+
+    publishers:
+      - postbuildscript:
+          builders:
+            - role: SLAVE
+              build-on:
+                  - FAILURE
+                  - ABORTED
+              build-steps:
+                - shell:
+                    !include-raw-escape:
+                      - ../../../scripts/build_utils.sh
+                      - ../../build/teardown
+
+      - archive:
+          artifacts: 'logs/**'
+          allow-empty: true
+          latest-only: false
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: ceph-ansible-upstream-ci
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD
+


### PR DESCRIPTION
This adds a job definition for cephadm-ansible.
For now it doesn't run anything, it's just adding the definition into
jenkins so we can start setting up the corresponding repository
(cephadm-ansible).

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>