### PR TITLE
*: use create_venv_dir() helper

### DIFF
--- a/calamari-clients-build/build/setup
+++ b/calamari-clients-build/build/setup
@@ -54,6 +54,8 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
 esac
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/calamari/build/setup
+++ b/calamari/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-ansible-docs-prs/build/build
+++ b/ceph-ansible-docs-prs/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 cd $WORKSPACE/docs/

--- a/ceph-ansible-docs/build/build
+++ b/ceph-ansible-docs/build/build
@@ -4,6 +4,8 @@ set -ex
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # trims leading slashes

--- a/ceph-ansible-nightly/build/build
+++ b/ceph-ansible-nightly/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # XXX this might not be needed

--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # XXX this might not be needed

--- a/ceph-ansible-rpm/build/build
+++ b/ceph-ansible-rpm/build/build
@@ -18,6 +18,8 @@ make rpm || ( tail -n +1 {root,build}.log && exit 1 )
 # Chacra time
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-ansible-scenario/build/build
+++ b/ceph-ansible-scenario/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # XXX this might not be needed

--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -6,6 +6,8 @@ set -e
 # must pin urllib3 to 1.22 because 1.23 is incompatible with requests, which
 # is used by jenkins-job-builder
 pkgs=( "ansible" "jenkins-job-builder>=3.5.0" "urllib3==1.22" "pyopenssl" "ndg-httpsclient" "pyasn1" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 

--- a/ceph-build/build/setup_deb
+++ b/ceph-build/build/setup_deb
@@ -59,6 +59,8 @@ NORMAL_ARCH=$ARCH
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 chacra_url=https://chacra.ceph.com/

--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -49,6 +49,8 @@ NORMAL_ARCH=$ARCH
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # create the .chacractl config file using global variables

--- a/ceph-container-nighlity/build/build
+++ b/ceph-container-nighlity/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # XXX this might not be needed

--- a/ceph-container-prs/build/build
+++ b/ceph-container-prs/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # XXX this might not be needed

--- a/ceph-deploy-build/build/setup
+++ b/ceph-deploy-build/build/setup
@@ -22,6 +22,8 @@ if test -f /etc/redhat-release ; then
 fi
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-deploy-docs/build/build
+++ b/ceph-deploy-docs/build/build
@@ -4,6 +4,8 @@ set -ex
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # create the docs build with tox

--- a/ceph-deploy-pull-requests/build/setup
+++ b/ceph-deploy-pull-requests/build/setup
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "ansible" "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 

--- a/ceph-deploy-tag/build/build
+++ b/ceph-deploy-tag/build/build
@@ -9,6 +9,8 @@ fi
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "ansible" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # run ansible to do all the tagging and release specifying

--- a/ceph-dev-build/build/setup_deb
+++ b/ceph-dev-build/build/setup_deb
@@ -59,6 +59,8 @@ NORMAL_ARCH=$ARCH
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-dev-build/build/setup_osc
+++ b/ceph-dev-build/build/setup_osc
@@ -78,6 +78,8 @@ NORMAL_ARCH=$ARCH
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -51,6 +51,8 @@ NORMAL_ARCH=$ARCH
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-dev-new-build/build/setup_deb
+++ b/ceph-dev-new-build/build/setup_deb
@@ -59,6 +59,8 @@ NORMAL_ARCH=$ARCH
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-dev-new-build/build/setup_mingw
+++ b/ceph-dev-new-build/build/setup_mingw
@@ -45,6 +45,8 @@ NORMAL_ARCH=$ARCH
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -49,6 +49,8 @@ NORMAL_ARCH=$ARCH
 create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-iscsi-cli-flake8/build/build
+++ b/ceph-iscsi-cli-flake8/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 cd "$WORKSPACE/ceph-iscsi-cli"

--- a/ceph-iscsi-cli/build/setup
+++ b/ceph-iscsi-cli/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-iscsi-config-flake8/build/build
+++ b/ceph-iscsi-config-flake8/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 cd "$WORKSPACE/ceph-iscsi-config"

--- a/ceph-iscsi-config/build/setup
+++ b/ceph-iscsi-config/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-iscsi-stable/build/setup
+++ b/ceph-iscsi-stable/build/setup
@@ -45,6 +45,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 chacra_url="https://chacra.ceph.com/"

--- a/ceph-iscsi-tools/build/setup
+++ b/ceph-iscsi-tools/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-iscsi-tox/build/build
+++ b/ceph-iscsi-tox/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 cd "$WORKSPACE/ceph-iscsi"

--- a/ceph-iscsi/build/setup
+++ b/ceph-iscsi/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-medic-docs/build/build
+++ b/ceph-medic-docs/build/build
@@ -4,6 +4,8 @@ set -ex
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # trims leading slashes

--- a/ceph-medic-pull-requests/build/build
+++ b/ceph-medic-pull-requests/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 sudo yum install -y epel-release

--- a/ceph-medic-release/build/build_rpm
+++ b/ceph-medic-release/build/build_rpm
@@ -16,6 +16,8 @@ make rpm || ( tail -n +1 {root,build}.log && exit 1 )
 # Chacra time
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 make_chacractl_config

--- a/ceph-medic-rpm/build/build
+++ b/ceph-medic-rpm/build/build
@@ -18,6 +18,8 @@ make rpm || ( tail -n +1 {root,build}.log && exit 1 )
 # Chacra time
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/ceph-medic-tests/build/build
+++ b/ceph-medic-tests/build/build
@@ -1,5 +1,7 @@
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)

