### PR TITLE
container-{flake8,lint}: always pull the image

### DIFF
--- a/ceph-container-flake8/build/build
+++ b/ceph-container-flake8/build/build
@@ -47,6 +47,7 @@ function main() {
     fi
 
 
+    sudo docker pull eeacms/flake8
     pushd "$workspace/ceph-container"
     generate_filelist | check
     popd

--- a/ceph-container-lint/build/build
+++ b/ceph-container-lint/build/build
@@ -50,6 +50,7 @@ function main() {
     fi
 
 
+    sudo docker pull koalaman/shellcheck
     pushd "$workspace/ceph-container"
     generate_filelist | check
     popd


### PR DESCRIPTION
Otherwise we will still use an outdated container image.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>