### PR TITLE
ansible/examples/slave.yml: add python3-venv to python3_debs of debian

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -106,6 +106,7 @@
           - python3
           - python3-dev
           - python3-pip
+          - python3-venv
           - python3-virtualenv
       when:
         - ansible_os_family == "Debian"


### PR DESCRIPTION
let's add python3-venv.

keep python3-virtualenv around for a while just in case.

Signed-off-by: Kefu Chai <kchai@redhat.com>