### PR TITLE
scripts/build_utils.sh: use "python3 -m venv" to create venv

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -103,7 +103,7 @@ create_virtualenv () {
         echo "Will reuse existing virtual env: $path"
     else
         if command -v python3 > /dev/null; then
-            virtualenv -p python3 $path
+            python3 -m venv $path
         elif command -v python2.7 > /dev/null; then
             virtualenv -p python2.7 $path
         else


### PR DESCRIPTION
we started to have following error recently:

```
+ local path=/tmp/venv.0D0Gwn9bMl
+ '[' -d /tmp/venv.0D0Gwn9bMl ']'
+ command -v python3
+ virtualenv -p python3 /tmp/venv.0D0Gwn9bMl
/tmp/jenkins5609477504730019125.sh: line 106: virtualenv: command not found
```

instead of relying on `virtualenv`, let's use the builtin venv
module to create virtualenv.

Signed-off-by: Kefu Chai <kchai@redhat.com>