### PR TITLE
build_utils.sh: Do not remove unwanted python3 versions

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1656,10 +1656,6 @@ function retrycmd_if_failure() {
 function set_centos_python3_version() {
     # This function expects $1 to be a string like "python3.9"
     local EXPECTED_PYTHON3_VERSION=$1
-    local EXPECTED_PYTHON3_VERSION_MASHED=$(echo $EXPECTED_PYTHON3_VERSION | tr -d '.')
-    for package in $(rpm -qa | grep -E '^python3[1-9]{1,3}' | grep -v $EXPECTED_PYTHON3_VERSION_MASHED); do
-        sudo dnf remove -y $package
-    done
     sudo dnf reinstall -y $EXPECTED_PYTHON3_VERSION || sudo dnf install -y $EXPECTED_PYTHON3_VERSION
-    sudo alternatives --auto python3
+    sudo ln -fs /usr/bin/$EXPECTED_PYTHON3_VERSION /usr/bin/python3
 }


### PR DESCRIPTION
For some reason, python36 is a dependency of python3-virtualenv.  python39 is not.

So removing python36 was removing python3-virtualenv.

Signed-off-by: David Galloway <dgallowa@redhat.com>