### PR TITLE
Add branch param to the `ceph-windows-test` job

### DIFF
--- a/ceph-windows-test/build/get_chacra_build
+++ b/ceph-windows-test/build/get_chacra_build
@@ -3,6 +3,7 @@ set -o errexit
 set -o pipefail
 
 CEPH_WINDOWS_VERSION=${CEPH_WINDOWS_VERSION:-"1809"}
+CEPH_WINDOWS_BRANCH=${CEPH_WINDOWS_BRANCH:-"master"}
 CEPH_WINDOWS_SHA1=${CEPH_WINDOWS_SHA1:-"latest"}
 
 GET_BIN_SCRIPT_URL="https://raw.githubusercontent.com/ceph/ceph-win32-tests/master/get-bin.py"
@@ -13,4 +14,7 @@ GET_BIN_SCRIPT_URL="https://raw.githubusercontent.com/ceph/ceph-win32-tests/mast
 cd $WORKSPACE
 timeout 1m curl -L -o ./get-chacra-bin.py $GET_BIN_SCRIPT_URL
 chmod +x ./get-chacra-bin.py
-timeout 10m ./get-chacra-bin.py --distrover $CEPH_WINDOWS_VERSION --sha1 $CEPH_WINDOWS_SHA1
+timeout 10m ./get-chacra-bin.py \
+    --distrover $CEPH_WINDOWS_VERSION \
+    --branchname $CEPH_WINDOWS_BRANCH \
+    --sha1 $CEPH_WINDOWS_SHA1

--- a/ceph-windows-test/config/definitions/ceph-windows-test.yml
+++ b/ceph-windows-test/config/definitions/ceph-windows-test.yml
@@ -19,6 +19,10 @@
           description: "The Windows version for the Ceph build."
           default: 1809
       - string:
+          name: CEPH_WINDOWS_BRANCH
+          description: "The branch name for the Ceph build."
+          default: master
+      - string:
           name: CEPH_WINDOWS_SHA1
           description: "The SHA1 for the Ceph build."
           default: latest


### PR DESCRIPTION
The default value is `master`, since Windows builds for the master
branch were enabled by https://github.com/ceph/ceph-build/pull/1928.

The `get-bin.py` script is updated to support `--branchname` parameter:
https://github.com/ceph/ceph-win32-tests/pull/1