### PR TITLE
ceph-{,dev,dev-new}-build:  fix "test for cephadm package" again

### DIFF
--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -38,7 +38,11 @@ if [ "$THROWAWAY" = false ] ; then
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
     # extract cephadm if it exists
-    if [ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ] ; then
+    found=0
+    for f in ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm; do
+        if [ -f "$f" ]; then found=1; break; fi
+    done
+    if [[ $found == 1 ]]; then
         rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
         echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     fi

--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -56,7 +56,11 @@ if [ "$THROWAWAY" = false ] ; then
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source/flavors/${FLAVOR}
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     # extract cephadm if it exists
-    if [ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ] ; then
+    found=0
+    for f in ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm; do
+        if [ -f "$f" ]; then found=1; break; fi
+    done
+    if [[ $found == 1 ]]; then
         rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
         echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
         rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -57,7 +57,11 @@ if [ "$THROWAWAY" = false ] ; then
     find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source/flavors/${FLAVOR}
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     # extract cephadm if it exists
-    if [ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ] ; then
+    found=0
+    for f in ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm; do
+        if [ -f "$f" ]; then found=1; break; fi
+    done
+    if [[ $found == 1 ]]; then
         rpm2cpio ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm  | cpio -i --to-stdout *sbin/cephadm > cephadm
         echo cephadm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}
     fi

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -953,7 +953,11 @@ build_debs() {
             $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
 
         # extract cephadm if it exists
-        if [ -f release/${vers}/cephadm_${vers}*.deb ] ; then
+        found=0
+        for f in release/${vers}/cephadm_${vers}*.deb ; do
+            if [ -f "$f" ]; then found=1; break; fi
+        done
+        if [[ $found == 1 ]]; then
             dpkg-deb --fsys-tarfile release/${vers}/cephadm_${vers}*.deb | tar -x -f - --strip-components=3 ./usr/sbin/cephadm
             echo cephadm | $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
         fi


### PR DESCRIPTION
Try #3 to get the "check for existence of a file" correct.
The construct [ -f <glob> ] will throw a syntax error if <glob>
expands to nothing.  Try for f in glob; do if [ -f "$f" ] instead.

Signed-off-by: Dan Mick <dmick@redhat.com>