### PR TITLE
Refactor `ceph-windows-test` and `ceph-windows-pull-requests` jobs

### DIFF
--- a/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
+++ b/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
@@ -66,6 +66,7 @@
         !include-raw:
           - ../../../scripts/build_utils.sh
           - ../../build/build
+          - ../../../scripts/ceph-windows/setup_libvirt_vm
           - ../../../scripts/ceph-windows/run_tests
 
     publishers:
@@ -73,12 +74,15 @@
           builders:
             - role: SLAVE
               build-on:
+                - SUCCESS
+                - UNSTABLE
+                - FAILURE
                 - ABORTED
               build-steps:
                 - shell:
                     !include-raw:
                       - ../../../scripts/build_utils.sh
-                      - ../../../scripts/ceph-windows/cleanup_tests
+                      - ../../../scripts/ceph-windows/cleanup
 
     wrappers:
       - ansicolor

--- a/ceph-windows-test/config/definitions/ceph-windows-test.yml
+++ b/ceph-windows-test/config/definitions/ceph-windows-test.yml
@@ -32,6 +32,7 @@
           !include-raw:
             - ../../build/get_chacra_build
             - ../../../scripts/build_utils.sh
+            - ../../../scripts/ceph-windows/setup_libvirt_vm
             - ../../../scripts/ceph-windows/run_tests
 
     wrappers:
@@ -50,9 +51,12 @@
           builders:
             - role: SLAVE
               build-on:
+                - SUCCESS
+                - UNSTABLE
+                - FAILURE
                 - ABORTED
               build-steps:
                 - shell:
                     !include-raw:
                       - ../../../scripts/build_utils.sh
-                      - ../../../scripts/ceph-windows/cleanup_tests
+                      - ../../../scripts/ceph-windows/cleanup

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1596,32 +1596,6 @@ docs_pr_only() {
   popd
 }
 
