### PR TITLE
Add ceph-grafana job

### DIFF
--- a/ceph-grafana/build/build
+++ b/ceph-grafana/build/build
@@ -1,0 +1,5 @@
+sudo yum install -y buildah
+cd monitoring/grafana/build
+make build
+make push
+make clean

--- a/ceph-grafana/config/definitions/ceph-grafana.yml
+++ b/ceph-grafana/config/definitions/ceph-grafana.yml
@@ -1,0 +1,54 @@
+- job:
+    name: ceph-grafana
+    description: 'Builds the ceph-grafana container.'
+    project-type: freestyle
+    concurrent: true
+    display-name: 'ceph-grafana'
+    properties:
+      - groovy-label:
+          script: return ARCH + '&&centos8'
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 25
+          artifact-days-to-keep: 25
+          artifact-num-to-keep: 25
+      - github:
+          url: https://github.com/ceph/ceph
+
+    scm:
+        - git:
+            url: https://github.com/ceph/ceph
+            branches:
+                - $BRANCH
+            wipe-workspace: true
+
+    parameters:
+      - string:
+          name: BRANCH
+          description: "The git branch (or tag) to build"
+          default: master
+      - string:
+          name: ARCH
+          description: "Architecture to build for. Available options are: x86_64, arm64"
+          default: "x86_64"
+
+    builders:
+        - shell:
+            !include-raw:
+                ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: dmick-quay
+              username: CONTAINER_REPO_USERNAME
+              password: CONTAINER_REPO_PASSWORD
+          - username-password-separated:
+              credential-id: docker-hub-leseb
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD
+      - build-name:
+          name: "#${BUILD_NUMBER} ${BRANCH}, ${ARCH}"


### PR DESCRIPTION
This job builds a ceph-grafana container for a specific branch of Ceph and a specific architecture.  There are variables in the ceph.git Makefile that it invokes for versions of grafana and other included tools, but those are not currently exposed as parameters in this build job.

This job could be called by a parent job that builds both architectures on demand or via some trigger yet to be discussed.

This job's code depends on changes in https://github.com/ceph/ceph/pull/41559.