### PR TITLE
ceph-container-lint: add missing pipe

### DIFF
--- a/ceph-container-lint/build/build
+++ b/ceph-container-lint/build/build
@@ -12,7 +12,7 @@ function generate_filelist(){
        find . -name '*.sh' | grep -vE "$IGNORE_THESE_FILES"
    else
        curl -XGET "https://api.github.com/repos/ceph/ceph-container/pulls/$pull_request_id/files" |
-       jq -r '.[] | select(.status != "removed") | .filename'  # just the files please (not removed)
+       jq -r '.[] | select(.status != "removed") | .filename' |  # just the files please (not removed)
        grep ".sh$" | # just the bash
        grep -vE "$IGNORE_THESE_FILES"
    fi


### PR DESCRIPTION
The pipe was removed in the previous change but it shouldn't.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>