### PR TITLE
ceph-iscsi-tox: replace python3 node label constraint

### DIFF
--- a/ceph-iscsi-tox/config/definitions/ceph-iscsi-tox.yml
+++ b/ceph-iscsi-tox/config/definitions/ceph-iscsi-tox.yml
@@ -16,7 +16,7 @@
     name: ceph-iscsi-tox
     description: Runs tox tests for ceph-iscsi on each GitHub PR
     project-type: freestyle
-    node: python3
+    node: focal && x86_64
     block-downstream: false
     block-upstream: false
     defaults: global


### PR DESCRIPTION
mira042, the only node with python3 label, was retired two months ago.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>