### PR TITLE
build_utils.sh: update start_tox()

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1155,6 +1155,9 @@ start_tox() {
     ENV_NAME="$(build_job_name "$DISTRIBUTION" "$DEPLOYMENT" "$SCENARIO")"
 
     case $SCENARIO in
+        rbdmirror)
+            TOX_INI_FILE=tox-rbdmirror.ini
+            ;;
         update)
             TOX_INI_FILE=tox-update.ini
             ;;


### PR DESCRIPTION
This makes tox pick the right tox config file when scenario is
'rbdmirror'

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>