### PR TITLE
Use Jenkins' 'built-in' magic phrase

### DIFF
--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-dev-build
-    node: controller
+    node: built-in
     project-type: matrix
     defaults: global
     display-name: 'ceph-dev-build'

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -1,6 +1,6 @@
 - job:
     name: 'ceph-dev-cron'
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     concurrent: true

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-dev-new-build
-    node: controller
+    node: built-in
     project-type: matrix
     defaults: global
     display-name: 'ceph-dev-new-build'

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-dev-new-trigger
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-dev-new
     description: 'This job builds branches from https://github.com/ceph/ceph-ci for testing purposes.'
-    node: controller
+    node: built-in
     project-type: multijob
     defaults: global
     concurrent: true

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -1,7 +1,7 @@
 - job:
     disabled: true
     name: ceph-dev-trigger
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-dev
     description: 'This job builds branches from https://github.com/ceph/ceph for testing purposes.'
-    node: controller
+    node: built-in
     project-type: multijob
     defaults: global
     concurrent: true

--- a/ceph-iscsi-cli-trigger/config/definitions/ceph-iscsi-cli-trigger.yml
+++ b/ceph-iscsi-cli-trigger/config/definitions/ceph-iscsi-cli-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-iscsi-cli-trigger
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/ceph-iscsi-config-trigger/config/definitions/ceph-iscsi-config-trigger.yml
+++ b/ceph-iscsi-config-trigger/config/definitions/ceph-iscsi-config-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-iscsi-config-trigger
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/ceph-iscsi-tools-trigger/config/definitions/ceph-iscsi-tools-trigger.yml
+++ b/ceph-iscsi-tools-trigger/config/definitions/ceph-iscsi-tools-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-iscsi-tools-trigger
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/ceph-iscsi-trigger/config/definitions/ceph-iscsi-trigger.yml
+++ b/ceph-iscsi-trigger/config/definitions/ceph-iscsi-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-iscsi-trigger
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/ceph-pr-arm-trigger/config/definitions/ceph-pr-arm-trigger.yml
+++ b/ceph-pr-arm-trigger/config/definitions/ceph-pr-arm-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-pr-arm-trigger
-    node: controller
+    node: built-in
     # disabled for now because this is not passing the right BRANCH to
     # `ceph-dev` which causes failures there
     disabled: true

--- a/kernel-trigger/config/definitions/kernel-trigger.yml
+++ b/kernel-trigger/config/definitions/kernel-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: kernel-trigger
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/mita-deploy/config/definitions/mita-deploy.yml
+++ b/mita-deploy/config/definitions/mita-deploy.yml
@@ -12,7 +12,7 @@
 
 - job:
     name: mita-deploy
-    node: controller
+    node: built-in
     description: "This job clones mita and deploys it to its production server based on the BRANCH value"
     display-name: 'mita-deploy'
     block-downstream: false

--- a/rtslib-fb-trigger/config/definitions/rtslib-fb-trigger.yml
+++ b/rtslib-fb-trigger/config/definitions/rtslib-fb-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: rtslib-fb-trigger
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/samba-trigger/config/definitions/samba-trigger.yml
+++ b/samba-trigger/config/definitions/samba-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: samba-trigger
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     quiet-period: 5

--- a/tcmu-runner-trigger/config/definitions/tcmu-runner-trigger.yml
+++ b/tcmu-runner-trigger/config/definitions/tcmu-runner-trigger.yml
@@ -1,6 +1,6 @@
 - job:
     name: tcmu-runner-trigger
-    node: controller
+    node: built-in
     project-type: freestyle
     defaults: global
     quiet-period: 5


### PR DESCRIPTION
https://www.jenkins.io/changelog-stable/#v2.319.1

I don't know if it's a bug or what but giving the controller a "controller" label and instructing the jobs to run on that label only, they would still get stuck on `(pending—Waiting for next available executor on ‘builtin’)`.

Signed-off-by: David Galloway <dgallowa@redhat.com>