### PR TITLE
[ceph-windows-installer-build] Remove `FORCE` parameter

### DIFF
--- a/ceph-windows-installer-build/build/build
+++ b/ceph-windows-installer-build/build/build
@@ -46,8 +46,7 @@ cp $WORKSPACE/ceph-windows-installer/Driver/wnbd.cer $WORKSPACE/wnbd_code_signin
 #
 if [ "$THROWAWAY" = false ]; then
     # push binaries to chacra
-    chacra_binary="$VENV/chacractl binary"
-    [ "$FORCE" = true ] && chacra_binary="$chacra_binary --force"
+    chacra_binary="$VENV/chacractl binary --force"
 
     ls $WORKSPACE/Ceph.msi $WORKSPACE/wnbd_code_signing.cer | $chacra_binary create ${chacra_binary_endpoint}
 

--- a/ceph-windows-installer-build/build/setup
+++ b/ceph-windows-installer-build/build/setup
@@ -35,11 +35,6 @@ chacra_binary_endpoint="${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}"
 chacra_repo_endpoint="${chacra_endpoint}/flavors/${FLAVOR}"
 chacra_check_url="${chacra_binary_endpoint}/Ceph.msi"
 
-if [ "$THROWAWAY" = false ] ; then
-    # this exists in scripts/build_utils.sh
-    check_binary_existence $VENV $chacra_check_url
-fi
-
 # create build status in shaman
 update_build_status "started" "ceph-windows-installer" $DISTRO $DISTRO_VERSION $ARCH
 

--- a/ceph-windows-installer-build/config/definitions/ceph-windows-installer-build.yml
+++ b/ceph-windows-installer-build/config/definitions/ceph-windows-installer-build.yml
@@ -45,13 +45,6 @@
             Default: False. When True it will not POST binaries to chacra. Artifacts will not be around for long. Useful to test builds.
           default: false
 
-      - bool:
-          name: FORCE
-          description: |
-            If this is unchecked, then nothing is built or pushed if they already exist in chacra. This is the default.
-
-            If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra.
-
     triggers:
       - timed: "H 1 * * *"
 


### PR DESCRIPTION
Remove the `FORCE` parameter from the `ceph-windows-installer-build`
Jenkins job, and use it by default.

This job builds the installer from source code, and it bundles
the Ceph binaries and the WNBD driver.

Therefore, the logic to skip the build if the latest installer commit
didn't change is not useful, because the installer might contain
different Ceph binaries and WNBD driver.