### PR TITLE
build_utils: set extra args for jaeger based on branch name

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -131,7 +131,7 @@
       - conditional-step:
           condition-kind: shell
           condition-command: |
-            echo "${GIT_BRANCH}" | grep -v '\(luminous\|mimic\|nautilus\|octopus\|pacific\|crimson-only\)'
+            echo "${GIT_BRANCH}" | grep -v '\(luminous\|mimic\|nautilus\|octopus\|pacific\|crimson-only\|jaeger)'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -171,6 +171,27 @@
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=crimson
+                    ARCHS=x86_64
+      # Build jaegertracing branch on needed env,  don't waste resources on the default one.
+      # Useful for testing specific builds failure
+      # default: focal, centos8
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*jaeger.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=centos8 focal
+                    FLAVOR=jaeger
                     ARCHS=x86_64
 
     wrappers:

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -56,8 +56,9 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           choices:
             - default
             - crimson
+            - jaeger
           default: "default"
-          description: "Type of Ceph build, choices are: crimson, default. Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: crimson, jaeger, default. Defaults to: 'default'"
 
       - string:
           name: CI_CONTAINER

--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -36,6 +36,7 @@ rm -rf release
 echo "Running submodule update ..."
 git submodule update --init
 
+# export args for building optional packages
 ceph_build_args_from_flavor ${FLAVOR}
 
 # When using autotools/autoconf it is possible to see output from `git diff`

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -840,7 +840,7 @@ gen_debian_version() {
 # Flavor Builds support
 # - CEPH_EXTRA_RPMBUILD_ARGS is consumed by build_rpms()
 # - CEPH_EXTRA_CMAKE_ARGS is consumed by debian/rules and ceph.spec directly
-# - PROFILES is consumed by pbuilder
+# - PROFILES is consumed by build_debs()
 ceph_build_args_from_flavor() {
     local flavor=$1
     shift
@@ -914,7 +914,12 @@ build_debs() {
 
     CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS $(extra_cmake_args)"
     DEB_BUILD_OPTIONS="parallel=$(get_nr_build_jobs)"
-    PROFILES="nocheck,$PROFILES"
+
+    if [ -z "$PROFILES" ]; then
+      PROFILES="nocheck,$PROFILES"
+    else
+      PROFILES="nocheck"
+    fi
 
     # pass only those env vars specifically noted
     sudo \


### PR DESCRIPTION

1. if jaeger in branch name for ceph-ci: this shall only build focal and centos 8
   default packages with jaeger on, the FLAVOR=jaeger gets exported to ceph_extra_args_flavor 

Jaeger can be useful when someone wants to do analysis with tracing, most preferably we want to use it on centos 8 and focal, for component of interest, that can be a perf/latency analysis for crimson to debugging operations in client, please use preferred method to produce ceph builds with jaeger as adding jaeger suffix to branch name. 

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>