### PR TITLE
cephadm-ansible-prs: update scenario name

### DIFF
--- a/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
+++ b/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
@@ -2,7 +2,7 @@
     name: cephadm-ansible-prs-smithi
     worker_labels: 'vagrant && libvirt && (braggi || adami)'
     scenario:
-      - deploy_and_purge
+      - tox
     jobs:
       - 'cephadm-ansible-prs-auto'
 


### PR DESCRIPTION
The tox config in cephadm-ansible has now more than 1 test.
Let's rename from 'deploy_and_purge' to 'tox' so it's more generic

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>