### PR TITLE
Add triggers for `wnbd-build` and `ceph-windows-installer-build`

### DIFF
--- a/ceph-windows-installer-build/config/definitions/ceph-windows-installer-build.yml
+++ b/ceph-windows-installer-build/config/definitions/ceph-windows-installer-build.yml
@@ -52,6 +52,9 @@
 
             If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra.
 
+    triggers:
+      - timed: "H 1 * * *"
+
     scm:
       - git:
           url: https://github.com/cloudbase/ceph-windows-installer.git

--- a/wnbd-build/config/definitions/wnbd-build.yml
+++ b/wnbd-build/config/definitions/wnbd-build.yml
@@ -32,6 +32,9 @@
 
             If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra.
 
+    triggers:
+      - timed: "H 0 * * *"
+
     scm:
       - git:
           url: https://github.com/ceph/wnbd.git


### PR DESCRIPTION
Add daily triggers for `wnbd-build` and `ceph-windows-installer-build`.

The ceph-windows installer trigger time is offset by 1 hour to
allow the `wnbd` build to be uploaded to Chacra.