### PR TITLE
ceph-ansible*: pass $TEMPVENV to start_tox

### DIFF
--- a/ceph-ansible-nightly/build/build
+++ b/ceph-ansible-nightly/build/build
@@ -46,7 +46,7 @@ function run_tox {
       ;;
   esac
 
-  [ -n "$CEPH_DOCKER_IMAGE_TAG" ] && start_tox CEPH_DOCKER_IMAGE_TAG="$CEPH_DOCKER_IMAGE_TAG"
+  [ -n "$CEPH_DOCKER_IMAGE_TAG" ] && start_tox $TEMPVENV CEPH_DOCKER_IMAGE_TAG="$CEPH_DOCKER_IMAGE_TAG"
 }
 
 ########

--- a/ceph-ansible-scenario/build/build
+++ b/ceph-ansible-scenario/build/build
@@ -19,4 +19,4 @@ update_vagrant_boxes
 # In the same logic, clean fact cache
 rm -rf $HOME/ansible/facts/*
 
-start_tox
+start_tox $TEMPVENV


### PR DESCRIPTION
to address the regression introduced by e302eaabb977f3e93b1a7005c879f4b2eba581fc

Signed-off-by: Kefu Chai <tchaikov@gmail.com>