### PR TITLE
ansible: Stop installing Jessie key

### DIFF
--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -612,27 +612,6 @@
     ## DEBIAN GPG KEY TASKS
     - name: Install Debian GPG Keys on Ubuntu
       block:
-        - name: Add the Debian Jessie Key
-          apt_key:
-           id: 2B90D010
-           url: https://ftp-master.debian.org/keys/archive-key-8.asc
-           keyring: /etc/apt/trusted.gpg
-           state: present
-      
-        - name: Add the Debian Security Jessie Key
-          apt_key:
-            id: C857C906
-            url: https://ftp-master.debian.org/keys/archive-key-8-security.asc
-            keyring: /etc/apt/trusted.gpg
-            state: present
-      
-        - name: Add the Debian Jessie Stable Key
-          apt_key:
-            id: 518E17E1
-            url: https://ftp-master.debian.org/keys/release-8.asc
-            keyring: /etc/apt/trusted.gpg
-            state: present
-      
         - name: Add the Debian Buster Key
           apt_key:
            id: 3CBBABEE


### PR DESCRIPTION
We don't build for Jessie anymore

Signed-off-by: David Galloway <dgallowa@redhat.com>