### PR TITLE
scripts/build_utils: remove create_build_status()

### DIFF
--- a/ceph-build/build/setup_deb
+++ b/ceph-build/build/setup_deb
@@ -53,7 +53,7 @@ NORMAL_DISTRO_VERSION=$DIST
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
 TEMPVENV=$(create_venv_dir)

--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -43,7 +43,7 @@ NORMAL_DISTRO_VERSION=$RELEASE
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
 TEMPVENV=$(create_venv_dir)

--- a/ceph-dev-build/build/setup_deb
+++ b/ceph-dev-build/build/setup_deb
@@ -53,7 +53,7 @@ NORMAL_DISTRO_VERSION=$DIST
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
 TEMPVENV=$(create_venv_dir)

--- a/ceph-dev-build/build/setup_osc
+++ b/ceph-dev-build/build/setup_osc
@@ -75,7 +75,7 @@ NORMAL_DISTRO_VERSION=$RELEASE
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
 TEMPVENV=$(create_venv_dir)

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -45,7 +45,7 @@ NORMAL_DISTRO_VERSION=$RELEASE
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
 TEMPVENV=$(create_venv_dir)

--- a/ceph-dev-cron/build/notify
+++ b/ceph-dev-cron/build/notify
@@ -6,4 +6,4 @@
 BRANCH=`branch_slash_filter ${GIT_BRANCH}`
 SHA1=${GIT_COMMIT}
 
-create_build_status "queued" "ceph"
+update_build_status "queued" "ceph"

--- a/ceph-dev-new-build/build/setup_deb
+++ b/ceph-dev-new-build/build/setup_deb
@@ -53,7 +53,7 @@ NORMAL_DISTRO_VERSION=$DIST
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
 TEMPVENV=$(create_venv_dir)

--- a/ceph-dev-new-build/build/setup_mingw
+++ b/ceph-dev-new-build/build/setup_mingw
@@ -42,7 +42,7 @@ NORMAL_DISTRO_VERSION="1809"
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
 TEMPVENV=$(create_venv_dir)

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -43,7 +43,7 @@ NORMAL_DISTRO_VERSION=$RELEASE
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 pkgs=( "chacractl>=0.0.21" )
 TEMPVENV=$(create_venv_dir)

--- a/ceph-dev-new-trigger/build/notify
+++ b/ceph-dev-new-trigger/build/notify
@@ -6,5 +6,5 @@
 BRANCH=`branch_slash_filter ${GIT_BRANCH}`
 SHA1=${GIT_COMMIT}
 
-create_build_status "queued" "ceph"
+update_build_status "queued" "ceph"
 

--- a/ceph-dev-trigger/build/notify
+++ b/ceph-dev-trigger/build/notify
@@ -6,4 +6,4 @@
 BRANCH=`branch_slash_filter ${GIT_BRANCH}`
 SHA1=${GIT_COMMIT}
 
-create_build_status "queued" "ceph"
+update_build_status "queued" "ceph"

--- a/kernel/build/setup
+++ b/kernel/build/setup
@@ -89,4 +89,4 @@ git clean -fxd
 export SHA1="${GIT_COMMIT}"
 
 # create build status in shaman
-create_build_status "started" "kernel" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $ARCH
+update_build_status "started" "kernel" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $ARCH

--- a/nfs-ganesha-stable/build/build_deb
+++ b/nfs-ganesha-stable/build/build_deb
@@ -102,7 +102,7 @@ NORMAL_DISTRO_VERSION=$DIST
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "nfs-ganesha-stable" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "nfs-ganesha-stable" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 cd $WORKSPACE/nfs-ganesha-debian
 git checkout ${NFS_GANESHA_DEBIAN_BRANCH}

--- a/nfs-ganesha-stable/build/build_rpm
+++ b/nfs-ganesha-stable/build/build_rpm
@@ -77,7 +77,7 @@ NORMAL_DISTRO_VERSION=$RELEASE
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "nfs-ganesha-stable" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "nfs-ganesha-stable" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 cd $WORKSPACE/nfs-ganesha
 

--- a/nfs-ganesha/build/build_deb
+++ b/nfs-ganesha/build/build_deb
@@ -38,7 +38,7 @@ NORMAL_DISTRO_VERSION=$DIST
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "nfs-ganesha" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "nfs-ganesha" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 ## Setup the pbuilder
 setup_pbuilder use_gcc

--- a/nfs-ganesha/build/build_rpm
+++ b/nfs-ganesha/build/build_rpm
@@ -88,7 +88,7 @@ NORMAL_DISTRO_VERSION=$RELEASE
 NORMAL_ARCH=$ARCH
 
 # create build status in shaman
-create_build_status "started" "nfs-ganesha" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+update_build_status "started" "nfs-ganesha" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
 
 cd $WORKSPACE/nfs-ganesha
 

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -363,26 +363,8 @@ EOF
 
 
 update_build_status() {
-    # A proxy script to PUT (update) the status of a build in shaman
-    # 'state' can be either of: 'started', 'completed', or 'failed'
-    # 'project' is used to post to the right url in shaman
-
-    # required
-    state=$1
-    project=$2
-
-    # optional
-    distro=$3
-    distro_version=$4
-    distro_arch=$5
-
-    submit_build_status "POST" $state $project $distro $distro_version $distro_arch
-}
-
-
-create_build_status() {
-    # A proxy script to POST (create) the status of a build in shaman for
-    # a normal/initial build
+    # A proxy script to PUT (create or update) the status of a build
+    # in shaman for a normal/initial build
     # 'state' can be either of: 'started', 'completed', or 'failed'
     # 'project' is used to post to the right url in shaman
 


### PR DESCRIPTION
it's identical to update_build_status(), apart from that it is only used
for creating the build status. but from the semantic point of view,
create is also an "update", IMHO. so consolidating them sounds like a
good move.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>