### PR TITLE
dep: delete the network before creating it again

### DIFF
--- a/scripts/dashboard/install-cephadm-e2e-deps.sh
+++ b/scripts/dashboard/install-cephadm-e2e-deps.sh
@@ -86,5 +86,7 @@ sudo chmod +x /usr/local/bin/kcli
 
 # KCLI cleanup function can be found here: https://github.com/ceph/ceph/blob/master/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
 sudo mkdir -p /var/lib/libvirt/images/ceph-dashboard
+kcli delete plan ceph -y || true
+kcli delete network ceph-dashboard -y
 kcli create pool -p /var/lib/libvirt/images/ceph-dashboard ceph-dashboard
 kcli create network -c 192.168.100.0/24 ceph-dashboard


### PR DESCRIPTION
Need to recreate the network to avoid issues like ssh ing into the
environment.

Last runs with this change in the configuration is a success.
![Screenshot from 2022-02-04 14-33-14](https://user-images.githubusercontent.com/71764184/152510834-6420d034-2af1-404b-a89f-1cf020516bcc.png)

Fixes: https://tracker.ceph.com/issues/54131
Signed-off-by: Nizamudeen A <nia@redhat.com
