### PR TITLE
Revert "use alpha tag for ceph-ansible until we have a stable-7.0 bra…

### DIFF
--- a/ceph-volume-ansible-prs/build/build
+++ b/ceph-volume-ansible-prs/build/build
@@ -34,8 +34,6 @@ elif [[ "$ghprbTargetBranch" == "octopus" ]]; then
     CEPH_ANSIBLE_BRANCH="stable-5.0"
 elif [[ "$ghprbTargetBranch" == "pacific" ]]; then
     CEPH_ANSIBLE_BRANCH="stable-6.0"
-elif [[ "$ghprbTargetBranch" == "quincy" ]]; then
-    CEPH_ANSIBLE_BRANCH="v7.0.0alpha1"
 else
     CEPH_ANSIBLE_BRANCH="master"
 fi


### PR DESCRIPTION
…nch"

This reverts commit 207adf189e25753bfc68b2998d430b16fb50d389.

This breaks ceph-volume/ceph-ansible testing.

`v7.0.0alpha1` is a tag present on stable-6.0.
ceph-ansible stable-6.0 doesn't support quincy.

We have to keep using ceph-ansible@master for now.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>