### PR TITLE
ceph-pull-requests/build/build: enable WITH_PMEM

### DIFF
--- a/ceph-pull-requests/build/build
+++ b/ceph-pull-requests/build/build
@@ -9,6 +9,7 @@ fi
 export NPROC=$(nproc)
 export WITH_SEASTAR=true
 export WITH_RBD_RWL=true
+export WITH_PMEM=true
 if which apt-get > /dev/null ; then
     export WITH_ZBD=true
 fi


### PR DESCRIPTION
WITH_PMEM is added in
https://github.com/ceph/ceph/commit/17d2bc3707bb0078e2fa1b4eef31b39804e45135.

Signed-off-by: Yin Congmin <congmin.yin@intel.com>