### PR TITLE
cephadm-ansible: add new credentials

### DIFF
--- a/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
+++ b/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
@@ -108,7 +108,11 @@
           mask-password-params: true
       - credentials-binding:
           - username-password-separated:
-              credential-id: cephadm-ansible-upstream-ci
-              username: DOCKER_HUB_USERNAME
-              password: DOCKER_HUB_PASSWORD
+              credential-id: cephadm-ansible-quay-io
+              username: QUAY_IO_USERNAME
+              password: QUAY_IO_PASSWORD
+          - username-password-separated:
+              credential-id: cephadm-ansible-quay-ceph-io
+              username: QUAY_CEPH_IO_USERNAME
+              password: QUAY_CEPH_IO_PASSWORD
 


### PR DESCRIPTION
This will allow using default images from cephadm instead of
maintaining what needs to be used in the tox.ini file of cephadm-ansible.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>