--- a/ceph-pr-commits/build/build
+++ b/ceph-pr-commits/build/build
@@ -17,6 +17,8 @@ fi
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "pytest" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 cd "$WORKSPACE"

--- a/ceph-qa-suite-pull-requests/build/build
+++ b/ceph-qa-suite-pull-requests/build/build
@@ -4,6 +4,8 @@ set -ex
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 

--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -13,6 +13,8 @@ rm -rf dist
 rm -rf RPMBUILD
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # create the .chacractl config file using global variables

--- a/ceph-tag/build/build
+++ b/ceph-tag/build/build
@@ -9,6 +9,8 @@ fi
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "ansible" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # run ansible to do all the tagging and release specifying

--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -10,6 +10,8 @@ github_status_setup
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" "github-status>0.0.3" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 GITHUB_STATUS_STATE="pending" $VENV/github-status create

--- a/ceph-volume-ansible-prs/build/teardown
+++ b/ceph-volume-ansible-prs/build/teardown
@@ -4,6 +4,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" "github-status>0.0.3" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 GITHUB_STATUS_STATE="failure" $VENV/github-status create

--- a/ceph-volume-nightly/build/build
+++ b/ceph-volume-nightly/build/build
@@ -4,6 +4,8 @@ WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 prune_stale_vagrant_vms $WORKSPACE/../**/tests

--- a/ceph-volume-pr/build/build
+++ b/ceph-volume-pr/build/build
@@ -8,6 +8,8 @@ github_status_setup
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" "github-status>0.0.3")
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 cd src/ceph-volume

--- a/ceph-volume-pr/build/teardown
+++ b/ceph-volume-pr/build/teardown
@@ -4,6 +4,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "github-status>0.0.3" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 GITHUB_STATUS_STATE="failure" $VENV/github-status create

--- a/ceph-volume-scenario/build/build
+++ b/ceph-volume-scenario/build/build
@@ -4,6 +4,8 @@ WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 

--- a/cephadm-ansible-prs/build/build
+++ b/cephadm-ansible-prs/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # XXX this might not be needed

--- a/cephmetrics-pull-requests/setup/setup
+++ b/cephmetrics-pull-requests/setup/setup
@@ -13,4 +13,6 @@ elif test -f /etc/debian_version ; then
 fi
 
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"

--- a/cephmetrics-release/build/setup
+++ b/cephmetrics-release/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # create the .chacractl config file using global variables

