### PR TITLE
ceph-pull-requests: enable the RWL mode of RBD persistent cache

### DIFF
--- a/ceph-pull-requests/build/build
+++ b/ceph-pull-requests/build/build
@@ -8,6 +8,7 @@ fi
 
 export NPROC=$(nproc)
 export WITH_SEASTAR=true
+export WITH_RBD_RWL=true
 if which apt-get > /dev/null ; then
     export WITH_ZBD=true
 fi


### PR DESCRIPTION
WITH_RBD_RWL variable is added in https://github.com/ceph/ceph/pull/45872.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>