### PR TITLE
ceph-{,dev,dev-new} build: fix conditional for cephadm package test

### DIFF
--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -38,7 +38,7 @@ if [ "$THROWAWAY" = false ] ; then
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
     # extract cephadm if it exists
-    if [[ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ]] ; then
+    if [ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ] ; then
         rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
         echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     fi

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -56,7 +56,7 @@ if [ "$THROWAWAY" = false ] ; then
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source/flavors/${FLAVOR}
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     # extract cephadm if it exists
-    if [[ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ]] ; then
+    if [ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ] ; then
         rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
         echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
         rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -57,7 +57,7 @@ if [ "$THROWAWAY" = false ] ; then
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source/flavors/${FLAVOR}
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     # extract cephadm if it exists
-    if [[ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ]] ; then
+    if [ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ] ; then
         rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
         echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     fi

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -953,7 +953,7 @@ build_debs() {
             $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
 
         # extract cephadm if it exists
-        if [[ -f release/${vers}/cephadm_${vers}*.deb ]] ; then
+        if [ -f release/${vers}/cephadm_${vers}*.deb ] ; then
             dpkg-deb --fsys-tarfile release/${vers}/cephadm_${vers}*.deb | tar -x -f - --strip-components=3 ./usr/sbin/cephadm
             echo cephadm | $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
         fi


### PR DESCRIPTION
https://github.com/ceph/ceph-build/pull/1919 added a conditional
test to check for cephadm package existence (so the code to extract
cephadm could work on older builds that did not have a cephadm package).
However, it used bash's [[ operator, and that doesn't expand file globs
in its arguments, so it effectively stopped creating the cephadm
binary altogether.

Switch to [, which doesn't have that problem.

Signed-off-by: Dan Mick <dmick@redhat.com>