### PR TITLE
cephadm-ansible: use dedicated credential-id

### DIFF
--- a/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
+++ b/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
@@ -108,7 +108,7 @@
           mask-password-params: true
       - credentials-binding:
           - username-password-separated:
-              credential-id: ceph-ansible-upstream-ci
+              credential-id: cephadm-ansible-upstream-ci
               username: DOCKER_HUB_USERNAME
               password: DOCKER_HUB_PASSWORD
 


### PR DESCRIPTION
This makes the cephadm-ansible job use the right credential id

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>