### PR TITLE
ceph-ansible-prs: add purge-dashboard jobs

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -62,6 +62,19 @@
       - 'ceph-ansible-prs-common-trigger'
 
 - project:
+    name: ceph-ansible-prs-purge-dashboard
+    slave_labels: 'vagrant && libvirt && (adami || braggi)'
+    distribution:
+      - centos
+    deployment:
+      - container
+      - non_container
+    scenario:
+      - purge_dashboard
+    jobs:
+      - 'ceph-ansible-prs-common-trigger'
+
+- project:
     name: ceph-ansible-prs-common-trigger
     slave_labels: 'vagrant && libvirt && (smithi || braggi || centos7)'
     distribution:


### PR DESCRIPTION
This adds the purge-dashboards jobs for both container and non container
scenarios.
Those scenarios aren't triggered by default.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>