### PR TITLE
ansible: install python3-asyncssh copr repo on EL8 for cephadm

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -434,6 +434,15 @@
         enablerepo: epel
       when: ansible_os_family == "RedHat"
 
+    # This repo has the python-asyncssh EL8 package that cephadm depends on, which is not yet present in EPEL8
+    - name: Enable EL8 python3-asyncssh copr repo
+      command: "dnf -y copr enable ceph/python3-asyncssh"
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version|int == 8
+      tags: 
+        - copr
+
     - name: Install Suse RPMs
       zypper:
         name: "{{ zypper_rpms + zypper_libvirt_rpms|default([]) }}"


### PR DESCRIPTION
This change will install the copr repo to the test slave nodes so we can install the `python3-asyncssh` dependency for non-containerized tests, needed for ceph/ceph/pull/42051. The copr repo has the `python3-asyncssh` package we need for cephadm.

Fixes: https://tracker.ceph.com/issues/44676
Signed-off-by: Melissa Li <li.melissa.kun@gmail.com>