### PR TITLE
scripts: Use bash instead of python to determine is_not_tar

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -564,7 +564,7 @@ setup_pbuilder() {
     # ensure that the tgz is valid, otherwise remove it so that it can be recreated
     # again
     pbuild_tar="$basedir/$DIST.tgz"
-    is_not_tar=`python -c "exec 'try: import tarfile;print int(not int(tarfile.is_tarfile(\"$pbuild_tar\")))\nexcept IOError: print 1'"`
+    is_not_tar=`python3 -c "exec 'try: import tarfile;print int(not int(tarfile.is_tarfile(\"$pbuild_tar\")))\nexcept IOError: print 1'"`
     file_size_kb=`test -f $pbuild_tar && du -k "$pbuild_tar" | cut -f1 || echo 0`
 
     if [ "$is_not_tar" = "1" ]; then


### PR DESCRIPTION
As we continue to slowly move on from python2, this is a relic that should get future-proofed.

Signed-off-by: David Galloway <dgallowa@redhat.com>