### PR TITLE
dashboard/nighlty: fix applitools baseline

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -67,8 +67,8 @@
       - shell: |
           export CYPRESS_ARGS="--record --key $CYPRESS_RECORD_KEY --tag $JOB_NAME" COMMIT_INFO_MESSAGE="$JOB_NAME"
           export APPLITOOLS_BATCH_ID="${{JOB_NAME}}_${{BUILD_TAG}}"
-          export APPLITOOLS_BRANCH_NAME="$ghprbSourceBranch"
-          export APPLITOOLS_PARENT_BRANCH_NAME="$ghprbTargetBranch"
+          export APPLITOOLS_BATCH_NAME="Nightly-${{GIT_BRANCH#*/}}"
+          export APPLITOOLS_BRANCH_NAME="${{GIT_BRANCH#*/}}"
           mkdir -p .applitools
           echo "$APPLITOOLS_BATCH_ID" > .applitools/BATCH_ID
           cd src/pybind/mgr/dashboard; timeout 2h ./{test_suite_script}
@@ -84,6 +84,14 @@
           - text:
               credential-id: cd-applitools-api-key
               variable: APPLITOOLS_API_KEY
+      - raw:
+          xml: |
+            <com.applitools.jenkins.ApplitoolsBuildWrapper plugin="applitools-eyes@1.13">
+              <serverURL>https://eyes.applitools.com</serverURL>
+              <notifyByCompletion>true</notifyByCompletion>
+              <applitoolsApiKey/>
+            </com.applitools.jenkins.ApplitoolsBuildWrapper>
+ 
       - ansicolor
 
     publishers:

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -69,6 +69,7 @@
       - shell: |
           export CYPRESS_ARGS="--record --key $CYPRESS_RECORD_KEY --tag $ghprbTargetBranch" COMMIT_INFO_MESSAGE="$ghprbPullTitle"
           export APPLITOOLS_BATCH_ID="PR-${ghprbPullId}_${BUILD_TAG}"
+          export APPLITOOLS_BATCH_NAME="PR-${ghprbPullId}"
           export APPLITOOLS_BRANCH_NAME="$ghprbSourceBranch"
           export APPLITOOLS_PARENT_BRANCH_NAME="$ghprbTargetBranch"
           mkdir -p .applitools


### PR DESCRIPTION
E2E nightlies have been failing for a while due to visual regression issues (browser upgrades). However, Applitools doesn't seem to be able to mark those issues as resolved (because they need to be resolved in the baseline branch: `master`, `pacific`, etc, and Applitools doesn't find any branch with that name):

![image](https://user-images.githubusercontent.com/37327689/160427953-9e86c63d-0bfb-4826-9146-1eeadf5b0d4f.png)


Adds correct Branch to Nightly jobs:
* ~~`$CEPH_LOCAL_BRANCH` instead of `$CEPH_BRANCH`: `master` vs. `origin/master`~~ (it didn't work: it needs a specific option enabled in the git plugin).
* Let's try with shell substring replacement: `${{GIT_BRANCH#*/}}`. Yesss, it now works:
* Renames Batches with a more intuitive naming (`PR-<number>`, `Nightly-<branch>`).



## Before
```sh
+ export APPLITOOLS_BATCH_ID=ceph-api-nightly-master-e2e_jenkins-ceph-api-nightly-master-e2e-880
+ export APPLITOOLS_BATCH_NAME=
+ export APPLITOOLS_BRANCH_NAME=
```

## After
```sh
+ export APPLITOOLS_BATCH_ID=ceph-api-nightly-master-e2e_jenkins-ceph-api-nightly-master-e2e-881
+ export APPLITOOLS_BATCH_NAME=Nightly-master
+ export APPLITOOLS_BRANCH_NAME=master
```



Sample run: https://jenkins.ceph.com/view/mgr-dashboard/job/ceph-api-nightly-master-e2e/881/

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>