### PR TITLE
ansible: Give registration tasks a tag

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -818,6 +818,7 @@
         executors: '{{ executors|default(1) }}'
         exclusive: true
       when: not permanent|bool
+      tags: register
 
     - name: Register Permanent Slave
       block:
@@ -871,3 +872,4 @@
             enabled: yes
           when: jar_changed is changed or unit_files_changed is changed
       when: permanent|bool
+      tags: register


### PR DESCRIPTION
This is so I can skip it when I'm setting up a new CentOS 8 Vagrant builder.

https://wiki.sepia.ceph.com/doku.php?id=production:jenkins.ceph.com&#setting_up_new_jenkins_builder

Signed-off-by: David Galloway <dgallowa@redhat.com>