### PR TITLE
arrow: remove apache jfrog repositories

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -480,9 +480,6 @@ echo "deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu/ $DIST-backports main
 echo "deb [arch=amd64] http://security.ubuntu.com/ubuntu $DIST-security main restricted universe multiverse" >> /etc/apt/sources.list
 env DEBIAN_FRONTEND=noninteractive apt-get update -y -o Acquire::Languages=none -o Acquire::Translation=none || true
 env DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg
-
-curl -L https://dist.apache.org/repos/dist/dev/arrow/KEYS | apt-key add -
-add-apt-repository "deb [arch=amd64] https://apache.jfrog.io/artifactory/arrow/ubuntu $DIST main"
 EOF
     elif [[ "$ARCH" == "arm64" ]]; then
         cat > $hookdir/D04install-updates-repo <<EOF
@@ -1353,8 +1350,6 @@ setup_rpm_build_deps() {
         $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
         $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save
 
-        $SUDO rpm -import https://dist.apache.org/repos/dist/dev/arrow/KEYS
-        $SUDO dnf config-manager --add-repo="https://apache.jfrog.io/artifactory/arrow/centos/${RELEASE}/x86_64"
     fi
 
     DIR=/tmp/install-deps.$$


### PR DESCRIPTION
arrow is a runtime dependency, so we won't be relying on this apache repo

~~for ubuntu, we'll submodule the arrow library. ubuntu/debian have all of arrow's dependencies~~

~~for centos, we need this 'storage sig' repo for both the arrow library and its missing utf8proc dependency~~

edit: we'll build arrow from submodule until it's available from distros