### PR TITLE
ceph-container: publish ceph/ceph to quay.io

### DIFF
--- a/ceph-container-build-ceph-base-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-ceph-base-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs.yml
@@ -41,6 +41,6 @@
           mask-password-params: true
       - credentials-binding:
           - username-password-separated:
-              credential-id: docker-hub-leseb
-              username: DOCKER_HUB_USERNAME
-              password: DOCKER_HUB_PASSWORD
+              credential-id: ceph-container-quay-io
+              username: REGISTRY_USERNAME
+              password: REGISTRY_PASSWORD

--- a/ceph-container-build-ceph-base-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-ceph-base-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
@@ -41,6 +41,6 @@
           mask-password-params: true
       - credentials-binding:
           - username-password-separated:
-              credential-id: docker-hub-leseb
-              username: DOCKER_HUB_USERNAME
-              password: DOCKER_HUB_PASSWORD
+              credential-id: ceph-container-quay-io
+              username: REGISTRY_USERNAME
+              password: REGISTRY_PASSWORD


### PR DESCRIPTION
We're switching from docker.io registry for the ceph/ceph container images
to quay.io registry.
This requires to have a new credential-id in jenkins and update the
environment variables used by the ceph-container build script.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>