### PR TITLE
ceph-ansible-syntax: fix broken job

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -6,7 +6,9 @@ set -e
 # shellcheck disable=SC2034
 # force virtualenv to be created earlier for this occurence, so we are not stuck because of ansible-lint dependencie,
 # which would enforce latest ansible version to be installed.
-virtualenv $TEMPVENV
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
+
 "$VENV"/pip install --upgrade pip
 "$VENV"/pip install -r "$WORKSPACE"/ceph-ansible/requirements.txt
 if [[ "$ghprbTargetBranch" == "stable-3.2" ]]; then


### PR DESCRIPTION
commit b09f6470745a09ce4fce0265cb7a22a56b049886 supposed to fix
regression introduced by e302eaabb977f3e93b1a7005c879f4b2eba581fc missed
the ceph-ansible-pr-syntax-check job, so the CI is still failing like
following:

```
[ceph-ansible-pr-syntax-check] $ /bin/bash /tmp/jenkins6031146002439656501.sh
+ set -e
+ virtualenv
You must provide a DEST_DIR
Usage: virtualenv [OPTIONS] DEST_DIR
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>