### PR TITLE
scripts/build_utils: s/virtualenv/venv -m/

### DIFF
--- a/quay-pruner/build/build
+++ b/quay-pruner/build/build
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
-virtualenv -p python3 ./v
+python3 -m venv ./v
 ./v/bin/pip install requests
 ./v/bin/python3 ./ceph-build/quay-pruner/build/prune-quay.py -v
 rm -rf ./v

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -103,11 +103,11 @@ create_virtualenv () {
         echo "Will reuse existing virtual env: $path"
     else
         if command -v python3 > /dev/null; then
-            virtualenv -p python3 $path
+            python3 -m venv $path
         elif command -v python2.7 > /dev/null; then
-            virtualenv -p python2.7 $path
+            python2.7 -m venv $path
         else
-            virtualenv -p python $path
+            python -m venv $path
         fi
     fi
 }


### PR DESCRIPTION
intended to fix: 
```
+ install_python_packages /tmp/venv.TVbGooPJwM 'pkgs[@]'
+ local venv_dir=/tmp/venv.TVbGooPJwM
+ shift
+ local venv=/tmp/venv.TVbGooPJwM/bin
+ create_virtualenv /tmp/venv.TVbGooPJwM
+ local path=/tmp/venv.TVbGooPJwM
+ '[' -d /tmp/venv.TVbGooPJwM ']'
+ command -v python3
+ virtualenv -p python3 /tmp/venv.TVbGooPJwM
/tmp/jenkins4546418454625818542.sh: line 106: virtualenv: command not found
Build step 'Execute shell' marked build as failure
Recording test results
[GitHub Checks] Causes for no suitable publisher found: 
```
signed off failure: https://jenkins.ceph.com/job/ceph-pr-commits/54091/consoleFull#-85362248744e9240e-b50a-4693-bac0-8a991bac86ac

I am not sure from where we are getting "pkgs" arg here: 
`+ install_python_packages /tmp/venv.TVbGooPJwM 'pkgs[@]'`
Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>