### PR TITLE
ceph-pull-requests-arm64: reenable test on arm64

### DIFF
--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -68,6 +68,4 @@
         failure-status: "make check failed"
         white-list-target-branches:
         - master
-        white-list-labels:
-          - arm64
     wrappers: []


### PR DESCRIPTION
since the dependencies on aarch64 are available now, and the "make
check" passes on this architecture also. let's test the PRs on arm64.

this change reverts 1e0b902baa33b3b972891779d2950e580bb18e63

Signed-off-by: Kefu Chai <kchai@redhat.com>