### PR TITLE
DNM: ceph-dev-*: Trigger separate job to inform shaman of failure

### DIFF
--- a/build-failure/build/failure
+++ b/build-failure/build/failure
@@ -1,0 +1,42 @@
+#!/bin/bash -ex
+
+# note: the failed_build_status call relies on normalized variable names that
+# are infered by the builds themselves. If the build fails before these are
+# set, they will be posted with empty values
+BRANCH=`branch_slash_filter $BRANCH`
+
+# This build-failure job will only have one word for the $DISTROS parameter
+# because all the failed job's paramters are passed to this job when it's triggered.
+case $DISTROS in
+    focal)
+        NORMAL_DISTRO="ubuntu"
+        NORMAL_DISTRO_VERSION="focal"
+        ;;
+    bionic)
+        NORMAL_DISTRO="ubuntu"
+        NORMAL_DISTRO_VERSION="bionic"
+        ;;
+    centos8)
+        NORMAL_DISTRO="centos"
+        NORMAL_DISTRO_VERSION="8"
+        ;;
+    centos7)
+        NORMAL_DISTRO="centos"
+        NORMAL_DISTRO_VERSION="7"
+        ;;
+    leap15)
+        NORMAL_DISTRO="opensuse"
+        NORMAL_DISTRO_VERSION="15.2"
+        ;;
+    windows)
+        NORMAL_DISTRO="windows"
+        NORMAL_DISTRO_VERSION="1809"
+        ;;
+    *)
+        echo "Unable to determine distro.\nThis job will be unable to notify shaman of a build failure and it will remain in \"building\" indefinitely."
+        exit 1
+        ;;
+esac
+
+# update shaman with the failed build status
+failed_build_status "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $ARCHS

--- a/build-failure/config/definitions/build-failure.yml
+++ b/build-failure/config/definitions/build-failure.yml
@@ -1,0 +1,25 @@
+- job:
+    name: build-failure
+    description: "This job gets triggered by ceph-dev-*-{setup,build} when the job fails.\r\nThis is useful for when a Jenkins builder crashes and can't run the failure script itself."
+    project-type: freestyle
+    defaults: global
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    properties:
+      - build-discarder:
+          days-to-keep: 14
+    discard-old-builds: true
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/failure
+
+    wrappers:
+      - credentials-binding:
+          - text:
+              credential-id: shaman-api-key
+              variable: SHAMAN_API_KEY
+

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -114,12 +114,9 @@
                   - FAILURE
                   - ABORTED
               build-steps:
-                - inject:
-                    properties-file: ${WORKSPACE}/build_info
-                - shell:
-                    !include-raw:
-                      - ../../../scripts/build_utils.sh
-                      - ../../build/failure
+                - trigger-builds:
+                    - project: 'build-failure'
+                      current-parameters: true
 
     wrappers:
       - inject-passwords:

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -122,12 +122,9 @@
                   - FAILURE
                   - ABORTED
               build-steps:
-                - inject:
-                    properties-file: ${WORKSPACE}/build_info
-                - shell:
-                    !include-raw:
-                      - ../../../scripts/build_utils.sh
-                      - ../../build/failure
+                - trigger-builds:
+                    - project: 'build-failure'
+                      current-parameters: true
 
     wrappers:
       - inject-passwords:

--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -51,10 +51,9 @@
                   - FAILURE
                   - ABORTED
               build-steps:
-                - shell:
-                    !include-raw:
-                      - ../../../scripts/build_utils.sh
-                      - ../../build/failure
+                - trigger-builds:
+                    - project: 'build-failure'
+                      current-parameters: true
 
     wrappers:
       - inject-passwords:

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -51,10 +51,9 @@
                   - FAILURE
                   - ABORTED
               build-steps:
-                - shell:
-                    !include-raw:
-                      - ../../../scripts/build_utils.sh
-                      - ../../build/failure
+                - trigger-builds:
+                    - project: 'build-failure'
+                      current-parameters: true
 
     wrappers:
       - inject-passwords:


### PR DESCRIPTION
This doesn't work.  I couldn't figure out a way to pass the `$NORMAL_DISTRO`, `$NORMAL_DISTRO_VERSION`, and `$NORMAL_ARCH` vars from the failed job to the new triggered job.

Using `current-parameters: true` almost worked but since we're doing multijob projects, those vars look like `DISTROS='centos8 focal'`.

I just didn't want to lose the work.

Signed-off-by: David Galloway <dgallowa@redhat.com>