### PR TITLE
cephadm-ansible-prs: disable el9-functional

### DIFF
--- a/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
+++ b/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
@@ -13,7 +13,7 @@
     worker_labels: 'vagrant && libvirt && (braggi || adami)'
     distribution:
       - el8
-      - el9
+      # - el9
     scenario:
       - functional
     jobs:


### PR DESCRIPTION
el9 RPMs aren't available yet.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>