### PR TITLE
ceph-dashboard-pull-requests (e2e) job: do not build tests, only build ceph

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -4,8 +4,7 @@
       - master
       - pacific
       - octopus
-      - nautilus:
-          ceph_build: "export CHECK_MAKEOPTS='-N -Q'; timeout 2h ./run-make-check.sh"
+      - nautilus
     test_suite:
       - backend:
           test_suite_script: run-backend-api-tests.sh

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -62,7 +62,7 @@
           wipe-workspace: true
 
     builders:
-      - shell: "export NPROC=$(nproc) CHECK_MAKEOPTS='-j$(nproc) -N -Q'; timeout 7200 ./run-make-check.sh"
+      - shell: "export FOR_MAKE_CHECK=1; timeout 2h ./src/script/run-make.sh --cmake-args '-DWITH_TESTS=OFF -DENABLE_GIT_VERSION=OFF'"
       - shell:
           !include-raw:
             - ../../../scripts/dashboard/install-e2e-test-deps.sh


### PR DESCRIPTION
We don't need to build tests for this job and also this change is a workaround for: https://tracker.ceph.com/issues/53582

Also do not build tests for nautilus nightly jobs.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>