### PR TITLE
dashboard-e2e-job: get mgr logs as an artifact

### DIFF
--- a/ansible/examples/master.yml
+++ b/ansible/examples/master.yml
@@ -28,6 +28,7 @@
       - 'cobertura'
       - 'code-coverage-api'
       - 'command-launcher'
+      - 'compress-artifacts'
       - 'conditional-buildstep'
       - 'configuration-as-code'
       - 'copyartifact'

--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -89,3 +89,8 @@
     publishers:
       - email:
           recipients: ceph-qa@ceph.io
+
+      - archive:
+          artifacts: 'build/out/mgr.*.log'
+          allow-empty: true
+          latest-only: false

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -94,3 +94,9 @@
               <applitoolsApiKey/>
             </com.applitools.jenkins.ApplitoolsBuildWrapper>
       - ansicolor
+
+    publishers:
+      - archive:
+          artifacts: 'build/out/mgr.*.log'
+          allow-empty: true
+          latest-only: false

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -84,6 +84,11 @@
               build-steps:
                 - shell: "sudo dpkg --configure -a"
 
+      - archive:
+          artifacts: 'build/out/mgr.*.log'
+          allow-empty: true
+          latest-only: false
+
     wrappers:
       - ansicolor
       - credentials-binding:


### PR DESCRIPTION
archive the logs as an artifact in both pr and nightly jobs of
dashboard frontend e2es.

![Screenshot 2022-03-02 143840](https://user-images.githubusercontent.com/71764184/156330506-87c55482-5a8b-4db3-bd08-69eaf2d42e72.png)

Signed-off-by: Nizamudeen A <nia@redhat.com>