### PR TITLE
ansible: Pin CentOS7 vagrant-libvirt to 0.3.0

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -619,7 +619,7 @@
     - name: Install vagrant-libvirt plugin
       block:
         - name: Install the vagrant-libvirt plugin (without args)
-          shell: vagrant plugin install vagrant-libvirt
+          shell: vagrant plugin install vagrant-libvirt --plugin-version 0.3.0
           become_user: "{{ jenkins_user }}"
           when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int <= 7) or
                 (ansible_os_family == "Debian" and ansible_distribution_major_version|int <= 18)


### PR DESCRIPTION
So the vagrant-libvirt project itself admits that it does not support CentOS8.

Jobs /usually/ pass on the smithi builders (CentOS7.9, Vagrant 2.2.3, and vagrant-libvirt 0.3.0) so let's try running that everywhere.

Signed-off-by: David Galloway <dgallowa@redhat.com>