### PR TITLE
ceph-{ansible,container}*: Use CentOS8 builders instead of 7

### DIFF
--- a/ceph-ansible-docs-prs/config/definitions/ceph-ansible-docs-prs.yml
+++ b/ceph-ansible-docs-prs/config/definitions/ceph-ansible-docs-prs.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-ansible-docs-pull-requests
-    node: (small && (centos7 || trusty)) || (vagrant && libvirt && smithi)
+    node: (small && (centos8 || trusty)) || (vagrant && libvirt && smithi)
     project-type: freestyle
     defaults: global
     display-name: 'ceph-ansible: docs pull requests'

--- a/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
+++ b/ceph-ansible-nightly/config/definitions/ceph-ansible-nightly.yml
@@ -31,7 +31,7 @@
 
 - job-template:
     name: 'ceph-ansible-nightly-{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}'
-    node: vagrant&&libvirt&&centos7
+    node: vagrant&&libvirt&&centos8
     concurrent: true
     defaults: global
     display-name: 'ceph-ansible: Nightly [{release}-{distribution}-{deployment}-{ceph_ansible_branch}-{scenario}]'

--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -23,7 +23,7 @@
 
 - project:
     name: ceph-ansible-prs
-    slave_labels: 'vagrant && libvirt && (smithi || braggi || centos7)'
+    slave_labels: 'vagrant && libvirt && (smithi || braggi || centos8)'
     distribution:
       - centos
     deployment:
@@ -39,7 +39,7 @@
 
 - project:
     name: ceph-ansible-prs-docker2podman
-    slave_labels: 'vagrant && libvirt && (smithi || braggi || centos7)'
+    slave_labels: 'vagrant && libvirt && (smithi || braggi || centos8)'
     distribution:
       - centos
     deployment:
@@ -77,7 +77,7 @@
 
 - project:
     name: ceph-ansible-prs-common-trigger
-    slave_labels: 'vagrant && libvirt && (smithi || braggi || centos7)'
+    slave_labels: 'vagrant && libvirt && (smithi || braggi || centos8)'
     distribution:
       - centos
     deployment:

--- a/ceph-ansible-rpm/config/definitions/ceph-ansible-rpm.yml
+++ b/ceph-ansible-rpm/config/definitions/ceph-ansible-rpm.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-ansible-rpm
-    node: 'centos7 && x86_64 && small && !sepia'
+    node: 'centos8 && x86_64 && small && !sepia'
     project-type: freestyle
     defaults: global
     disabled: false

--- a/ceph-container-flake8/config/definitions/ceph-container-flake8.yml
+++ b/ceph-container-flake8/config/definitions/ceph-container-flake8.yml
@@ -14,7 +14,7 @@
 
 - job:
     name: ceph-container-flake8
-    node: small && centos7
+    node: small && centos8
     defaults: global
     display-name: 'ceph-container-flake8'
     properties:

--- a/ceph-container-lint/config/definitions/ceph-container-lint.yml
+++ b/ceph-container-lint/config/definitions/ceph-container-lint.yml
@@ -14,7 +14,7 @@
 
 - job:
     name: ceph-container-lint
-    node: small && centos7
+    node: small && centos8
     defaults: global
     display-name: 'ceph-container-lint'
     properties:

--- a/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
+++ b/ceph-container-nighlity/config/definitions/ceph-container-nightly.yml
@@ -9,7 +9,7 @@
 
 - job-template:
     name: 'ceph-container-nightly-ceph_ansible-{test}'
-    node: vagrant&&libvirt&&centos7
+    node: vagrant&&libvirt&&centos8
     concurrent: true
     defaults: global
     display-name: 'ceph-container: Nightly tests [ceph_ansible-{test}]'

--- a/ceph-container-prs/config/definitions/ceph-container-prs.yml
+++ b/ceph-container-prs/config/definitions/ceph-container-prs.yml
@@ -10,7 +10,7 @@
 - job-template:
     name: 'ceph-container-prs-ceph_ansible-{test}'
     id: 'ceph-container-prs-auto'
-    node: vagrant&&libvirt&&centos7
+    node: vagrant&&libvirt&&centos8
     concurrent: true
     defaults: global
     display-name: 'ceph-container: Pull Requests [ceph_ansible-{test}]'
@@ -92,7 +92,7 @@
 - job-template:
     name: 'ceph-container-prs-ceph_ansible-{test}'
     id: 'ceph-container-prs-trigger'
-    node: vagrant&&libvirt&&centos7
+    node: vagrant&&libvirt&&centos8
     concurrent: true
     defaults: global
     display-name: 'ceph-container: Pull Requests [ceph_ansible-{test}]'


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>