### PR TITLE
Revert "scripts: Use python3 to test is_not_tar"

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -564,7 +564,7 @@ setup_pbuilder() {
     # ensure that the tgz is valid, otherwise remove it so that it can be recreated
     # again
     pbuild_tar="$basedir/$DIST.tgz"
-    is_not_tar=`python3 -c "exec 'try: import tarfile;print int(not int(tarfile.is_tarfile(\"$pbuild_tar\")))\nexcept IOError: print 1'"`
+    is_not_tar=`python -c "exec 'try: import tarfile;print int(not int(tarfile.is_tarfile(\"$pbuild_tar\")))\nexcept IOError: print 1'"`
     file_size_kb=`test -f $pbuild_tar && du -k "$pbuild_tar" | cut -f1 || echo 0`
 
     if [ "$is_not_tar" = "1" ]; then

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -564,7 +564,7 @@ setup_pbuilder() {
     # ensure that the tgz is valid, otherwise remove it so that it can be recreated
     # again
     pbuild_tar="$basedir/$DIST.tgz"
-    is_not_tar=`python -c "exec 'try: import tarfile;print int(not int(tarfile.is_tarfile(\"$pbuild_tar\")))\nexcept IOError: print 1'"`
+    is_not_tar=`python3 -c $'try: import tarfile;print(int(not int(tarfile.is_tarfile(\"$pbuild_tar\"))))\nexcept IOError: print(1)'`
     file_size_kb=`test -f $pbuild_tar && du -k "$pbuild_tar" | cut -f1 || echo 0`
 
     if [ "$is_not_tar" = "1" ]; then


### PR DESCRIPTION
String format appears to be incompatible with the python version being
used and so this is causing more failures than the original.

This reverts commit 4668da7fb015138b626ad21d2519c76a64e390a0.