### PR TITLE
ceph-ansible-syntax: create virtualenv after dir creation

### DIFF
--- a/ceph-ansible-pr-syntax-check/build/build
+++ b/ceph-ansible-pr-syntax-check/build/build
@@ -8,6 +8,7 @@ set -e
 # which would enforce latest ansible version to be installed.
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
+virtualenv $TEMPVENV
 
 "$VENV"/pip install --upgrade pip
 "$VENV"/pip install -r "$WORKSPACE"/ceph-ansible/requirements.txt


### PR DESCRIPTION
add back venv creation that has been removed accidentally by
commit 3d832da831f0b938faa6f845617b0257bda184f4

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>