### PR TITLE
ansible: Update playbooks to install newest vagrant&plugin

### DIFF
--- a/ansible/examples/centos8-vagrant.yml
+++ b/ansible/examples/centos8-vagrant.yml
@@ -29,9 +29,7 @@
 
     - name: Set the latest vagrant version URL
       set_fact:
-        latest_vagrant_url: "https://releases.hashicorp.com/vagrant/2.2.10/vagrant_2.2.10_x86_64.rpm"
-        # Latest vagrant version sometimes has issue.  Pinning to 2.2.10 for now.
-        # latest_vagrant_url: "https://releases.hashicorp.com/vagrant/{{ latest_vagrant_version.stdout }}/vagrant_{{ latest_vagrant_version.stdout }}_x86_64.rpm"
+        latest_vagrant_url: "https://releases.hashicorp.com/vagrant/{{ latest_vagrant_version.stdout }}/vagrant_{{ latest_vagrant_version.stdout }}_x86_64.rpm"
 
     ## Wipe out vagrant stuff
     # From https://github.com/vagrant-libvirt/vagrant-libvirt/issues/943#issuecomment-463678158
@@ -72,21 +70,18 @@
         LDFLAGS='-L/opt/vagrant/embedded/' ./configure
         make
         sudo cp lib/libk5crypto.* /opt/vagrant/embedded/lib/
-# This was required for vagrant-libvirt version 0.5.3.  That version was giving us a lot of trouble
-# so we've pinned vagrant-libvirt to a known good version, 0.3.0.
-# Just saving this in case we want in in the future.
-#        wget https://vault.centos.org/8.4.2105/BaseOS/Source/SPackages/libssh-0.9.4-2.el8.src.rpm
-#        rpm2cpio libssh-0.9.4-2.el8.src.rpm | cpio -imdV
-#        tar xf libssh-0.9.4.tar.xz
-#        mkdir build
-#        cd build
-#        cmake ../libssh-0.9.4 -DOPENSSL_ROOT_DIR=/opt/vagrant/embedded/
-#        make
-#        cp lib/libssh* /opt/vagrant/embedded/lib64
+        wget https://vault.centos.org/8.4.2105/BaseOS/Source/SPackages/libssh-0.9.4-2.el8.src.rpm
+        rpm2cpio libssh-0.9.4-2.el8.src.rpm | cpio -imdV
+        tar xf libssh-0.9.4.tar.xz
+        mkdir build
+        cd build
+        cmake ../libssh-0.9.4 -DOPENSSL_ROOT_DIR=/opt/vagrant/embedded/
+        make
+        cp lib/libssh* /opt/vagrant/embedded/lib64
 
     # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/943#issuecomment-479360033
     - name: Install the vagrant-libvirt plugin (EL)
-      shell: vagrant plugin install vagrant-libvirt --plugin-version 0.3.0
+      shell: vagrant plugin install vagrant-libvirt --plugin-version 0.8.1
       become_user: "{{ jenkins_user }}"
       environment:
         CONFIGURE_ARGS: 'with-ldflags=-L/opt/vagrant/embedded/lib with-libvirt-include=/usr/include/libvirt with-libvirt-lib=/usr/lib'

--- a/ansible/examples/slave.yml
+++ b/ansible/examples/slave.yml
@@ -658,6 +658,14 @@
             LDFLAGS='-L/opt/vagrant/embedded/' ./configure
             make
             sudo cp lib/libk5crypto.* /opt/vagrant/embedded/lib/
+            wget https://vault.centos.org/8.4.2105/BaseOS/Source/SPackages/libssh-0.9.4-2.el8.src.rpm
+            rpm2cpio libssh-0.9.4-2.el8.src.rpm | cpio -imdV
+            tar xf libssh-0.9.4.tar.xz
+            mkdir build
+            cd build
+            cmake ../libssh-0.9.4 -DOPENSSL_ROOT_DIR=/opt/vagrant/embedded/
+            make
+            cp lib/libssh* /opt/vagrant/embedded/lib64
           when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
 
         # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1127#issuecomment-713651332


### PR DESCRIPTION
The time finally came to update 2.jenkins.ceph.com's builders to CentOS8. Along with that change came the library issues mentioned here: https://github.com/vagrant-libvirt/vagrant-libvirt#additional-notes-for-fedora-and-similar-linux-distributions

Signed-off-by: David Galloway <dgallowa@redhat.com>