### PR TITLE
ceph-{ansible,container}*: Globally destroy all stale VMs

### DIFF
--- a/ceph-ansible-nightly/build/build
+++ b/ceph-ansible-nightly/build/build
@@ -52,6 +52,7 @@ function run_tox {
 ########
 # MAIN #
 ########
+prune_stale_vagrant_running_vms
 delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services

--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -11,6 +11,7 @@ source $VENV/activate
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
+prune_stale_vagrant_running_vms
 delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services

--- a/ceph-ansible-scenario/build/build
+++ b/ceph-ansible-scenario/build/build
@@ -11,6 +11,7 @@ source $VENV/activate
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
+prune_stale_vagrant_running_vms
 delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services

--- a/ceph-container-nighlity/build/build
+++ b/ceph-container-nighlity/build/build
@@ -11,6 +11,7 @@ source $VENV/activate
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
+prune_stale_vagrant_running_vms
 delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services

--- a/ceph-container-prs/build/build
+++ b/ceph-container-prs/build/build
@@ -11,6 +11,7 @@ source $VENV/activate
 
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
+prune_stale_vagrant_running_vms
 delete_libvirt_vms
 clear_libvirt_networks
 restart_libvirt_services


### PR DESCRIPTION
This can't be normal.

```
[jenkins-build@smithi020 ~]$ vagrant global-status
id       name        provider state     directory                                                                                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
531ccc7  osd3        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_filestore/tests/functional/fs-osds/container               
b1fa008  osd5        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_filestore/tests/functional/fs-osds/container               
cf2df32  osd0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_filestore/tests/functional/fs-osds/container               
43da811  osd2        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_filestore/tests/functional/fs-osds/container               
6118914  osd1        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_filestore/tests/functional/fs-osds/container               
3655031  osd4        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_filestore/tests/functional/fs-osds/container               
d162798  mon0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-dev-centos-container-rgw_multisite/tests/functional/rgw-multisite/container                               
fbe9b69  osd0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-dev-centos-container-rgw_multisite/tests/functional/rgw-multisite/container                               
94ce3f3  mon0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_bluestore/tests/functional/bs-osds/container               
d1d933d  osd2        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_bluestore/tests/functional/bs-osds/container               
be59686  osd1        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_bluestore/tests/functional/bs-osds/container               
1dcff2e  osd3        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_bluestore/tests/functional/bs-osds/container               
c122eb8  osd0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_bluestore/tests/functional/bs-osds/container               
f1b4b40  osd5        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_bluestore/tests/functional/bs-osds/container               
4499383  osd4        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-luminous-centos-container-stable-3.1-purge_bluestore/tests/functional/bs-osds/container               
7996de8  client0     libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
ec89b54  rgw0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
53f949b  mon2        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
8aa1130  nfs0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
9be2dcc  iscsi-gw0   libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
e1016c0  mds0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
b5e9a41  mon1        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
a832e6a  mgr0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
ebc71f2  rbd-mirror0 libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
95bd316  client1     libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
40876e4  osd1        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
e2b6fe8  osd0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
51d5614  mon0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-centos-non_container-all_daemons/tests/functional/all_daemons                                    
f72942f  osd0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-nautilus-ubuntu-container-stable-4.0-rgw_multisite/tests/functional/rgw-multisite/container/secondary 
5035d91  mon0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-nightly-nautilus-ubuntu-container-stable-4.0-rgw_multisite/tests/functional/rgw-multisite/container/secondary 
8f41bcc  mon0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-add_osds/tests/functional/add-osds/container                                             
fa8c0da  osd1        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-add_osds/tests/functional/add-osds/container                                             
d255b3c  osd0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-add_osds/tests/functional/add-osds/container                                             
c7fcbb3  mon0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-add_rgws/tests/functional/add-rgws/container                                             
ca78e52  rgw0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-add_rgws/tests/functional/add-rgws/container                                             
146d485  osd0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-add_rgws/tests/functional/add-rgws/container                                             
89bff4c  osd4        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-all_daemons/tests/functional/all_daemons/container                                       
99c7f02  osd3        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-all_daemons/tests/functional/all_daemons/container                                       
9941538  nfs0        libvirt preparing /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-update/tests/functional/all_daemons/container                                            
d874994  mgr0        libvirt preparing /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-update/tests/functional/all_daemons/container                                            
4ebe604  client0     libvirt preparing /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-container-update/tests/functional/all_daemons/container                                            
156ec4b  client1     libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
85fdfe9  client0     libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
5dc80b1  mon0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
806930a  nfs0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
7b9acc7  mgr0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
b885429  rgw0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
b74169d  iscsi-gw0   libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
bb4471b  mon2        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
66466ae  mon1        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
1f7eab1  mds1        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
8c4bf07  mds0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
c2c4be9  mds2        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
2ddd280  rbd-mirror0 libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
d32952f  osd2        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
39c56fe  osd1        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
65a1c63  osd0        libvirt running   /home/jenkins-build/build/workspace/ceph-ansible-prs-centos-non_container-switch_to_containers/tests/functional/all_daemons                                    
 
The above shows information about all known Vagrant environments
on this machine. This data is cached and may not be completely
up-to-date (use "vagrant global-status --prune" to prune invalid
entries). To interact with any of the machines, you can go to that
directory and run Vagrant, or you can use the ID directly with
Vagrant commands from any directory. For example:
"vagrant destroy 1a2b3c4d"
```

This also works but I didn't want to reinvent the wheel.

```
for vm in $(vagrant global-status | grep "running" | grep -v "$WORKSPACE\|provider" | awk '{ print $1 }'); do vagrant destroy -f $vm; done
```

Signed-off-by: David Galloway <dgallowa@redhat.com>