### PR TITLE
Revert "ansible: install python3-asyncssh copr repo on EL8 for cephadm"

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -434,15 +434,6 @@
         enablerepo: epel
       when: ansible_os_family == "RedHat"
 
-    # This repo has the python-asyncssh EL8 package that cephadm depends on, which is not yet present in EPEL8
-    - name: Enable EL8 python3-asyncssh copr repo
-      command: "dnf -y copr enable ceph/python3-asyncssh"
-      when:
-        - ansible_os_family == "RedHat"
-        - ansible_distribution_major_version|int == 8
-      tags: 
-        - copr
-
     - name: Install Suse RPMs
       zypper:
         name: "{{ zypper_rpms + zypper_libvirt_rpms|default([]) }}"


### PR DESCRIPTION
This reverts commit 733be223a72951db7e66eac0f28e379d83da54bd.
Discussion at https://github.com/ceph/ceph/pull/42051#issuecomment-888817516: on why it's not needed

Signed-off-by: Melissa Li <li.melissa.kun@gmail.com>