### PR TITLE
ceph-*-build: add step to extract and store cephadm binary

### DIFF
--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -36,6 +36,9 @@ if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
+    # extract cephadm
+    rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
+    echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     # write json file with build info
     cat > $WORKSPACE/repo-extra.json << EOF
 {

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -54,6 +54,9 @@ if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source/flavors/${FLAVOR}
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
+    # extract cephadm
+    rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
+    echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     # write json file with build info
     cat > $WORKSPACE/repo-extra.json << EOF
 {

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -55,6 +55,9 @@ if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source/flavors/${FLAVOR}
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
+    # extract cephadm
+    rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
+    echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     # write json file with build info
     cat > $WORKSPACE/repo-extra.json << EOF
 {

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# vim: ts=4 sw=4 expandtab
 
 set -ex
 
@@ -947,9 +948,9 @@ build_debs() {
             egrep -v "(Packages|Sources|Contents)" | \
             $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
 
-	# extract cephadm binary and push
-	dpkg-deb --fsys-tarfile release/${vers}/cephadm_${vers}*.deb | tar -x -f - --strip-components=3 ./usr/sbin/cephadm
-	echo cephadm | $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+        # extract cephadm binary and push
+        dpkg-deb --fsys-tarfile release/${vers}/cephadm_${vers}*.deb | tar -x -f - --strip-components=3 ./usr/sbin/cephadm
+        echo cephadm | $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
 
         # write json file with build info
         cat > $WORKSPACE/repo-extra.json << EOF
@@ -1403,8 +1404,8 @@ setup_rpm_build_deps() {
         $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
         $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save
 
-	$SUDO rpm -import https://dist.apache.org/repos/dist/dev/arrow/KEYS
-	$SUDO dnf config-manager --add-repo="https://apache.jfrog.io/artifactory/arrow/centos/${RELEASE}/x86_64"
+        $SUDO rpm -import https://dist.apache.org/repos/dist/dev/arrow/KEYS
+        $SUDO dnf config-manager --add-repo="https://apache.jfrog.io/artifactory/arrow/centos/${RELEASE}/x86_64"
     fi
 
     DIR=/tmp/install-deps.$$
@@ -1496,7 +1497,7 @@ Source0:        ceph.repo
 #Source0:        RPM-GPG-KEY-CEPH
 #Source1:        ceph.repo
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-BuildArch:	noarch
+BuildArch:      noarch
 
 %description
 This package contains the Ceph repository GPG key as well as configuration

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -946,6 +946,11 @@ build_debs() {
             egrep "*\.(changes|deb|ddeb|dsc|gz)$" | \
             egrep -v "(Packages|Sources|Contents)" | \
             $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+
+	# extract cephadm binary and push
+	dpkg-deb --fsys-tarfile release/${vers}/cephadm_${vers}*.deb | tar -x -f - --strip-components=3 ./usr/sbin/cephadm
+	echo cephadm | $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+
         # write json file with build info
         cat > $WORKSPACE/repo-extra.json << EOF
 {


### PR DESCRIPTION
For deb builds, this is all in build_utils.sh; for rpm, it's in
build_rpm for each build

Signed-off-by: Dan Mick <dmick@redhat.com>