### PR TITLE
add ceph-grafana-trigger job

### DIFF
--- a/ceph-grafana-trigger/build/build
+++ b/ceph-grafana-trigger/build/build
@@ -1,0 +1,21 @@
+#!/bin/bash -ex
+
+CONTAINER_VERSION=${CONTAINER_VERSION:-6.7.4}
+CONTAINER=ceph/ceph-grafana:${CONTAINER_VERSION}
+sudo dnf install -y podman
+sudo podman login docker.io -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}
+sudo podman login quay.io -u ${CONTAINER_REPO_USERNAME} -p ${CONTAINER_REPO_PASSWORD}
+
+for repohost in quay.io docker.io; do
+        sudo podman rmi -f grafana:${CONTAINER_VERSION}-combined ${repohost}/${CONTAINER}-x86_64 ${repohost}/${CONTAINER}-aarch64  || true
+
+        sudo podman pull ${repohost}/${CONTAINER}-x86_64
+        sudo podman pull ${repohost}/${CONTAINER}-aarch64
+        sudo podman manifest create grafana:${CONTAINER_VERSION}-combined
+        sudo podman manifest add grafana:${CONTAINER_VERSION}-combined ${repohost}/${CONTAINER}-x86_64
+        sudo podman manifest add grafana:${CONTAINER_VERSION}-combined ${repohost}/${CONTAINER}-aarch64
+
+        sudo podman manifest push grafana:${CONTAINER_VERSION}-combined ${repohost}/${CONTAINER}-combined
+
+        sudo podman rmi -f grafana:${CONTAINER_VERSION}-combined ${repohost}/${CONTAINER}-x86_64 ${repohost}/${CONTAINER}-aarch64  || true
+done

--- a/ceph-grafana-trigger/config/definitions/ceph-grafana-trigger.yml
+++ b/ceph-grafana-trigger/config/definitions/ceph-grafana-trigger.yml
@@ -1,0 +1,62 @@
+- job:
+    name: ceph-grafana-trigger
+    description: 'Build a combined container image "manifest list" for ceph-grafana that includes both architectures'
+    node: centos8
+    project-type: freestyle
+    defaults: global
+    concurrent: true
+    display-name: 'ceph-grafana-trigger'
+    block-downstream: true
+    properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 10
+          artifact-num-to-keep: 10
+      - github:
+          url: https://github.com/ceph/ceph
+
+    parameters:
+      - string:
+          name: BRANCH
+          description: "The git branch (or tag) to build"
+          default: master
+      - string:
+          name: CONTAINER_VERSION
+          description: "The version tag for the containers; will have -ARCH added to it.  By convention, the version of Grafana"
+          default: "6.7.4"
+    axes:
+        - axis:
+            type: label-expression
+            name: ARCH
+            values:
+                - x86_64
+                - arm64
+    builders:
+        - trigger-builds:
+            - project: ceph-grafana
+              predefined-parameters: ARCH=x86_64
+              current-parameters: true
+              block: true
+        - trigger-builds:
+            - project: ceph-grafana
+              predefined-parameters: ARCH=arm64
+              current-parameters: true
+              block: true
+        - shell:
+            !include-raw: ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: docker-hub-leseb
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD
+          - username-password-separated:
+              credential-id: dmick-quay
+              username: CONTAINER_REPO_USERNAME
+              password: CONTAINER_REPO_PASSWORD
+      - build-name:
+          name: "#${BUILD_NUMBER} ${BRANCH}"


### PR DESCRIPTION
Build both x86_64 and arm64 containers using ceph-grafana job,
and then pull, create a combined manifest, and push, currently to
both docker.io and quay.io

Signed-off-by: Dan Mick <dmick@redhat.com>