### PR TITLE
ceph-pr-commits: test_commits: Also allow reverts

### DIFF
--- a/ceph-pr-commits/build/test_commits.py
+++ b/ceph-pr-commits/build/test_commits.py
@@ -39,7 +39,7 @@ class TestCommits(object):
 
     @pytest.mark.doc_test
     def test_doc_title(self):
-        doc_regex = '\nDate:[^\n]+\n\n    doc'
+        doc_regex = '\nDate:[^\n]+\n\n    (doc|Revert "doc)'
         all_commits = 'git log -z --no-merges origin/%s..%s' % (
             self.target_branch, self.source_branch)
         wrong_commits = list(filterfalse(


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sewagner@redhat.com>

I'd like to merge this commit:

![image](https://user-images.githubusercontent.com/2574405/146541191-93bd4f23-32bc-44e7-8923-6616d29d6627.png)

https://github.com/ceph/ceph/pull/44346/commits/bd30062a67234d4b1d89a02a1d74892f6b311d0b

And I'm personally ok with also allowing the commit tile that was automatically generated by `git revert`