### PR TITLE
dashboard-e2e: change artifact dir to mstart ones

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -99,6 +99,6 @@
           recipients: ceph-qa@ceph.io
 
       - archive:
-          artifacts: 'build/out/mgr.*.log'
+          artifacts: 'build/out/*.log, build/run/1/out/*.log, build/run/2/out/*.log'
           allow-empty: true
           latest-only: false

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -98,7 +98,7 @@
 
     publishers:
       - archive:
-          artifacts: 'build/out/mgr.*.log'
+          artifacts: 'build/out/*.log, build/run/1/out/*.log, build/run/2/out/*.log'
           allow-empty: true
           latest-only: false
 

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -85,7 +85,7 @@
                 - shell: "sudo dpkg --configure -a"
 
       - archive:
-          artifacts: 'build/out/mgr.*.log'
+          artifacts: 'build/out/*.log'
           allow-empty: true
           latest-only: false
 


### PR DESCRIPTION
after #46848, the log dir will be changed because the test is going to
use the mstart instead of vstart

![Screenshot from 2022-07-26 23-01-20](https://user-images.githubusercontent.com/71764184/181072751-480d52ba-863c-4c75-92cf-376446c7419d.png)


Signed-off-by: Nizamudeen A <nia@redhat.com>