### PR TITLE
ceph-dev-*-trigger: stop building master on bionic

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -126,7 +126,7 @@
                     DISTROS=centos8
                     FLAVOR=crimson
                     ARCHS=x86_64
-      # If no release name is found in branch, build on all possible distro/flavor combos (except xenial).
+      # If no release name is found in branch, build on all possible distro/flavor combos (except xenial and bionic).
       # regex matching and 'on-evaluation-failure: run' doesn't work here so triple negative it is.
       - conditional-step:
           condition-kind: shell
@@ -143,7 +143,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal bionic centos8 windows
+                    DISTROS=focal centos8 windows
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -101,7 +101,7 @@
                     DISTROS=centos8
                     FLAVOR=crimson
       # build master on:
-      # default: focal bionic centos8 leap15
+      # default: focal centos8 leap15
       # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
@@ -118,7 +118,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal bionic centos8
+                    DISTROS=focal centos8
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -101,7 +101,7 @@
                     DISTROS=centos8
                     FLAVOR=crimson
       # build master on:
-      # default: focal centos8 leap15
+      # default: focal centos8
       # crimson: centos8
       - conditional-step:
           condition-kind: regex-match

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -844,23 +844,7 @@ ceph_build_args_from_flavor() {
     case "${flavor}" in
     default)
         CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
-        # we have to build quincy and up on bionic, because some teuthology tests are
-        # still using ubuntu bionic:
-        # - the perftest depends on cosbench which is not compatible with ubuntu/focal, see
-        #   https://tracker.ceph.com/issues/49139
-        # - we need to test old clients which are built on bionic. for instance, we don't build
-        #   nautilus on focal yet.
-        # - some upgrade tests still include bionic facets.
-        #
-        # do not specify -DALLOCATOR=tcmalloc in CEPH_EXTRA_CMAKE_ARGS, and let
-        # cmake figure it out:
-        # - on quincy and up, gperftools 2.6.2 is required, so we are not
-        #   impacted by https://tracker.ceph.com/issues/39703. and cmake uses
-        #   tcmalloc if gperftools 2.6.2 and up is found. on bionic, cmake
-        #   falls back to libc allocator.
-        # - before quincy, since ALLOCATOR is not specified, cmake uses
-        #   tcmalloc as long as gperftools is found, and the fix of
-        #   https://tracker.ceph.com/issues/39703 is still not removed.
+        CEPH_EXTRA_CMAKE_ARGS+=" -DALLOCATOR=tcmalloc"
         ;;
     crimson)
         CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"


### PR DESCRIPTION
in short, we don't need to test on bionic anymore for couple reasons:

- for accessing newer GCC
- for accessing more packages

see the discussion at
https://lists.ceph.io/hyperkitty/list/dev@ceph.io/thread/BW5NKQ4KTOPV7OYUBUHVDVCSH72LVIEO/

the only qa suite referencing ubuntu 18.02 is the qa/suites/orch/rook/smoke,
but it deploys ceph using Rook, and the container image of Ceph is
based on CentOS, so stop building on ubuntu/bionic does not
break it, despite the fact that 18.02 is included by
qa/suites/orch/rook/smoke/0-distro.

Signed-off-by: Kefu Chai <kchai@redhat.com>