### PR TITLE
ceph-volume-test: add missing SUBCOMMAND var

### DIFF
--- a/ceph-volume-test/config/definitions/ceph-volume-test.yml
+++ b/ceph-volume-test/config/definitions/ceph-volume-test.yml
@@ -283,6 +283,7 @@
                   current-parameters: true
                   predefined-parameters: |
                     SCENARIO=centos7-bluestore-mixed_type
+                    SUBCOMMAND=batch
                 - name: ceph-volume-scenario
                   current-parameters: true
                   predefined-parameters: |


### PR DESCRIPTION
SUBCOMMAND is missing for `centos7-bluestore-mixed_type` test.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>