### PR TITLE
ceph-dashboard-cephadm-e2e job: update nodejs to v12

### DIFF
--- a/scripts/dashboard/install-cephadm-e2e-deps.sh
+++ b/scripts/dashboard/install-cephadm-e2e-deps.sh
@@ -15,7 +15,31 @@ on_error() {
 
 trap 'on_error $? $LINENO' ERR
 
-sudo apt -y install libvirt-daemon-system libvirt-daemon-driver-qemu qemu-kvm libvirt-clients
+# Install required deps.
+sudo apt update -y
+sudo apt install -y apt-transport-https ca-certificates curl gnupg lsb-release \
+    openssh-server software-properties-common
+
+NODEJS_MAJOR_VERSION=12
+DISTRO="$(lsb_release -cs)"
+if [[ ! $(command -v node) || $(node --version | grep -oE "v([0-9])+" | cut -c 2-) < ${NODEJS_MAJOR_VERSION} ]]; then
+    sudo add-apt-repository -y -r ppa:chris-lea/node.js
+    sudo rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list
+    sudo rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list.save
+
+    NODEJS_KEYRING=/usr/share/keyrings/nodesource.gpg
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee "${NODEJS_KEYRING}" >/dev/null
+    gpg --no-default-keyring --keyring "${NODEJS_KEYRING}" --list-keys
+
+    NODEJS_VERSION="node_${NODEJS_MAJOR_VERSION}.x"
+    echo "deb [signed-by=${NODEJS_KEYRING}] https://deb.nodesource.com/${NODEJS_VERSION} ${DISTRO} main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+    echo "deb-src [signed-by=${NODEJS_KEYRING}] https://deb.nodesource.com/${NODEJS_VERSION} ${DISTRO} main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list
+
+    sudo apt update -y
+    sudo apt install -y nodejs
+    sudo rm -f /etc/apt/sources.list.d/nodesource.list
+fi
+sudo apt install -y libvirt-daemon-system libvirt-daemon-driver-qemu qemu-kvm libvirt-clients
 
 sudo usermod -aG libvirt $(id -un)
 newgrp libvirt  # Avoid having to log out and log in for group addition to take effect.
@@ -23,17 +47,10 @@ sudo systemctl enable --now libvirtd
 
 if [[ $(command -v docker) == '' ]]; then
     # Set up docker official repo and install docker.
-    sudo apt update -y
-    sudo apt install \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
     echo \
         "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-        $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        ${DISTRO} stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     sudo apt update -y
     sudo apt install -y docker-ce docker-ce-cli containerd.io
 fi
@@ -66,10 +83,6 @@ docker run --net host --security-opt label=disable \
     ${KCLI_CONTAINER_IMAGE} \""'${@}'"\"
 " | sudo tee /usr/local/bin/kcli
 sudo chmod +x /usr/local/bin/kcli
-
-# Install required deps.
-sudo apt update -y
-sudo apt install -y nodejs npm openssh-server
 
 # KCLI cleanup function can be found here: https://github.com/ceph/ceph/blob/master/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
 sudo mkdir -p /var/lib/libvirt/images/ceph-dashboard


### PR DESCRIPTION
 `ceph/make-dist` file and Angular 12 ([#43404](https://github.com/ceph/ceph/pull/43404)) require nodejs >= 12.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>