### PR TITLE
ceph-dev-*-setup: do not specify ALLOCATOR

### DIFF
--- a/ceph-dev-new-setup/build/build
+++ b/ceph-dev-new-setup/build/build
@@ -64,7 +64,7 @@ else
     echo "forcing."
 fi
 
-ceph_build_args_from_flavor_and_dist ${FLAVOR} ${DIST}
+ceph_build_args_from_flavor ${FLAVOR}
 
 mkdir -p release
 

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -36,7 +36,7 @@ rm -rf release
 echo "Running submodule update ..."
 git submodule update --init
 
-ceph_build_args_from_flavor_and_dist ${FLAVOR} ${DIST}
+ceph_build_args_from_flavor ${FLAVOR}
 
 # When using autotools/autoconf it is possible to see output from `git diff`
 # since some macros can be copied over to the ceph source, triggering this


### PR DESCRIPTION
$DIST env variable is not set by ceph-dev-new-setup, as it prepares
the dist tarball for building on different distros. to build with
tcmalloc if gperftools 2.6.2 is available, we leave it to cmake to
decide the allocator to use. because, if ALLOCATOR is not specified,
cmake first tries to find gperftools, and falls back to JeMalloc, and
the libc allocator. after quincy, the fix for gperftools <2.6.2 is
dropped, and gperftools >= 2.6.2 is required, so it's safe. before
quincy, the fix gperftools <2.6.2 is still included, so it's also safe.

Signed-off-by: Kefu Chai <kchai@redhat.com>