### PR TITLE
ansible: Disable gc logging for Jenkins

### DIFF
--- a/ansible/roles/ansible-jenkins/tasks/config.yml
+++ b/ansible/roles/ansible-jenkins/tasks/config.yml
@@ -7,6 +7,18 @@
     backup: yes
   register: config_changed
 
+- name: Configure Jenkins systemd service overrides
+  template:
+    src: override.conf
+    dest: /etc/systemd/system/jenkins.service.d/override.conf
+    backup: yes
+  register: config_changed
+
+- name: Reload systemd services
+  systemd:
+    daemon_reload: true
+  when: config_changed|bool
+
 - name: Configure Jenkins E-mail
   when: email is defined
   template:

--- a/ansible/roles/ansible-jenkins/templates/etc_default.j2
+++ b/ansible/roles/ansible-jenkins/templates/etc_default.j2
@@ -6,9 +6,6 @@ NAME=jenkins
 # location of java
 JAVA=/usr/bin/java
 
-# From https://jenkins.io/blog/2016/11/21/gc-tuning/
-JAVA_ARGS="-Xmx20g -Xms20g -Djava.awt.headless=true -Dhudson.model.User.SECURITY_243_FULL_DEFENSE=false -Dhudson.model.ParametersAction.keepUndefinedParameters=true -Dorg.jenkinsci.plugins.pipeline.modeldefinition.parser.RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION=true -server -XX:+AlwaysPreTouch -Xloggc:/var/log/jenkins/gc-%t.log -XX:+PrintGC -XX:+PrintGCDetails -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1"
-
 PIDFILE=/var/run/$NAME/$NAME.pid
 
 # user and group to be invoked as (default to jenkins)

--- a/ansible/roles/ansible-jenkins/templates/override.conf
+++ b/ansible/roles/ansible-jenkins/templates/override.conf
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+[Service]
+Environment="JAVA_OPTS=-Xmx20g -Xms20g -Djava.awt.headless=true -Dhudson.model.User.SECURITY_243_FULL_DEFENSE=false -Dhudson.model.ParametersAction.keepUndefinedParameters=true -Dorg.jenkinsci.plugins.pipeline.modeldefinition.parser.RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION=true -server -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1 -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=1200"
+TimeoutStartSec=10min


### PR DESCRIPTION
These options were deprecated a long time ago and we haven't been logging gc output since last year.

Signed-off-by: David Galloway <dgallowa@redhat.com>