### PR TITLE
ceph-dev-*-setup: use libc allocator when building quincy on bionic

### DIFF
--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -64,7 +64,7 @@ else
     echo "forcing."
 fi
 
-ceph_build_args_from_flavor ${FLAVOR}
+ceph_build_args_from_flavor_and_dist ${FLAVOR} ${DIST}
 
 mkdir -p release
 

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -36,7 +36,7 @@ rm -rf release
 echo "Running submodule update ..."
 git submodule update --init
 
-ceph_build_args_from_flavor ${FLAVOR}
+ceph_build_args_from_flavor_and_dist ${FLAVOR} ${DIST}
 
 # When using autotools/autoconf it is possible to see output from `git diff`
 # since some macros can be copied over to the ceph source, triggering this


### PR DESCRIPTION
see also https://tracker.ceph.com/issues/39703, to silence the warning
std::allocator<void> is deprecated in C++17 and will be removed in
C++20, so stop using allocator<void> in quincy and up.

but the libtcmalloc shipped by bionic is still buggy (v2.5), so we should not
build qunincy and up with tcmalloc on this distro.

in this change, we only build with tcmalloc on non-bionic distro.

Signed-off-by: Kefu Chai <kchai@redhat.com>