### PR TITLE
ceph-dev-new-trigger: add escape ) by adding \ before it

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -131,7 +131,7 @@
       - conditional-step:
           condition-kind: shell
           condition-command: |
-            echo "${GIT_BRANCH}" | grep -v '\(luminous\|mimic\|nautilus\|octopus\|pacific\|crimson-only\|jaeger)'
+            echo "${GIT_BRANCH}" | grep -v '\(luminous\|mimic\|nautilus\|octopus\|pacific\|crimson-only\|jaeger\)'
           on-evaluation-failure: dont-run
           steps:
             - shell:


### PR DESCRIPTION
this should address the regression introduced by
99ac2b60d3e9c236802daf752d9924076151bf82

Signed-off-by: Kefu Chai <kchai@redhat.com>