### PR TITLE
container: update push jobs display name

### DIFF
--- a/ceph-container-build-ceph-base-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-ceph-base-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs.yml
@@ -3,7 +3,7 @@
     node: arm64 && xenial
     project-type: freestyle
     defaults: global
-    display-name: 'ceph-container: build and push ceph base container images to Docker Hub on arm64'
+    display-name: 'ceph-container: build and push ceph base container images to Quay.io on arm64'
     quiet-period: 5
     block-downstream: false
     block-upstream: false

--- a/ceph-container-build-ceph-base-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-ceph-base-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
@@ -3,7 +3,7 @@
     node: huge && trusty && x86_64
     project-type: freestyle
     defaults: global
-    display-name: 'ceph-container: build and push ceph base container images to Docker Hub'
+    display-name: 'ceph-container: build and push ceph base container images to Quay.io'
     quiet-period: 5
     block-downstream: false
     block-upstream: false

--- a/ceph-container-build-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs-arm64.yml
+++ b/ceph-container-build-push-imgs-arm64/config/definitions/ceph-container-build-push-imgs-arm64.yml
@@ -3,7 +3,7 @@
     node: arm64 && xenial
     project-type: freestyle
     defaults: global
-    display-name: 'ceph-container: build and push container images to Docker Hub on arm64'
+    display-name: 'ceph-container: build and push container images to Quay.io on arm64'
     quiet-period: 5
     block-downstream: false
     block-upstream: false

--- a/ceph-container-build-push-imgs-devel-nightly/config/definitions/ceph-container-build-push-imgs-devel-nightly.yml
+++ b/ceph-container-build-push-imgs-devel-nightly/config/definitions/ceph-container-build-push-imgs-devel-nightly.yml
@@ -3,7 +3,7 @@
     node: huge && trusty && x86_64
     project-type: freestyle
     defaults: global
-    display-name: 'ceph-container: Nightly build and push devel container images to Docker Hub'
+    display-name: 'ceph-container: Nightly build and push devel container images to Quay.io'
     quiet-period: 5
     block-downstream: false
     block-upstream: false

--- a/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
+++ b/ceph-container-build-push-imgs/config/definitions/ceph-container-build-push-imgs.yml
@@ -3,7 +3,7 @@
     node: huge && trusty && x86_64
     project-type: freestyle
     defaults: global
-    display-name: 'ceph-container: build and push container images to Docker Hub'
+    display-name: 'ceph-container: build and push container images to Quay.io'
     quiet-period: 5
     block-downstream: false
     block-upstream: false


### PR DESCRIPTION
Because we don't push to Docker Hub registry anymore, we don't need to have
that in the job display name.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>