### PR TITLE
ceph-perf-pull-requests: enable llvm-toolset-10 repo using distribution-version-architecture format.

### DIFF
--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -170,7 +170,7 @@
               ;;
           centos|rhel)
               sudo dnf module disable -y llvm-toolset
-              sudo dnf copr enable -y tchaikov/llvm-toolset-10 centos-stream-x86_64
+              sudo dnf copr enable -y tchaikov/llvm-toolset-10 centos-stream-8-x86_64
               sudo yum install -y python3-pyyaml python3-lxml python3-prettytable clang
               gcc_toolset_ver=9
               # so clang is able to find gcc-toolset-${{gcc_toolset_ver}} which is listed as a


### PR DESCRIPTION
ceph-perf-pull-requests: When enabling llvm-toolset-10 copr repo, dnf
uses the following URL layout:
https://copr.fedorainfracloud.org/coprs/'repository'/repo/'distribution-version'/dnf.repo?arch='architecture'

The current merged command for enabling specifies repo, distribution and architecture
but not version.

This causes an incorrect url to be calculated and returns a 404 error as seen below:
https://copr.fedorainfracloud.org/coprs/tchaikov/llvm-toolset-10/repo/centos-stream/dnf.repo?arch=x86_64

When centos-stream-8 is specified the repo is fetched:
https://copr.fedorainfracloud.org/coprs/tchaikov/llvm-toolset-10/repo/centos-stream-8/dnf.repo?arch=x86_64

Signed-off-by: Christopher Hoffman <choffman@redhat.com>