### PR TITLE
build_utils.sh: Remove python3 versions we don't want

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1655,11 +1655,13 @@ function retrycmd_if_failure() {
 
 function set_centos_python3_version() {
     # This function expects $1 to be a string like "python3.9"
-    local CURRENT_PYTHON3_VERSION=$(sudo alternatives --list | grep -e '^python3' | awk '{ print $3 }')
+    local CURRENT_PYTHON3_VERSION=$(sudo alternatives --display python3 | grep -e 'Current.*best.* version is' | awk '{ print $5 }' | sed 's/\.$//')
     local EXPECTED_PYTHON3_VERSION=$1
     if ! [[ "$CURRENT_PYTHON3_VERSION" =~ .*"$EXPECTED_PYTHON3_VERSION" ]]; then
-        sudo dnf install -y $EXPECTED_PYTHON3_VERSION
-        sudo alternatives --set python3 /usr/bin/$EXPECTED_PYTHON3_VERSION
+        PYTHON3_TO_REMOVE=$(rpm -qf $CURRENT_PYTHON3_VERSION | cut -d '-' -f1)
+        sudo dnf remove -y ${PYTHON3_TO_REMOVE}\*
+        sudo dnf install -y $EXPECTED_PYTHON3_VERSION || sudo dnf reinstall -y $EXPECTED_PYTHON3_VERSION
+        sudo alternatives --display python3
     else
         echo "python3 symlink already points to $CURRENT_PYTHON3_VERSION"
     fi


### PR DESCRIPTION
@guits and I think there's either a bug in `alternatives` or we just can't figure out how it's supposed to work.  Even with setting `alternatives --set python3 /usr/bin/python3.9`, python3.6 was still the "best" version according to `alternatives --display`.

So we'll just remove the other version entirely.

```
+ set_centos_python3_version python3.9
++ sudo alternatives --display python3
++ grep -e 'Current.*best.* version is'
++ awk '{ print $5 }'
++ sed 's/\.$//'
+ local CURRENT_PYTHON3_VERSION=/usr/bin/python3.6
+ local EXPECTED_PYTHON3_VERSION=python3.9
+ [[ /usr/bin/python3.6 =~ .*python3\.9 ]]
++ rpm -qf /usr/bin/python3.6
++ cut -d - -f1
+ PYTHON3_TO_REMOVE=python36
+ sudo dnf remove -y 'python36*'

Dependencies resolved.
================================================================================================
 Package                        Arch    Version                                Repository   Size
================================================================================================
Removing:
 python36                       x86_64  3.6.8-38.module_el8.5.0+895+a459eca8   @appstream   13 k
 python36-devel                 x86_64  3.6.8-38.module_el8.5.0+895+a459eca8   @appstream   13 k
Removing dependent packages:
 mock                           noarch  3.0-1.el8                              @epel       633 k
 python3-virtualenv             noarch  15.1.0-21.module_el8.5.0+895+a459eca8  @appstream  312 k
Removing unused dependencies:
 distribution-gpg-keys          noarch  1.68-1.el8                             @epel       479 k
 mock-core-configs              noarch  37.3-1.el8                             @epel       254 k
 mock-filesystem                noarch  3.0-1.el8                              @epel        18 k
 platform-python-devel          x86_64  3.6.8-46.el8                           @appstream  699 k
 python3-babel                  noarch  2.5.1-7.el8                            @appstream   20 M
 python3-distro                 noarch  1.4.0-2.module_el8.5.0+761+faacb0fb    @appstream  150 k
 python3-jinja2                 noarch  2.10.1-3.el8                           @appstream  2.5 M
 python3-markupsafe             x86_64  0.23-19.el8                            @appstream   76 k
 python3-pip                    noarch  9.0.3-22.el8                           @appstream  2.8 k
 python3-pyroute2               noarch  0.5.3-3.el8                            @epel       1.8 M
 python3-pytz                   noarch  2017.2-9.el8                           @appstream  175 k
 python3-rpm-generators         noarch  5-7.el8                                @appstream   55 k
 python3-templated-dictionary   noarch  1.1-1.el8                              @epel        26 k
 python3-wheel-wheel            noarch  1:0.31.1-3.module_el8.5.0+895+a459eca8 @appstream   33 k
 python39-wheel-wheel           noarch  1:0.35.1-4.module_el8.6.0+930+10acc06f @appstream   33 k
 usermode                       x86_64  1.113-2.el8                            @baseos     834 k
 yum-utils                      noarch  4.0.21-11.el8                          @baseos      23 k

Transaction Summary
================================================================================================
Remove  21 Packages

Freed space: 28 M
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Erasing          : mock-3.0-1.el8.noarch                                 1/21 
  Erasing          : python3-virtualenv-15.1.0-21.module_el8.5.0+895+a4    2/21 
  Running scriptlet: python3-virtualenv-15.1.0-21.module_el8.5.0+895+a4    2/21 
  Erasing          : python36-devel-3.6.8-38.module_el8.5.0+895+a459eca    3/21 
  Running scriptlet: python36-devel-3.6.8-38.module_el8.5.0+895+a459eca    3/21 
  Erasing          : mock-core-configs-37.3-1.el8.noarch                   4/21 
  Erasing          : python3-pip-9.0.3-22.el8.noarch                       5/21 
  Erasing          : python36-3.6.8-38.module_el8.5.0+895+a459eca8.x86_    6/21 
  Running scriptlet: python36-3.6.8-38.module_el8.5.0+895+a459eca8.x86_    6/21 
  Erasing          : platform-python-devel-3.6.8-46.el8.x86_64             7/21 
  Erasing          : python3-templated-dictionary-1.1-1.el8.noarch         8/21 
  Erasing          : python3-jinja2-2.10.1-3.el8.noarch                    9/21 
  Erasing          : python3-babel-2.5.1-7.el8.noarch                     10/21 
  Erasing          : python3-pytz-2017.2-9.el8.noarch                     11/21 
  Erasing          : python3-rpm-generators-5-7.el8.noarch                12/21 
  Erasing          : distribution-gpg-keys-1.68-1.el8.noarch              13/21 
  Erasing          : mock-filesystem-3.0-1.el8.noarch                     14/21 
  Erasing          : python39-wheel-wheel-1:0.35.1-4.module_el8.6.0+930   15/21 
  Erasing          : python3-wheel-wheel-1:0.31.1-3.module_el8.5.0+895+   16/21 
  Erasing          : python3-distro-1.4.0-2.module_el8.5.0+761+faacb0fb   17/21 
  Erasing          : python3-pyroute2-0.5.3-3.el8.noarch                  18/21 
  Erasing          : yum-utils-4.0.21-11.el8.noarch                       19/21 
  Erasing          : python3-markupsafe-0.23-19.el8.x86_64                20/21 
  Erasing          : usermode-1.113-2.el8.x86_64                          21/21 
  Running scriptlet: usermode-1.113-2.el8.x86_64                          21/21 
  Verifying        : distribution-gpg-keys-1.68-1.el8.noarch               1/21 
  Verifying        : mock-3.0-1.el8.noarch                                 2/21 
  Verifying        : mock-core-configs-37.3-1.el8.noarch                   3/21 
  Verifying        : mock-filesystem-3.0-1.el8.noarch                      4/21 
  Verifying        : platform-python-devel-3.6.8-46.el8.x86_64             5/21 
  Verifying        : python3-babel-2.5.1-7.el8.noarch                      6/21 
  Verifying        : python3-distro-1.4.0-2.module_el8.5.0+761+faacb0fb    7/21 
  Verifying        : python3-jinja2-2.10.1-3.el8.noarch                    8/21 
  Verifying        : python3-markupsafe-0.23-19.el8.x86_64                 9/21 
  Verifying        : python3-pip-9.0.3-22.el8.noarch                      10/21 
  Verifying        : python3-pyroute2-0.5.3-3.el8.noarch                  11/21 
  Verifying        : python3-pytz-2017.2-9.el8.noarch                     12/21 
  Verifying        : python3-rpm-generators-5-7.el8.noarch                13/21 
  Verifying        : python3-templated-dictionary-1.1-1.el8.noarch        14/21 
  Verifying        : python3-virtualenv-15.1.0-21.module_el8.5.0+895+a4   15/21 
  Verifying        : python3-wheel-wheel-1:0.31.1-3.module_el8.5.0+895+   16/21 
  Verifying        : python36-3.6.8-38.module_el8.5.0+895+a459eca8.x86_   17/21 
  Verifying        : python36-devel-3.6.8-38.module_el8.5.0+895+a459eca   18/21 
  Verifying        : python39-wheel-wheel-1:0.35.1-4.module_el8.6.0+930   19/21 
  Verifying        : usermode-1.113-2.el8.x86_64                          20/21 
  Verifying        : yum-utils-4.0.21-11.el8.noarch                       21/21 

Removed:
  distribution-gpg-keys-1.68-1.el8.noarch                                       
  mock-3.0-1.el8.noarch                                                         
  mock-core-configs-37.3-1.el8.noarch                                           
  mock-filesystem-3.0-1.el8.noarch                                              
  platform-python-devel-3.6.8-46.el8.x86_64                                     
  python3-babel-2.5.1-7.el8.noarch                                              
  python3-distro-1.4.0-2.module_el8.5.0+761+faacb0fb.noarch                     
  python3-jinja2-2.10.1-3.el8.noarch                                            
  python3-markupsafe-0.23-19.el8.x86_64                                         
  python3-pip-9.0.3-22.el8.noarch                                               
  python3-pyroute2-0.5.3-3.el8.noarch                                           
  python3-pytz-2017.2-9.el8.noarch                                              
  python3-rpm-generators-5-7.el8.noarch                                         
  python3-templated-dictionary-1.1-1.el8.noarch                                 
  python3-virtualenv-15.1.0-21.module_el8.5.0+895+a459eca8.noarch               
  python3-wheel-wheel-1:0.31.1-3.module_el8.5.0+895+a459eca8.noarch             
  python36-3.6.8-38.module_el8.5.0+895+a459eca8.x86_64                          
  python36-devel-3.6.8-38.module_el8.5.0+895+a459eca8.x86_64                    
  python39-wheel-wheel-1:0.35.1-4.module_el8.6.0+930+10acc06f.noarch            
  usermode-1.113-2.el8.x86_64                                                   
  yum-utils-4.0.21-11.el8.noarch                                                

Complete!
+ sudo dnf install -y python3.9

Last metadata expiration check: 0:56:04 ago on Mon 02 May 2022 05:40:47 PM UTC.

Package python39-3.9.7-1.module_el8.6.0+930+10acc06f.x86_64 is already installed.
Dependencies resolved.
Nothing to do.
Complete!
+ sudo alternatives --display python3
python3 - status is manual.
 link currently points to /usr/bin/python3.9
/usr/bin/python3.9 - priority 3900
 slave easy_install-3: /usr/bin/easy_install-3.9
 slave pip-3: /usr/bin/pip-3.9
 slave pip3: /usr/bin/pip3.9
 slave pydoc-3: /usr/bin/pydoc3.9
 slave pydoc3: /usr/bin/pydoc3.9
 slave pyvenv-3: (null)
 slave python3-man: /usr/share/man/man1/python3.9.1.gz
Current `best' version is /usr/bin/python3.9.
```

Signed-off-by: David Galloway <dgallowa@redhat.com>