### PR TITLE
dashboard-nightly-e2e: add APPLITOOLS_API_KEY

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -76,6 +76,9 @@
           - text:
               credential-id: cd-cypress-record-key
               variable: CYPRESS_RECORD_KEY
+          - text:
+              credential-id: cd-applitools-api-key
+              variable: APPLITOOLS_API_KEY
       - ansicolor
 
     publishers:


### PR DESCRIPTION
It's making dashboard e2e nightly fail: https://jenkins.ceph.com/job/ceph-api-nightly-master-e2e/

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>