### PR TITLE
ceph-dashboard-cephadm-e2e-job: update workspace path 

### DIFF
--- a/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
+++ b/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
@@ -18,6 +18,7 @@
     block-downstream: false
     block-upstream: false
     retry-count: 3
+    workspace: /home/jenkins-build/build/workspace/{name}/ceph
     properties:
       - build-discarder:
           days-to-keep: 15
@@ -41,7 +42,6 @@
           branches:
             - '{ceph_branch}'
           browser: auto
-          basedir: "ceph"
           timeout: 20
           skip-tag: true
           shallow-clone: true
@@ -53,7 +53,6 @@
             - ../../../scripts/dashboard/install-e2e-test-deps.sh
             - ../../../scripts/dashboard/install-cephadm-e2e-deps.sh
       - shell: |
-          cd ceph
           export CYPRESS_ARGS="--record --key $CYPRESS_RECORD_KEY --tag $JOB_NAME" COMMIT_INFO_MESSAGE="$JOB_NAME"
           timeout 7200 ./src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
 


### PR DESCRIPTION
In the nightly runs we saw that the ceph_cluster.yml file which we used
to deploy kcli plans is not up-to-date with the master one. It cause
problems in the nightlies. We've narrowed down the problem is with the basedir
and and also with the path difference in the dependency script and the location of
ceph. So changing the workspace path to workspace/ceph.

Also jenkins adviced against using basedir in the jenkins config
![Screenshot from 2022-01-04 20-00-04](https://user-images.githubusercontent.com/71764184/148075756-76ee762d-cdc2-4289-bc1f-bbc3ae5268c0.png)


Signed-off-by: Nizamudeen A <nia@redhat.com>