### PR TITLE
scripts/build_utils: populate DEB_BUILD_PROFILES using dist/other_env…

### DIFF
--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -151,9 +151,12 @@ cat > dist/branch << EOF
 BRANCH=${BRANCH}
 EOF
 
-# CEPH_EXTRA_{CONFIGURE,RPMBUILD}_ARGS are consumed by ceph-build before
-# the switch to cmake; CEPH_EXTRA_CMAKE_ARGS is for after cmake
+# - CEPH_EXTRA_RPMBUILD_ARGS are consumed by build_rpm before
+#   the switch to cmake;
+# - CEPH_EXTRA_CMAKE_ARGS is for after cmake
+# - DEB_BUILD_PROFILES is consumed by build_debs()
 cat > dist/other_envvars << EOF
 CEPH_EXTRA_RPMBUILD_ARGS=${CEPH_EXTRA_RPMBUILD_ARGS}
 CEPH_EXTRA_CMAKE_ARGS=${CEPH_EXTRA_CMAKE_ARGS}
+DEB_BUILD_PROFILES=${DEB_BUILD_PROFILES}
 EOF

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -847,17 +847,17 @@ ceph_build_args_from_flavor() {
     default)
         CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
         CEPH_EXTRA_CMAKE_ARGS+=" -DALLOCATOR=tcmalloc"
-        PROFILES=""
+        DEB_BUILD_PROFILES=""
         ;;
     crimson)
         CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
         CEPH_EXTRA_CMAKE_ARGS+=" -DCMAKE_BUILD_TYPE=Debug"
         CEPH_EXTRA_CMAKE_ARGS+=" -DWITH_SEASTAR=ON"
-        PROFILES="pkg.ceph.crimson"
+        DEB_BUILD_PROFILES="pkg.ceph.crimson"
         ;;
     jaeger)
         CEPH_EXTRA_RPMBUILD_ARGS="--with jaeger"
-        PROFILES="pkg.ceph.jaeger"
+        DEB_BUILD_PROFILES="pkg.ceph.jaeger"
         ;;
     *)
         echo "unknown FLAVOR: ${FLAVOR}" >&2
@@ -918,11 +918,11 @@ build_debs() {
     sudo \
         CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS" \
         DEB_BUILD_OPTIONS="$DEB_BUILD_OPTIONS" \
+        DEB_BUILD_PROFILES="$DEB_BUILD_PROFILES" \
         pbuilder build \
         --distribution $DIST \
         --basetgz $pbuilddir/$DIST.tgz \
         --buildresult $releasedir/$cephver \
-        --profiles "$PROFILES" \
         --use-network yes \
         $releasedir/$cephver/ceph_$bpvers.dsc
 


### PR DESCRIPTION
…vars

* rename PROFILES to DEB_BUILD_PROFILES so it's more explicit that
  DEB_BUILD_PROFILES is for debian package build
* populate DEB_BUILD_PROFILES using dist/other_envvars, so that
  this environment variable can be populate to the next jenkins job.
  as dist/other_envvars is specified as one of the "properties-file"s
  in ceph-*build/config/definitions/ceph-build.yml and
* pass DEB_BUILD_PROFILES to pbuilder via an environment
  variable with the same name. more consistent this way, as
  DEB_BUILD_OPTIONS is also passed this way.

Signed-off-by: Kefu Chai <kchai@redhat.com>