### PR TITLE
ansible: fakeroot-ng doesn't exist anymore

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -33,7 +33,6 @@
         universal_debs:
           - git
           - fakeroot
-          - fakeroot-ng
           - debhelper
           - reprepro
           - devscripts


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>