### PR TITLE
build_utils: Fix get_distro to support CentOS Stream

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -451,8 +451,13 @@ get_distro_and_target() {
             DISTRO="ubuntu"
             ;;
         centos*)
+            source /etc/os-release
+            if [ $VERSION -ge 8 ]; then
+                MOCK_TARGET="centos-stream+epel"
+            else
+                MOCK_TARGET="epel"
+            fi
             DISTRO="centos"
-            MOCK_TARGET="epel"
             ;;
         rhel*)
             DISTRO="rhel"


### PR DESCRIPTION
There is no /etc/mock/epel-8-x86_64.cfg with the deprecation of CentOS 8.

```
[root@braggi07 mock]# ls -l /etc/mock/ | grep epel
-rw-r--r--. 1 root mock  201 Mar  3 07:18 alma+epel-8-aarch64.cfg
-rw-r--r--. 1 root mock  201 Mar  3 07:18 alma+epel-8-ppc64le.cfg
-rw-r--r--. 1 root mock  198 Mar  3 07:18 alma+epel-8-x86_64.cfg
-rw-r--r--. 1 root mock  200 Mar  3 07:18 centos+epel-7-ppc64le.cfg
-rw-r--r--. 1 root mock  197 Mar  3 07:18 centos+epel-7-x86_64.cfg
-rw-r--r--. 1 root mock  256 Mar  3 07:18 centos-stream+epel-8-aarch64.cfg
-rw-r--r--. 1 root mock  256 Mar  3 07:18 centos-stream+epel-8-ppc64le.cfg
-rw-r--r--. 1 root mock  253 Mar  3 07:18 centos-stream+epel-8-x86_64.cfg
-rw-r--r--. 1 root mock  256 Mar  3 07:18 centos-stream+epel-9-aarch64.cfg
-rw-r--r--. 1 root mock  256 Mar  3 07:18 centos-stream+epel-9-ppc64le.cfg
-rw-r--r--. 1 root mock  250 Mar  3 07:18 centos-stream+epel-9-s390x.cfg
-rw-r--r--. 1 root mock  253 Mar  3 07:18 centos-stream+epel-9-x86_64.cfg
-rw-r--r--. 1 root mock  304 Mar  3 07:18 centos-stream+epel-next-8-aarch64.cfg
-rw-r--r--. 1 root mock  304 Mar  3 07:18 centos-stream+epel-next-8-ppc64le.cfg
-rw-r--r--. 1 root mock  301 Mar  3 07:18 centos-stream+epel-next-8-x86_64.cfg
-rw-r--r--. 1 root mock  303 Mar  3 07:18 centos-stream+epel-next-9-aarch64.cfg
-rw-r--r--. 1 root mock  303 Mar  3 07:18 centos-stream+epel-next-9-ppc64le.cfg
-rw-r--r--. 1 root mock  297 Mar  3 07:18 centos-stream+epel-next-9-s390x.cfg
-rw-r--r--. 1 root mock  300 Mar  3 07:18 centos-stream+epel-next-9-x86_64.cfg
lrwxrwxrwx. 1 root root   17 Mar  6  2020 default.cfg -> epel-8-x86_64.cfg
lrwxrwxrwx. 1 root root   31 Mar 29 16:53 default.cfg.rpmnew -> centos-stream+epel-8-x86_64.cfg
lrwxrwxrwx. 1 root mock   25 Mar  3 07:18 epel-7-ppc64le.cfg -> centos+epel-7-ppc64le.cfg
lrwxrwxrwx. 1 root mock   24 Mar  3 07:18 epel-7-x86_64.cfg -> centos+epel-7-x86_64.cfg
-rw-r--r--. 1 root mock  210 Mar  3 07:18 oraclelinux+epel-7-aarch64.cfg
-rw-r--r--. 1 root mock  207 Mar  3 07:18 oraclelinux+epel-7-x86_64.cfg
-rw-r--r--. 1 root mock  210 Mar  3 07:18 oraclelinux+epel-8-aarch64.cfg
-rw-r--r--. 1 root mock  207 Mar  3 07:18 oraclelinux+epel-8-x86_64.cfg
-rw-r--r--. 1 root mock  117 Mar  3 07:18 rhel+epel-8-aarch64.cfg
-rw-r--r--. 1 root mock  117 Mar  3 07:18 rhel+epel-8-ppc64le.cfg
-rw-r--r--. 1 root mock  115 Mar  3 07:18 rhel+epel-8-s390x.cfg
-rw-r--r--. 1 root mock  116 Mar  3 07:18 rhel+epel-8-x86_64.cfg
-rw-r--r--. 1 root mock  198 Mar  3 07:18 rocky+epel-8-aarch64.cfg
-rw-r--r--. 1 root mock  195 Mar  3 07:18 rocky+epel-8-x86_64.cfg
```

Signed-off-by: David Galloway <dgallowa@redhat.com>