### PR TITLE
ceph-website: Build PR checkouts

### DIFF
--- a/ceph-website/config/definitions/ceph-website.yml
+++ b/ceph-website/config/definitions/ceph-website.yml
@@ -45,11 +45,11 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph.io
+          branches:
+            - main
+            - origin/pr/${ghprbPullId}/merge
+          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
           browser: auto
-          # The default is to build and publish every branch.
-          # Uncomment this for testing:
-          #branches:
-          #  - 'origin/master'
           skip-tag: true
           timeout: 20
           wipe-workspace: true


### PR DESCRIPTION
The previous way this was configured would only build branches from this repo; no forks.  When a PR is submitted from a fork, the job would just build main.  Oops.

Signed-off-by: David Galloway <dgallowa@redhat.com>