### PR TITLE
kernel: specify KDEB_SOURCENAME for make bindeb-pkg

### DIFF
--- a/kernel/build/build_deb
+++ b/kernel/build/build_deb
@@ -49,7 +49,7 @@ rm -f ../*.deb
 
 # Build the debs
 echo "Building DEBs"
-make -j$(getconf _NPROCESSORS_ONLN) bindeb-pkg
+KDEB_SOURCENAME="linux-$kernelrelease" make -j$(getconf _NPROCESSORS_ONLN) bindeb-pkg
 
 # Make sure we execute at the top level directory
 cd "$WORKSPACE"


### PR DESCRIPTION
Undo the damage caused by linux.git commit 82526ef43399 ("kbuild:
deb-pkg: change the source package name to linux-upstream").

We don't build a source package, but the source package name gets
embedded in the package metadata and ends up affecting the paths in
the repository generated by chacra.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>