### PR TITLE
ceph-ansible-prs: use braggi or adami only for cephadm_adopt

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -50,7 +50,7 @@
 
 - project:
     name: ceph-ansible-prs-cephadm
-    slave_labels: 'vagrant && libvirt && (smithi || braggi || centos7)'
+    slave_labels: 'vagrant && libvirt && (braggi || adami)'
     distribution:
       - centos
     deployment:


### PR DESCRIPTION
smithi nodes aren't enough powerful for that job.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>