--- a/cephmetrics/build/setup
+++ b/cephmetrics/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/chacra-pull-requests/build/build
+++ b/chacra-pull-requests/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "ansible" "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # run ansible to get this current host to meet our requirements, specifying

--- a/configshell-fb/build/setup
+++ b/configshell-fb/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/diamond-build/build/setup
+++ b/diamond-build/build/setup
@@ -54,6 +54,8 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
 esac
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -10,6 +10,8 @@ set -euxo pipefail
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "jenkins-job-builder>=3.5.0" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]" latest
 
 # Wipe out JJB's cache if $FORCE is set.

--- a/kernel/build/setup
+++ b/kernel/build/setup
@@ -68,6 +68,8 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
 esac
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/merfi-pull-requests/build/build
+++ b/merfi-pull-requests/build/build
@@ -4,6 +4,8 @@ set -ex
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # run tox by recreating the environment and in verbose mode

--- a/mita-deploy/build/build
+++ b/mita-deploy/build/build
@@ -4,6 +4,8 @@ set -ex
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "ansible" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 cd "$WORKSPACE/deploy/playbooks/"

--- a/nfs-ganesha-stable/build/setup
+++ b/nfs-ganesha-stable/build/setup
@@ -45,6 +45,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 NFS_GANESHA_BRANCH=`branch_slash_filter $NFS_GANESHA_BRANCH`

--- a/nfs-ganesha/build/setup
+++ b/nfs-ganesha/build/setup
@@ -42,6 +42,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 NFS_GANESHA_BRANCH=`branch_slash_filter $NFS_GANESHA_BRANCH`

--- a/paddles-pull-requests/build/build
+++ b/paddles-pull-requests/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 sudo yum install -y epel-release

--- a/radosgw-agent-pull-requests/build/build
+++ b/radosgw-agent-pull-requests/build/build
@@ -2,6 +2,8 @@
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "ansible" "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 

--- a/radosgw-agent/build/build
+++ b/radosgw-agent/build/build
@@ -15,6 +15,8 @@ ls -l
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # create the .chacractl config file using global variables

--- a/rtslib-fb/build/setup
+++ b/rtslib-fb/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/samba/build/setup
+++ b/samba/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 SAMBA_BRANCH=$(branch_slash_filter $SAMBA_BRANCH)

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -2,8 +2,12 @@
 
 set -ex
 
-TEMPVENV=$(mktemp -td venv.XXXXXXXXXX)
-VENV="$TEMPVENV/bin"
+function create_venv_dir() {
+    local venv_dir
+    venv_dir=$(mktemp -td venv.XXXXXXXXXX)
+    trap "rm -rf ${venv_dir}" EXIT
+    echo "${venv_dir}"
+}
 
 function release_from_version() {
     local ver=$1

--- a/tcmu-runner/build/setup
+++ b/tcmu-runner/build/setup
@@ -36,6 +36,8 @@ echo "*****"
 export LC_ALL=C # the following is vulnerable to i18n
 
 pkgs=( "chacractl>=0.0.21" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # ask shaman which chacra instance to use

--- a/teuthology-docs/build/build
+++ b/teuthology-docs/build/build
@@ -4,6 +4,8 @@ set -ex
 
 # the following two methods exist in scripts/build_utils.sh
 pkgs=( "tox" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"
 
 # create the docs build with tox


### PR DESCRIPTION
- [x] scripts/build_utils.sh: pass VENV to helper functions #1813
- [ ] use create_venv_dir() helper (this PR)
- [ ] consolidate the code deploying githubcheck into a helper function

* define create_venv_dir() helper to
  1. create a temp dir
  2. set a trap to clean it up upon exit
* use create_venv_dir() in all scripts where
  TEMPVENV and/or VENV variables are used.

this change can help us to avoid creating a tempdir in /tmp,
and keep the tempdir forever.

Signed-off-by: Kefu Chai <kchai@redhat.com>