### PR TITLE
build_utils.sh: Disable CI_CONTAINER for nautilus too

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1547,7 +1547,7 @@ maybe_reset_ci_container() {
     if ! "$CI_CONTAINER"; then
         return
     fi
-    if [[ "$BRANCH" =~ octopus|pacific && "$DIST" == el7 ]]; then
+    if [[ "$BRANCH" =~ nautilus|octopus|pacific && "$DIST" == el7 ]]; then
         echo "disabling CI container build for $BRANCH"
         CI_CONTAINER=false
     fi


### PR DESCRIPTION
Brad and Yuri are working on something for downstream and need some branches built in ceph-ci.git based on the nautilus branch.  The builds keep showing up as failed in shaman because the container is failing to build.  This minor change fixes that.

Signed-off-by: David Galloway <dgallowa@redhat.com>