### PR TITLE
ceph-ansible-prs: use braggi for biggest jobs

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -1,6 +1,6 @@
 - project:
-    name: ceph-ansible-prs-smithi
-    slave_labels: 'vagrant && libvirt && smithi'
+    name: ceph-ansible-prs-braggi-adami
+    slave_labels: 'vagrant && libvirt && (braggi||adami)'
     distribution:
       - centos
     deployment:


### PR DESCRIPTION
smithi and ovh workers aren't enough powerful, let's use braggi and
adami instead for those jobs.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>