### PR TITLE
ceph-volume-test: add missing SUBCOMMAND definition

### DIFF
--- a/ceph-volume-test/config/definitions/ceph-volume-test.yml
+++ b/ceph-volume-test/config/definitions/ceph-volume-test.yml
@@ -343,6 +343,7 @@
                   current-parameters: true
                   predefined-parameters: |
                     SCENARIO=xenial-bluestore-mixed_type
+                    SUBCOMMAND=batch
                 - name: ceph-volume-scenario
                   current-parameters: true
                   predefined-parameters: |


### PR DESCRIPTION
This is making some tests fail in the CI like following:

```
+ /tmp/venv.LBZdiW0Nx4/bin/tox --workdir=/tmp/tox.pQhNDR2lrs -vre
  xenial-bluestore-mixed_type -- --provider=libvirt
  using tox.ini:
  /home/jenkins-build/build/workspace/ceph-volume-scenario/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
  (pid 1864)
  ERROR: unknown environment 'xenial-bluestore-mixed_type'
```

it's picking up the wrong tox.ini file because SUBCOMMAND isn't injected
as it should be.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>