### PR TITLE
[wnbd-build] Remove `FORCE` parameter

### DIFF
--- a/wnbd-build/build/build
+++ b/wnbd-build/build/build
@@ -60,8 +60,7 @@ zip -r $WORKSPACE/wnbd.zip wnbd
 #
 if [ "$THROWAWAY" = false ]; then
     # push binaries to chacra
-    chacra_binary="$VENV/chacractl binary"
-    [ "$FORCE" = true ] && chacra_binary="$chacra_binary --force"
+    chacra_binary="$VENV/chacractl binary --force"
 
     ls $WORKSPACE/wnbd.zip | $chacra_binary create ${chacra_binary_endpoint}
 

--- a/wnbd-build/build/setup
+++ b/wnbd-build/build/setup
@@ -25,10 +25,5 @@ chacra_binary_endpoint="${chacra_endpoint}/${ARCH}/flavors/${FLAVOR}"
 chacra_repo_endpoint="${chacra_endpoint}/flavors/${FLAVOR}"
 chacra_check_url="${chacra_binary_endpoint}/wnbd.zip"
 
-if [ "$THROWAWAY" = false ] ; then
-    # this exists in scripts/build_utils.sh
-    check_binary_existence $VENV $chacra_check_url
-fi
-
 # create build status in shaman
 update_build_status "started" "wnbd" $DISTRO $DISTRO_VERSION $ARCH

--- a/wnbd-build/config/definitions/wnbd-build.yml
+++ b/wnbd-build/config/definitions/wnbd-build.yml
@@ -25,13 +25,6 @@
             Default: False. When True it will not POST binaries to chacra. Artifacts will not be around for long. Useful to test builds.
           default: false
 
-      - bool:
-          name: FORCE
-          description: |
-            If this is unchecked, then nothing is built or pushed if they already exist in chacra. This is the default.
-
-            If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra.
-
     triggers:
       - timed: "H 0 * * *"
 


### PR DESCRIPTION
Remove the `FORCE` parameter from the `wnbd-build` Jenkins job, and
use it by default.

The `wnbd` project is not updated that frequently, so the daily
build trigger mostly skips the Chacra upload. This is a problem
because when old Chacra artifacts are deleted, the `wnbd` build will
not be available in Chacra.

We need `wnbd` to always be available in Chacra, since the
Windows Teuthology tests will try to download it from there.