### PR TITLE
dashboard-e2e: fix applitools BATCH_ID error

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -66,6 +66,11 @@
             -  ../../../scripts/dashboard/{test_deps_script}
       - shell: |
           export CYPRESS_ARGS="--record --key $CYPRESS_RECORD_KEY --tag $JOB_NAME" COMMIT_INFO_MESSAGE="$JOB_NAME"
+          export APPLITOOLS_BATCH_ID="${{JOB_NAME}}_${{BUILD_TAG}}"
+          export APPLITOOLS_BRANCH_NAME="$ghprbSourceBranch"
+          export APPLITOOLS_PARENT_BRANCH_NAME="$ghprbTargetBranch"
+          mkdir -p .applitools
+          echo "$APPLITOOLS_BATCH_ID" > .applitools/BATCH_ID
           cd src/pybind/mgr/dashboard; timeout 2h ./{test_suite_script}
 
     wrappers:

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -68,6 +68,11 @@
             - ../../../scripts/dashboard/install-e2e-test-deps.sh
       - shell: |
           export CYPRESS_ARGS="--record --key $CYPRESS_RECORD_KEY --tag $ghprbTargetBranch" COMMIT_INFO_MESSAGE="$ghprbPullTitle"
+          export APPLITOOLS_BATCH_ID="PR-${ghprbPullId}_${BUILD_TAG}"
+          export APPLITOOLS_BRANCH_NAME="$ghprbSourceBranch"
+          export APPLITOOLS_PARENT_BRANCH_NAME="$ghprbTargetBranch"
+          mkdir -p .applitools
+          echo "$APPLITOOLS_BATCH_ID" > .applitools/BATCH_ID
           cd src/pybind/mgr/dashboard; timeout 7200 ./run-frontend-e2e-tests.sh
 
     wrappers:


### PR DESCRIPTION
Fixes: https://jenkins.ceph.com/job/ceph-dashboard-pull-requests/8764/consoleFull#-85362248744e9240e-b50a-4693-bac0-8a991bac86ac

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>