### PR TITLE
ceph-ansible-prs: don't run all_in_one on smithi

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -8,6 +8,7 @@
       - non_container
     scenario:
       - all_daemons
+      - all_in_one
       - update
       - purge
       - switch_to_containers
@@ -31,7 +32,6 @@
       - lvm_osds
       - collocation
       - lvm_batch
-      - all_in_one
       - external_clients
     jobs:
       - 'ceph-ansible-prs-auto'


### PR DESCRIPTION
smithi nodes aren't enough powerful for that job, let's run it on either
braggi or amadi

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>