### PR TITLE
ansible: replace version number in project(..VERSION..)

### DIFF
--- a/ansible/roles/ceph-release/tasks/main.yml
+++ b/ansible/roles/ceph-release/tasks/main.yml
@@ -47,8 +47,8 @@
 
 - name: replace the version in CMakeLists.txt
   lineinfile: dest=ceph/CMakeLists.txt
-              regexp='^set\(VERSION '
-              line='set(VERSION {{ version }})'
+              regexp='^  VERSION \d+\.\d+\.\d+$'
+              line='  VERSION {{ version }}'
   when: cmake_lists.stat.exists
 
 - include: release/candidate.yml


### PR DESCRIPTION
should be replace the VERSION number in project(...). this is the
authentic place to set version number.

Signed-off-by: Kefu Chai <kchai@redhat.com>