### PR TITLE
ceph-perf-pull-requests: update libarchive

### DIFF
--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -172,6 +172,7 @@
               sudo dnf module disable -y llvm-toolset
               sudo dnf copr enable -y tchaikov/llvm-toolset-10 centos-stream-8-x86_64
               sudo yum install -y python3-pyyaml python3-lxml python3-prettytable clang
+              sudo yum update -y libarchive
               gcc_toolset_ver=9
               # so clang is able to find gcc-toolset-${{gcc_toolset_ver}} which is listed as a
               # BuildRequires in ceph.spec.in, and it is installed by `run-make.sh`.


### PR DESCRIPTION
Ensure version of libarchive is installed due to cmake dependency: https://access.redhat.com/solutions/6068431

Error message encountered:
cmake3: symbol lookup error: cmake3: undefined symbol: archive_write_add_filter_zstd

Related: https://github.com/ceph/ceph/pull/42294

Signed-off-by: Christopher Hoffman <choffman@redhat.com>