### PR TITLE
container: publish daemon,daemon-base to quay.io

### DIFF
--- a/ceph-container-build-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs-arm64.yml
+++ b/ceph-container-build-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs-arm64.yml
@@ -41,6 +41,6 @@
           mask-password-params: true
       - credentials-binding:
           - username-password-separated:
-              credential-id: docker-hub-leseb
-              username: DOCKER_HUB_USERNAME
-              password: DOCKER_HUB_PASSWORD
+              credential-id: ceph-container-quay-io
+              username: REGISTRY_USERNAME
+              password: REGISTRY_PASSWORD

--- a/ceph-container-build-push-imgs-devel-nightly/config/definitions/ceph-container-build-push-imgs-devel-nightly.yml
+++ b/ceph-container-build-push-imgs-devel-nightly/config/definitions/ceph-container-build-push-imgs-devel-nightly.yml
@@ -44,6 +44,6 @@
           mask-password-params: true
       - credentials-binding:
           - username-password-separated:
-              credential-id: docker-hub-leseb
-              username: DOCKER_HUB_USERNAME
-              password: DOCKER_HUB_PASSWORD
+              credential-id: ceph-container-quay-io
+              username: REGISTRY_USERNAME
+              password: REGISTRY_PASSWORD

--- a/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
@@ -41,6 +41,6 @@
           mask-password-params: true
       - credentials-binding:
           - username-password-separated:
-              credential-id: docker-hub-leseb
-              username: DOCKER_HUB_USERNAME
-              password: DOCKER_HUB_PASSWORD
+              credential-id: ceph-container-quay-io
+              username: REGISTRY_USERNAME
+              password: REGISTRY_PASSWORD

--- a/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
+++ b/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
@@ -59,9 +59,9 @@
           mask-password-params: true
       - credentials-binding:
           - username-password-separated:
-              credential-id: docker-hub-leseb
-              username: DOCKER_HUB_USERNAME
-              password: DOCKER_HUB_PASSWORD
+              credential-id: ceph-container-quay-io
+              username: REGISTRY_USERNAME
+              password: REGISTRY_PASSWORD
 
     publishers:
       - postbuildscript:

--- a/ceph-container-prs/config/definitions/ceph-container-prs.yml
+++ b/ceph-container-prs/config/definitions/ceph-container-prs.yml
@@ -75,9 +75,9 @@
           mask-password-params: true
       - credentials-binding:
           - username-password-separated:
-              credential-id: docker-hub-leseb
-              username: DOCKER_HUB_USERNAME
-              password: DOCKER_HUB_PASSWORD
+              credential-id: ceph-container-quay-io
+              username: REGISTRY_USERNAME
+              password: REGISTRY_PASSWORD
 
     publishers:
       - postbuildscript:
@@ -157,9 +157,9 @@
           mask-password-params: true
       - credentials-binding:
           - username-password-separated:
-              credential-id: docker-hub-leseb
-              username: DOCKER_HUB_USERNAME
-              password: DOCKER_HUB_PASSWORD
+              credential-id: ceph-container-quay-io
+              username: REGISTRY_USERNAME
+              password: REGISTRY_PASSWORD
 
     publishers:
       - postbuildscript:


### PR DESCRIPTION
We're switching from docker.io registry for the ceph/{daemon,daemon-base}
container images to quay.io registry.
This requires to have a new credential-id in jenkins and update the
environment variables used by the ceph-container build script.

This impacts image tags like:
  - latest-xxxxx
  - latest-xxxxx-devel
  - latest-bis
  - vX.Y.Z-stable-X.Y

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>