### PR TITLE
pr-api: trigger on feature branches

### DIFF
--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -39,6 +39,7 @@
             - pacific
             - octopus
             - nautilus
+            - "feature-.*"
           trigger-phrase: 'jenkins test api'
           skip-build-phrase: '^jenkins do not test.*'
           only-trigger-phrase: false


### PR DESCRIPTION
While other Jenkins jobs don't filter by specific branches, the API
tests do, so we need to support 'feature-*' branch syntax.

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>