### PR TITLE
dashboard-pr: add JUnit tests

### DIFF
--- a/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
+++ b/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
@@ -88,3 +88,7 @@
           artifacts: 'logs/**'
           allow-empty: true
           latest-only: false
+
+      - junit:
+          results: 'src/pybind/mgr/dashboard/frontend/cypress/reports/results-*.xml'
+          allow-empty: true

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -101,3 +101,7 @@
           artifacts: 'build/out/mgr.*.log'
           allow-empty: true
           latest-only: false
+
+      - junit:
+          results: 'src/pybind/mgr/dashboard/frontend/cypress/reports/results-*.xml'
+          allow-empty: true


### PR DESCRIPTION
[JUnit Plugin](https://plugins.jenkins.io/junit/)
[JJB Config](https://docs.openstack.org/infra/jenkins-job-builder/publishers.html?highlight=junit#publishers.junit)

![Screenshot from 2022-07-04 15-12-52](https://user-images.githubusercontent.com/66050535/177300823-5389380f-7bcd-4c39-9343-3379963a6d8b.png)


TODO:
- [ ] Add [Claim plugin](https://plugins.jenkins.io/claim/): this would allow developers 'claim' ownership of a failure, so jobs failing with the same reason are automatically assigned to the same 'owner'.
- [ ] Add [Test Stability plugin](https://plugins.jenkins.io/test-stability/)


Signed-off-by: Ernesto Puerta <epuertat@redhat.com>