### PR TITLE
ansible: Pin centos8 vagrant builders to 2.2.10

### DIFF
--- a/ansible/examples/centos8-vagrant.yml
+++ b/ansible/examples/centos8-vagrant.yml
@@ -29,7 +29,9 @@
 
     - name: Set the latest vagrant version URL
       set_fact:
-        latest_vagrant_url: "https://releases.hashicorp.com/vagrant/{{ latest_vagrant_version.stdout }}/vagrant_{{ latest_vagrant_version.stdout }}_x86_64.rpm"
+        latest_vagrant_url: "https://releases.hashicorp.com/vagrant/2.2.10/vagrant_2.2.10_x86_64.rpm"
+        # Latest vagrant version sometimes has issue.  Pinning to 2.2.10 for now.
+        # latest_vagrant_url: "https://releases.hashicorp.com/vagrant/{{ latest_vagrant_version.stdout }}/vagrant_{{ latest_vagrant_version.stdout }}_x86_64.rpm"
 
     ## Wipe out vagrant stuff
     # From https://github.com/vagrant-libvirt/vagrant-libvirt/issues/943#issuecomment-463678158


### PR DESCRIPTION
Seeing weird random failures with 2.2.16.

Signed-off-by: David Galloway <dgallowa@redhat.com>