-function cleanup_windows_tests_env() {
-    local VM_NAME=${VM_NAME:-"ceph-win-ltsc2019-${JOB_NAME}-${BUILD_ID}"}
-
-    # Cleanup virsh VM
-    if sudo virsh list | grep -q $VM_NAME; then
-        echo "Shutting down VM $VM_NAME"
-        sudo virsh destroy $VM_NAME
-    fi
-    if sudo virsh list --all | grep -q $VM_NAME; then
-        echo "Deleting VM $VM_NAME"
-        sudo virsh undefine $VM_NAME --remove-all-storage
-    fi
-    # Cleanup Ceph clusters spawned via cephadm
-    if [[ -x $WORKSPACE/cephadm ]] && [[ -d /var/lib/ceph ]]; then
-        for FSID in $(sudo ls /var/lib/ceph); do
-            echo "Removing Ceph cluster $FSID"
-            sudo $WORKSPACE/cephadm rm-cluster --fsid $FSID --force
-        done
-    fi
-    # Cleanup remaning files / directories
-    sudo rm -rf \
-        $WORKSPACE/ceph.conf $WORKSPACE/keyring $WORKSPACE/cephadm \
-        $WORKSPACE/ceph.zip $WORKSPACE/known_hosts \
-        /etc/ceph /var/log/ceph /var/lib/ceph /var/run/ceph
-}
-
 function ssh_exec() {
     if [[ -z $SSH_ADDRESS ]]; then
         echo "ERROR: Env variable SSH_ADDRESS is not set"

--- a/scripts/ceph-windows/cleanup_tests
+++ b/scripts/ceph-windows/cleanup_tests
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -o errexit
-set -o pipefail
-
-
-cleanup_windows_tests_env

--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -2,46 +2,12 @@
 set -o errexit
 set -o pipefail
 
-if [[ -z $CEPH_WIN_CI_KEY ]]; then
-    echo "ERROR: The CI SSH private key secret (CEPH_WIN_CI_KEY) is not set"
-    exit 1
-fi
 if [[ ! -f $WORKSPACE/ceph.zip ]]; then
     echo "ERROR: The Ceph Windows build zip file doesn't exist at $WORKSPACE/ceph.zip"
     exit 1
 fi
 
-VM_IMAGE_URL=${VM_IMAGE_URL:-"https://filedump.ceph.com/windows/ceph-win-ltsc2019-ci-image.qcow2"}
 CEPHADM_RELEASE=${CEPHADM_RELEASE:-"pacific"}
-
-VM_NAME="ceph-win-ltsc2019-${JOB_NAME}-${BUILD_ID}"
-SSH_TIMEOUT="30s"
-
-
-function run_ssh_command() {
-    local VM_IP="$1"
-    shift
-    timeout $SSH_TIMEOUT ssh -i $CEPH_WIN_CI_KEY -o UserKnownHostsFile=${WORKSPACE}/known_hosts administrator@${VM_IP} ${@}
-}
-
-function run_scp_upload_command() {
-    local VM_IP="$1"
-    local LOCAL_FILE="$2"
-    local REMOTE_FILE="$3"
-    timeout $SSH_TIMEOUT scp -i $CEPH_WIN_CI_KEY -o UserKnownHostsFile=${WORKSPACE}/known_hosts -r $LOCAL_FILE administrator@${VM_IP}:${REMOTE_FILE}
-}
-
-function run_scp_download_command() {
-    local VM_IP="$1"
-    local REMOTE_FILE="$2"
-    local LOCAL_FILE="$3"
-    timeout $SSH_TIMEOUT scp -i $CEPH_WIN_CI_KEY -o UserKnownHostsFile=${WORKSPACE}/known_hosts -r administrator@${VM_IP}:${REMOTE_FILE} $LOCAL_FILE
-}
-
-#
-# Cleanup before the script exits
-#
-trap cleanup_windows_tests_env EXIT
 
 #
 # Install requirements (if needed)
@@ -57,28 +23,6 @@ if ! sudo docker version &>/dev/null; then
     sudo apt-get install -y docker-ce docker-ce-cli containerd.io
 
     sudo usermod -aG docker $USER
-fi
-if ! which virt-install >/dev/null; then
-    sudo apt-get update
-    sudo apt-get install -y virtinst
-fi
-if ! sudo virsh net-info default &>/dev/null; then
-    cat << EOF > $WORKSPACE/default-net.xml
-<network>
-  <name>default</name>
-  <bridge name="virbr0"/>
-  <forward mode="nat"/>
-  <ip address="192.168.122.1" netmask="255.255.255.0">
-    <dhcp>
-      <range start="192.168.122.2" end="192.168.122.254"/>
-    </dhcp>
-  </ip>
-</network>
-EOF
-    sudo virsh net-define $WORKSPACE/default-net.xml
-    sudo virsh net-start default
-    sudo virsh net-autostart default
-    rm $WORKSPACE/default-net.xml
 fi
 if ! which xmllint >/dev/null; then
     sudo apt-get update
@@ -104,82 +48,28 @@ sudo chown $USER $WORKSPACE/ceph.conf $WORKSPACE/keyring
 sudo ceph osd pool create rbd
 
 #
-# Download the Windows qcow2 image
-#
-IMAGE_FILE="$(basename $VM_IMAGE_URL)"
-echo "Downloading VM image from $VM_IMAGE_URL"
-curl -L -o ${WORKSPACE}/${IMAGE_FILE} $VM_IMAGE_URL
-
-#
-# Start the Windows testing VM
-#
-sudo virt-install \
-    --name $VM_NAME \
-    --os-variant win2k19 \
-    --boot hd \
-    --virt-type kvm \
-    --graphics spice \
-    --cpu host \
-    --vcpus 4 \
-    --memory 4096 \
-    --disk ${WORKSPACE}/${IMAGE_FILE},bus=virtio \
-    --network network=default,model=virtio \
-    --controller type=virtio-serial \
-    --channel unix,target_type=virtio,name=org.qemu.guest_agent.0 \
-    --noautoconsol
-
-#
-# Wait until the QEMU agent reports the VM IP, and it's reachable via SSH
-#
-SECONDS=0
-TIMEOUT=600
-SLEEP_SECS=10
-while true; do
-    if [[ $SECONDS -gt $TIMEOUT ]]; then
-        echo "Timeout waiting for the VM to start"
-        exit 1
-    fi
-    VM_IP=$(sudo virsh domifaddr --source agent --interface Ethernet --full $VM_NAME | grep ipv4 | awk '{print $4}' | cut -d '/' -f1) || {
-        echo "Retrying in $SLEEP_SECS seconds"
-        sleep $SLEEP_SECS
-        continue
-    }
-    ssh-keyscan -H $VM_IP &> ${WORKSPACE}/known_hosts || {
-        echo "SSH is not reachable yet"
-        sleep $SLEEP_SECS
-        continue
-    }
-    run_ssh_command $VM_IP hostname || {
-        echo "Cannot execute SSH commands yet"
-        sleep $SLEEP_SECS
-        continue
-    }
-    break
-done
-
-#
 # Copy the ceph.conf and keyring to the Windows VM
 #
-run_ssh_command $VM_IP powershell.exe mkdir -force /ProgramData/ceph/out
-run_scp_upload_command $VM_IP $WORKSPACE/ceph.conf /ProgramData/ceph/ceph.conf
-run_scp_upload_command $VM_IP $WORKSPACE/keyring /ProgramData/ceph/keyring
+ssh_exec powershell.exe mkdir -force /ProgramData/ceph/out
+scp_upload $WORKSPACE/ceph.conf /ProgramData/ceph/ceph.conf
+scp_upload $WORKSPACE/keyring /ProgramData/ceph/keyring
 
 #
 # Setup the Ceph Windows build in the Windows VM
 #
-SSH_TIMEOUT=5m run_scp_upload_command $VM_IP $WORKSPACE/ceph.zip /ceph.zip
-SSH_TIMEOUT=10m run_ssh_command $VM_IP powershell.exe "\$ProgressPreference='SilentlyContinue'; Expand-Archive -Path /ceph.zip -DestinationPath / -Force"
-run_ssh_command $VM_IP powershell.exe "New-Service -Name ceph-rbd -BinaryPathName 'c:\ceph\rbd-wnbd.exe service'"
-run_ssh_command $VM_IP powershell.exe Start-Service -Name ceph-rbd
+SSH_TIMEOUT=5m scp_upload $WORKSPACE/ceph.zip /ceph.zip
+SSH_TIMEOUT=10m ssh_exec powershell.exe "\$ProgressPreference='SilentlyContinue'; Expand-Archive -Path /ceph.zip -DestinationPath / -Force"
+ssh_exec powershell.exe "New-Service -Name ceph-rbd -BinaryPathName 'c:\ceph\rbd-wnbd.exe service'"
+ssh_exec powershell.exe Start-Service -Name ceph-rbd
 
 #
 # Run the Windows tests
 #
-SSH_TIMEOUT=5m run_ssh_command $VM_IP git.exe clone https://github.com/ceph/ceph-win32-tests.git /workspace/repos/ceph-win32-tests
-SSH_TIMEOUT=1h run_ssh_command $VM_IP powershell.exe /workspace/repos/ceph-win32-tests/test_host/run_tests.ps1 -workerCount 4
+SSH_TIMEOUT=5m ssh_exec git.exe clone https://github.com/ceph/ceph-win32-tests.git /workspace/repos/ceph-win32-tests
+SSH_TIMEOUT=1h ssh_exec powershell.exe /workspace/repos/ceph-win32-tests/test_host/run_tests.ps1 -workerCount 4
 
 #
 # Collect logs
 #
 mkdir -p $WORKSPACE/logs
-run_scp_download_command $VM_IP /workspace/test_results $WORKSPACE/logs/test_results
+scp_download /workspace/test_results $WORKSPACE/logs/test_results


### PR DESCRIPTION
Refactor the Ceph Windows Jenkins jobs (`ceph-windows-test` and `ceph-windows-pull-requests`) with common scripts from `scripts/ceph-windows` and `scripts/build_utils.sh`

The purpose of this change is to eliminate code duplication.