### PR TITLE
{ceph-pr-render,teuthology}-docs: Disable job

### DIFF
--- a/ceph-pr-render-docs/config/definitions/ceph-pr-render-docs.yml
+++ b/ceph-pr-render-docs/config/definitions/ceph-pr-render-docs.yml
@@ -1,5 +1,6 @@
 - job:
     name: ceph-pr-render-docs
+    disabled: true
     display-name: 'ceph: Pull Requests Render Docs'
     node: docs
     project-type: freestyle

--- a/teuthology-docs/config/definitions/teuthology-docs.yml
+++ b/teuthology-docs/config/definitions/teuthology-docs.yml
@@ -1,5 +1,6 @@
 - job:
     name: teuthology-docs
+    disabled: true
     node: docs
     project-type: freestyle
     defaults: global


### PR DESCRIPTION
We're using RTD now.  The docs Jenkins builder is retired.

Signed-off-by: David Galloway <dgallowa@redhat.com>