### PR TITLE
build_utils: fix $PROFILES not storing requried profiles

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -847,17 +847,17 @@ ceph_build_args_from_flavor() {
     default)
         CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
         CEPH_EXTRA_CMAKE_ARGS+=" -DALLOCATOR=tcmalloc"
-        PROFILES=""
+        export PROFILES=""
         ;;
     crimson)
         CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
         CEPH_EXTRA_CMAKE_ARGS+=" -DCMAKE_BUILD_TYPE=Debug"
         CEPH_EXTRA_CMAKE_ARGS+=" -DWITH_SEASTAR=ON"
-        PROFILES="pkg.ceph.crimson"
+        export PROFILES="pkg.ceph.crimson"
         ;;
     jaeger)
         CEPH_EXTRA_RPMBUILD_ARGS="--with jaeger"
-        PROFILES="pkg.ceph.jaeger"
+        export PROFILES="pkg.ceph.jaeger"
         ;;
     *)
         echo "unknown FLAVOR: ${FLAVOR}" >&2


### PR DESCRIPTION
theory: ceph_build_args_from_flavor runs and set's variables for subshell
running `ceph-dev-new-setup/build/build` while we consume $PROFILES from
subshell for `ceph-build/build/build_deb` which is why $PROFILES is
always --profiles '' irrespective of flavor used.

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>

Falied example: 
https://jenkins.ceph.com/job/ceph-dev-new-build/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=focal,DIST=focal,MACHINE_SIZE=gigantic/55927//consoleFull

flavor: jaeger, working fine since I can see, --with jaeger being set.