### PR TITLE
ansible: Pin vagrant-libvirt to 0.3.0

### DIFF
--- a/ansible/examples/centos8-vagrant.yml
+++ b/ansible/examples/centos8-vagrant.yml
@@ -72,18 +72,21 @@
         LDFLAGS='-L/opt/vagrant/embedded/' ./configure
         make
         sudo cp lib/libk5crypto.* /opt/vagrant/embedded/lib/
-        wget https://vault.centos.org/8.4.2105/BaseOS/Source/SPackages/libssh-0.9.4-2.el8.src.rpm
-        rpm2cpio libssh-0.9.4-2.el8.src.rpm | cpio -imdV
-        tar xf libssh-0.9.4.tar.xz
-        mkdir build
-        cd build
-        cmake ../libssh-0.9.4 -DOPENSSL_ROOT_DIR=/opt/vagrant/embedded/
-        make
-        cp lib/libssh* /opt/vagrant/embedded/lib64
+# This was required for vagrant-libvirt version 0.5.3.  That version was giving us a lot of trouble
+# so we've pinned vagrant-libvirt to a known good version, 0.3.0.
+# Just saving this in case we want in in the future.
+#        wget https://vault.centos.org/8.4.2105/BaseOS/Source/SPackages/libssh-0.9.4-2.el8.src.rpm
+#        rpm2cpio libssh-0.9.4-2.el8.src.rpm | cpio -imdV
+#        tar xf libssh-0.9.4.tar.xz
+#        mkdir build
+#        cd build
+#        cmake ../libssh-0.9.4 -DOPENSSL_ROOT_DIR=/opt/vagrant/embedded/
+#        make
+#        cp lib/libssh* /opt/vagrant/embedded/lib64
 
     # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/943#issuecomment-479360033
     - name: Install the vagrant-libvirt plugin (EL)
-      shell: vagrant plugin install vagrant-libvirt
+      shell: vagrant plugin install vagrant-libvirt --plugin-version 0.3.0
       become_user: "{{ jenkins_user }}"
       environment:
         CONFIGURE_ARGS: 'with-ldflags=-L/opt/vagrant/embedded/lib with-libvirt-include=/usr/include/libvirt with-libvirt-lib=/usr/lib'

--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -190,7 +190,7 @@
         - ansible_distribution_major_version|int <= 7
       tags: always
 
-    # EPEL8 RPMs
+    # EL8 RPMs
     - set_fact:
         epel_rpms:
           - jq
@@ -201,6 +201,15 @@
           - podman
         container_service_name: podman
         container_certs_path: "/etc/containers/certs.d/{{ container_mirror }}"
+        hackery_packages:
+          - gcc
+          - libguestfs-tools-c
+          - libvirt
+          - libvirt-devel
+          - libxml2-devel
+          - libxslt-devel
+          - make
+          - ruby-devel
       when:
         - ansible_os_family == "RedHat"
         - ansible_distribution_major_version|int >= 8
@@ -614,15 +623,41 @@
           become_user: "{{ jenkins_user }}"
           when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int <= 7) or
                 (ansible_os_family == "Debian" and ansible_distribution_major_version|int <= 18)
-    
-        - name: Install the vagrant-libvirt plugin (EL8/Suse)
+
+        - name: Install packages needed to build krb5 from source (EL8)
+          dnf:
+            name: "{{ hackery_packages }}"
+            state: present
+          when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
+
+        - name: Build krb5 library from source (EL8)
+          shell: |
+            cd $(mktemp -d)
+            wget https://vault.centos.org/8.4.2105/BaseOS/Source/SPackages/krb5-1.18.2-8.el8.src.rpm
+            rpm2cpio krb5-1.18.2-8.el8.src.rpm | cpio -imdV
+            tar xf krb5-1.18.2.tar.gz; cd krb5-1.18.2/src
+            LDFLAGS='-L/opt/vagrant/embedded/' ./configure
+            make
+            sudo cp lib/libk5crypto.* /opt/vagrant/embedded/lib/
+          when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
+
+        # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1127#issuecomment-713651332
+        - name: Install the vagrant-libvirt plugin (EL8)
+          command: vagrant plugin install vagrant-libvirt --plugin-version 0.3.0
+          become_user: "{{ jenkins_user }}"
+          environment:
+            CONFIGURE_ARGS: 'with-ldflags=-L/opt/vagrant/embedded/lib with-libvirt-include=/usr/include/libvirt with-libvirt-lib=/usr/lib'
+            GEM_HOME: '~/.vagrant.d/gems'
+            GEM_PATH: '$GEM_HOME:/opt/vagrant/embedded/gems'
+          when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
+
+        - name: Install the vagrant-libvirt plugin (Suse)
           command: vagrant plugin install vagrant-libvirt
           become_user: "{{ jenkins_user }}"
           environment:
             CONFIGURE_ARGS: 'with-libvirt-include=/usr/include/libvirt with-libvirt-lib=/usr/lib64'
-          when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8) or
-                ansible_os_family == "Suse"
-    
+          when: ansible_os_family == "Suse"
+
         - name: Install the vagrant-libvirt plugin (Focal)
           command: vagrant plugin install vagrant-libvirt
           become_user: "{{ jenkins_user }}"


### PR DESCRIPTION
The latest version (and possibly older) 0.5.3 is giving us tons of issues.

- VMs hanging on `vagrant up`
- `vagrant ssh-config` failing

Not to mention we have to manually build libssh as well as krb5.

Let's not mess with all that.

With this PR, we also don't /need/ to run centos8-vagrant.yml.  It can be used to RE-install vagrant but the separate playbook is no longer required.

Signed-off-by: David Galloway <dgallowa@redhat.com>