### PR TITLE
cephadm-dashboard-e2e: archiving takes too long to fail

### DIFF
--- a/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
+++ b/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
@@ -71,6 +71,6 @@
       - email:
           recipients: ceph-qa@ceph.io
       - archive:
-          artifacts: 'logs/*.log'
+          artifacts: 'logs/**'
           allow-empty: true
           latest-only: false

--- a/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
+++ b/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
@@ -85,6 +85,6 @@
 
     publishers:
       - archive:
-          artifacts: 'logs/*.log'
+          artifacts: 'logs/**'
           allow-empty: true
           latest-only: false


### PR DESCRIPTION
If the provided pattern for eg: `log/*.log` is not found, archiving takes
way too longer to fail and that increased the job time to 1 hour on our
cephadm dashboard e2e jobs. Instead I added a pattern like `log/**` and
this way it immediately failed when there is no logs. (In cephadm
dashboard e2e, there
won't be any logs if the job is succesfull and the logs are saved only
when the job is failed)

This is yesterday's nightly job which took more than 1hr to complete.
https://jenkins.ceph.com/job/ceph-dashboard-cephadm-e2e-nightly-master/171/
![Screenshot from 2022-04-27 12-14-08](https://user-images.githubusercontent.com/71764184/165457531-3fa11232-22e7-462d-b074-21a36b5b9e71.png)

This job ran with the current changes in PR and it took only 15 mins (usual time for a successful job run)
https://jenkins.ceph.com/job/ceph-dashboard-cephadm-e2e/3342/console
![Screenshot from 2022-04-27 12-15-30](https://user-images.githubusercontent.com/71764184/165457856-a06f3cdc-166c-43bb-a3d0-a7c65e166f5d.png)


Signed-off-by: Nizamudeen A <nia@redhat.com>