### PR TITLE
ceph-*-build: only try extracting cephadm if it exists

### DIFF
--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -1,4 +1,5 @@
 #!/bin/bash
+# vim: ts=4 sw=4 expandtab
 set -ex
 
 # create a release directory for ceph-build tools
@@ -36,9 +37,11 @@ if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
-    # extract cephadm
-    rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
-    echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
+    # extract cephadm if it exists
+    if [[ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ]] ; then
+        rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
+        echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
+    fi
     # write json file with build info
     cat > $WORKSPACE/repo-extra.json << EOF
 {

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -1,4 +1,5 @@
 #!/bin/bash
+# vim: ts=4 sw=4 expandtab
 set -ex
 
 # set to "true" or "false" so that both string comparisons
@@ -54,8 +55,12 @@ if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source/flavors/${FLAVOR}
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
-    # extract cephadm
-    rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
+    # extract cephadm if it exists
+    if [[ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ]] ; then
+        rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
+        echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
+        rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
+    fi
     echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     # write json file with build info
     cat > $WORKSPACE/repo-extra.json << EOF

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -1,4 +1,5 @@
 #!/bin/bash
+# vim: ts=4 sw=4 expandtab
 set -ex
 
 
@@ -55,9 +56,11 @@ if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source/flavors/${FLAVOR}
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
-    # extract cephadm
-    rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
-    echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
+    # extract cephadm if it exists
+    if [[ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ]] ; then
+        rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
+        echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
+    fi
     # write json file with build info
     cat > $WORKSPACE/repo-extra.json << EOF
 {

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -948,9 +948,11 @@ build_debs() {
             egrep -v "(Packages|Sources|Contents)" | \
             $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
 
-        # extract cephadm binary and push
-        dpkg-deb --fsys-tarfile release/${vers}/cephadm_${vers}*.deb | tar -x -f - --strip-components=3 ./usr/sbin/cephadm
-        echo cephadm | $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+        # extract cephadm if it exists
+        if [[ -f release/${vers}/cephadm_${vers}*.deb ]] ; then
+            dpkg-deb --fsys-tarfile release/${vers}/cephadm_${vers}*.deb | tar -x -f - --strip-components=3 ./usr/sbin/cephadm
+            echo cephadm | $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
+        fi
 
         # write json file with build info
         cat > $WORKSPACE/repo-extra.json << EOF


### PR DESCRIPTION
https://github.com/ceph/ceph-build/pull/1913 added code to extract
the cephadm binary from its package and push it to chacra; however,
older builds don't include a cephadm package, and ceph-build must
work for those as well.  Broke for nautilus.

Fixes: https://tracker.ceph.com/issues/52847
Signed-off-by: Dan Mick <dmick@redhat.com>