### PR TITLE
scripts/build_utils.sh: quote $PROFILES

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -922,7 +922,7 @@ build_debs() {
         --distribution $DIST \
         --basetgz $pbuilddir/$DIST.tgz \
         --buildresult $releasedir/$cephver \
-        --profiles $PROFILES \
+        --profiles "$PROFILES" \
         --use-network yes \
         $releasedir/$cephver/ceph_$bpvers.dsc
 


### PR DESCRIPTION
otherwise the following "--use-network" would be taken as a profile,
and "yes" is used as the path to package's dsc file.

Signed-off-by: Kefu Chai <kchai@redhat.com>