### PR TITLE
scripts/build_utils.sh: Remove virsh save images

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1048,6 +1048,7 @@ delete_libvirt_vms() {
     for vm in $libvirt_vms; do
         # Destroy returns a non-zero rc if the VM's not running
         sudo virsh destroy $vm || true
+        sudo virsh managedsave-remove $vm || true
         sudo virsh undefine $vm || true
     done
     # Clean up any leftover disk images


### PR DESCRIPTION
Fixes

```
+ sudo virsh undefine container_rgw0_1623696405_fb24199d9194c338f3d6
error: Refusing to undefine while domain managed save image exists
```
and subsequent
```
+ sudo service libvirt-guests restart
Redirecting to /bin/systemctl restart libvirt-guests.service
Job for libvirt-guests.service failed because the control process exited with error code.
See "systemctl status libvirt-guests.service" and "journalctl -xe" for details.
Build step 'Conditional step (single)' marked build as failure

Jun 15 15:40:10 braggi19 libvirt-guests.sh[44513]: Resuming guest container_rgw0_1623696405_fb24199d9194c338f3d6: error: Failed to start domain container_rgw0_1623696405_fb24199d9194c338f3d6
Jun 15 15:40:10 braggi19 libvirt-guests.sh[44513]: error: Network not found: no network with matching name 'vagrant-libvirt'
Jun 15 15:40:11 braggi19 systemd[1]: libvirt-guests.service: Main process exited, code=exited, status=1/FAILURE
Jun 15 15:40:11 braggi19 systemd[1]: libvirt-guests.service: Failed with result 'exit-code'.
Jun 15 15:40:11 braggi19 systemd[1]: Failed to start Suspend/Resume Running libvirt Guests.
```

Signed-off-by: David Galloway <dgallowa@redhat.com>