### PR TITLE
reenable ubuntu's toolchain ppa for c++20 support

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -632,25 +632,18 @@ setup_pbuilder() {
 }
 
 use_ppa() {
+    # only use ppa on focal for reef+
     case $vers in
-        10.*)
-            # jewel
+        15.*) # o
             use_ppa=false;;
-        11.*)
-            # kraken
+        16.*) # p
             use_ppa=false;;
-        12.*)
-            # luminous
+        17.2*) # q
             use_ppa=false;;
         *)
-            # mimic, nautilus, *
             case $DIST in
-                trusty)
+                focal)
                     use_ppa=true;;
-                xenial)
-                    use_ppa=true;;
-                bionic)
-                    use_ppa=false;;
                 *)
                     use_ppa=false;;
             esac

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -779,10 +779,7 @@ setup_pbuilder_for_old_gcc() {
 setup_pbuilder_for_ppa() {
     local hookdir=$1
     if use_ppa; then
-        local gcc_ver=7
-        if [ "$DIST" = "bionic" ]; then
-            gcc_ver=9
-        fi
+        local gcc_ver=11
         setup_pbuilder_for_new_gcc $hookdir $gcc_ver
     else
         setup_pbuilder_for_old_gcc $hookdir

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -703,21 +703,21 @@ setup_pbuilder_for_new_gcc() {
     local version=$1
     shift
 
-    # need to add the test repo and install gcc-7 after
+    # need to add the test repo and install new gcc after
     # `pbuilder create|update` finishes apt-get instead of using "extrapackages".
-    # otherwise installing gcc-7 will leave us a half-configured build-essential
-    # and gcc-7, and `pbuilder` command will fail. because the `build-essential`
+    # otherwise installing gcc will leave us a half-configured build-essential
+    # and gcc, and `pbuilder` command will fail. because the `build-essential`
     # depends on a certain version of gcc which is upgraded already by the one
     # in test repo.
     if [ "$ARCH" = "arm64" ]; then
-        cat > $hookdir/D05install-gcc-7 <<EOF
+        cat > $hookdir/D05install-new-gcc <<EOF
 echo "deb [lang=none] http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu $DIST main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
 echo "deb [lang=none] http://ports.ubuntu.com/ubuntu-ports $DIST-updates main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
 EOF
     elif [ "$ARCH" = "x86_64" ]; then
-        cat > $hookdir/D05install-gcc-7 <<EOF
+        cat > $hookdir/D05install-new-gcc <<EOF
 echo "deb [lang=none] http://security.ubuntu.com/ubuntu $DIST-security main" >> \
   /etc/apt/sources.list.d/ubuntu-toolchain-r.list
 echo "deb [lang=none] http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu $DIST main" >> \
@@ -731,7 +731,7 @@ EOF
         echo "unsupported arch: $ARCH"
         exit 1
     fi
-cat >> $hookdir/D05install-gcc-7 <<EOF
+cat >> $hookdir/D05install-new-gcc <<EOF
 env DEBIAN_FRONTEND=noninteractive apt-get install -y gnupg
 cat << ENDOFKEY | apt-key add -
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -753,7 +753,7 @@ env DEBIAN_FRONTEND=noninteractive apt-get update -y -o Acquire::Languages=none 
 env DEBIAN_FRONTEND=noninteractive apt-get install -y g++-$version
 EOF
 
-    chmod +x $hookdir/D05install-gcc-7
+    chmod +x $hookdir/D05install-new-gcc
 
     setup_gcc_hook $version > $hookdir/D10update-gcc-alternatives
     chmod +x $hookdir/D10update-gcc-alternatives


### PR DESCRIPTION
we've used this repo in the past to get access to newer compiler versions. reenable it for ubuntu focal for access to gcc 11

note that these changes don't preserve the original behavior against old distros like trusty/xenial. if there is still interest in building against those releases, i can work through these differences:

trusty: PPA 7 -> 11
xenial: PPA 8 -> 11
bionic: does not use PPA (unchanged)