### PR TITLE
ceph-dev*build: Stop using docker-mirror

### DIFF
--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -100,10 +100,8 @@ if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" ]] ; then
       # exit 1
     fi
 
-    use_internal_container_registry
-
     cd $WORKSPACE/ceph-container
-    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} OSD_FLAVOR=${FLAVOR} CONTAINER_FLAVOR=${BRANCH},${DISTRO},${RELEASE} BASEOS_REGISTRY=${REGISTRY} \
+    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} OSD_FLAVOR=${FLAVOR} CONTAINER_FLAVOR=${BRANCH},${DISTRO},${RELEASE} \
       /bin/bash ./contrib/build-push-ceph-container-imgs.sh
     cd $WORKSPACE
     sudo rm -rf ceph-container

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -100,10 +100,8 @@ if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" ]] ; then
       # exit 1
     fi
 
-    use_internal_container_registry
-
     cd $WORKSPACE/ceph-container
-    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} OSD_FLAVOR=${FLAVOR} CONTAINER_FLAVOR=${BRANCH},${DISTRO},${RELEASE} BASEOS_REGISTRY=${REGISTRY} \
+    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} OSD_FLAVOR=${FLAVOR} CONTAINER_FLAVOR=${BRANCH},${DISTRO},${RELEASE} \
       /bin/bash ./contrib/build-push-ceph-container-imgs.sh
     cd $WORKSPACE
     sudo rm -rf ceph-container

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1555,18 +1555,6 @@ maybe_reset_ci_container() {
     fi
 }
 
-# dockerhub started aggressively rate limiting in November 2020. We can use an internal docker mirror if the builder is in the upstream lab.
-use_internal_container_registry() {
-  if curl -s -k "https://docker-mirror.front.sepia.ceph.com:5000"; then
-    REGISTRY="docker-mirror.front.sepia.ceph.com:5000/library"
-  else
-    if [ -n "${DOCKER_HUB_USERNAME}" ] && [ -n "${DOCKER_HUB_PASSWORD}" ]; then
-      docker login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}" docker.io
-    fi
-    REGISTRY="docker.io"
-  fi
-}
-
 # NOTE: This function will only work on a Pull Request job!
 docs_pr_only() {
   pushd .


### PR DESCRIPTION
Non-stream CentOS8 containers no longer work because the BaseOS and AppStream repos moved.  We now use the centos/centos:stream8 container image as our BASEOS_TAG.  Except that container lives on quay.io and not dockerhub.

docker-mirror.front.sepia.ceph.com:5000 can only mirror one registry.  We'll keep it as mirroring dockerhub.

Signed-off-by: David Galloway <dgallowa@redhat.com>