### PR TITLE
ceph-container-{lint,flake8}: Start podman too

### DIFF
--- a/ceph-container-flake8/build/build
+++ b/ceph-container-flake8/build/build
@@ -33,7 +33,7 @@ function main() {
     then
         sudo yum -y install epel-release
         sudo yum -y install docker jq
-        sudo systemctl start docker
+        sudo systemctl start docker || sudo systemctl start podman
         pull_request_id=${ghprbPullId:-$2}
         workspace=${WORKSPACE:-$1}
     else

--- a/ceph-container-lint/build/build
+++ b/ceph-container-lint/build/build
@@ -36,7 +36,7 @@ function main() {
     then
         sudo yum -y install epel-release
         sudo yum -y install docker jq
-        sudo systemctl start docker
+        sudo systemctl start docker || sudo systemctl start podman
         pull_request_id=${ghprbPullId:-$2}
         workspace=${WORKSPACE:-$1}
     else


### PR DESCRIPTION
Installing 'docker' on CentOS8 installs podman (and podman-docker). One cannot restart the service by calling 'docker' however.

Signed-off-by: David Galloway <dgallowa@redhat.com>