### PR TITLE
project config: dashboard-cephadm-e2e

### DIFF
--- a/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
+++ b/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
@@ -1,0 +1,83 @@
+- job:
+    name: ceph-dashboard-cephadm-e2e
+    project-type: freestyle
+    defaults: global
+    concurrent: true
+    node: huge && focal && x86_64
+    display-name: 'ceph: Dashboard + Cephadm E2E'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 300
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+      - github:
+          url: https://github.com/ceph/ceph/
+      - rebuild:
+          auto-rebuild: true
+      - inject:
+          properties-content: |
+            TERM=xterm
+
+    parameters:
+      - string:
+          name: sha1
+          description: "commit id or a refname, like 'origin/pr/72/head'"
+
+    triggers:
+      - github-pull-request:
+          cancel-builds-on-update: true
+          allow-whitelist-orgs-as-admins: true
+          org-list:
+            - ceph
+          white-list-labels:
+            - cephadm
+            - dashboard
+          black-list-target-branches:
+            - luminous
+            - mimic
+            - nautilus
+          trigger-phrase: 'jenkins test dashboard cephadm'
+          skip-build-phrase: '^jenkins do not test.*'
+          only-trigger-phrase: false
+          github-hooks: true
+          permit-all: true
+          auto-close-on-fail: false
+          status-context: "ceph dashboard cephadm e2e tests"
+          started-status: "running ceph dashboard cephadm e2e tests"
+          success-status: "ceph dashboard cephadm e2e tests succeeded"
+          failure-status: "ceph dashboard cephadm e2e tests failed"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph.git
+          branches:
+            - origin/pr/${ghprbPullId}/merge
+          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          browser: auto
+          timeout: 20
+          skip-tag: true
+          shallow-clone: true
+          wipe-workspace: true
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/dashboard/install-cephadm-e2e-deps.sh
+      - shell: |
+          export CYPRESS_ARGS="--record --key $CYPRESS_RECORD_KEY --tag $ghprbTargetBranch" COMMIT_INFO_MESSAGE="$ghprbPullTitle"
+          timeout 7200 ./src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - text:
+              credential-id: cd-cypress-record-key
+              variable: CYPRESS_RECORD_KEY
+      - ansicolor

--- a/scripts/dashboard/install-cephadm-e2e-deps.sh
+++ b/scripts/dashboard/install-cephadm-e2e-deps.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -ex
+
+on_error() {
+    if [ "$1" != "0" ]; then
+        printf "\n\nERROR $1 thrown on line $2\n\n"
+        printf "\n\nCollecting info...\n\n"
+        sudo journalctl --since "10 min ago" --no-tail --no-pager -x
+        printf "\n\nERROR: displaying containers' logs:\n\n"
+        docker ps -aq | xargs docker logs
+        printf "\n\nTEST FAILED.\n\n"
+    fi
+}
+
+trap 'on_error $? $LINENO' ERR
+
+sudo apt -y install libvirt-daemon-system libvirt-daemon-driver-qemu qemu-kvm libvirt-clients
+
+sudo usermod -aG libvirt $(id -un)
+newgrp libvirt  # Avoid having to log out and log in for group addition to take effect.
+sudo systemctl enable --now libvirtd
+
+if [[ $(command -v docker) == '' ]]; then
+    # Set up docker official repo and install docker.
+    sudo apt update -y
+    sudo apt install \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+    echo \
+        "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+        $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt update -y
+    sudo apt install -y docker-ce docker-ce-cli containerd.io
+fi
+sudo groupadd docker || true
+sudo usermod -aG docker $(id -un)
+sudo systemctl start docker
+sudo chgrp "$(id -un)" /var/run/docker.sock
+
+docker info
+docker container prune -f
+
+KCLI_CONFIG_DIR="${HOME}/.kcli"
+mkdir -p ${KCLI_CONFIG_DIR}
+if [[ ! -f "${KCLI_CONFIG_DIR}/id_rsa" ]]; then
+    ssh-keygen -t rsa -q -f "${KCLI_CONFIG_DIR}/id_rsa" -N ""
+fi
+
+: ${KCLI_CONTAINER_IMAGE:='quay.io/karmab/kcli'}
+
+echo "#!/usr/bin/env bash
+
+docker run --net host --security-opt label=disable \
+    -v ${KCLI_CONFIG_DIR}:/root/.kcli \
+    -v ${PWD}:/workdir \
+    -v /var/lib/libvirt/images:/var/lib/libvirt/images \
+    -v /var/run/libvirt:/var/run/libvirt \
+    -v /var/tmp:/ignitiondir \
+    ${KCLI_CONTAINER_IMAGE} \""'${@}'"\"
+" | sudo tee /usr/local/bin/kcli
+sudo chmod +x /usr/local/bin/kcli
+
+# Install required deps.
+sudo apt update -y
+sudo apt install -y nodejs npm openssh-server
+
+# KCLI cleanup function can be found here: https://github.com/ceph/ceph/blob/master/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+sudo mkdir -p /var/lib/libvirt/images/ceph-dashboard
+kcli create pool -p /var/lib/libvirt/images/ceph-dashboard ceph-dashboard
+kcli create network -c 192.168.100.0/24 ceph-dashboard


### PR DESCRIPTION
To be merged after https://github.com/ceph/ceph/pull/42263

Project: run Dashboard E2E tests with cephadm as orchestrator backend
  on dashboard/cephadm PRs.

Fixes: https://tracker.ceph.com/issues/51301

Signed-off-by: Alfonso Martínez <almartin@redhat.com>