### PR TITLE
ceph-ansible-prs: Debug vagrant problems

### DIFF
--- a/ceph-ansible-prs/build/teardown
+++ b/ceph-ansible-prs/build/teardown
@@ -4,6 +4,13 @@ cd $WORKSPACE/tests
 
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
+
+echo "========= VAGRANT DEBUGGING ========="
+sudo virsh list --all
+for net in $(sudo virsh net-list --name); do sudo virsh net-dhcp-leases ${net}; done
+sudo journalctl -u libvirtd --pager-end --no-pager
+echo "======= END VAGRANT DEBUGGING ======="
+
 # the method exists in scripts/build_utils.sh
 teardown_vagrant_tests $VENV
 


### PR DESCRIPTION
Occasionally having VMs come up but not get an IP.  Or vagrant thinks they got an IP but didn't.  This is impossible to debug after the VMs in the job are torn down so let's spit out some debug info before that.

Signed-off-by: David Galloway <dgallowa@redhat.com>