### PR TITLE
ceph-grafana-trigger: update grafana container image version to 8.2.6

### DIFF
--- a/ceph-grafana-trigger/build/build
+++ b/ceph-grafana-trigger/build/build
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-CONTAINER_VERSION=${CONTAINER_VERSION:-6.7.4}
+CONTAINER_VERSION=${CONTAINER_VERSION:-8.2.6}
 CONTAINER=ceph/ceph-grafana:${CONTAINER_VERSION}
 sudo dnf install -y podman
 sudo podman login docker.io -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD}

--- a/ceph-grafana-trigger/config/definitions/ceph-grafana-trigger.yml
+++ b/ceph-grafana-trigger/config/definitions/ceph-grafana-trigger.yml
@@ -23,7 +23,7 @@
       - string:
           name: CONTAINER_VERSION
           description: "The version tag for the containers; will have -ARCH added to it.  By convention, the version of Grafana"
-          default: "6.7.4"
+          default: "8.2.6"
     axes:
         - axis:
             type: label-expression


### PR DESCRIPTION
update grafana container image version to 8.2.6

Signed-off-by: Aashish Sharma <aasharma@redhat.com>