### PR TITLE
ceph-dev: Keep 14 days' worth of builds

### DIFF
--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -11,8 +11,8 @@
       - github:
           url: https://github.com/ceph/ceph
       - build-discarder:
-          days-to-keep: 30
-          artifact-days-to-keep: 30
+          days-to-keep: 14
+          artifact-days-to-keep: 14
 
     scm:
       - git:

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -8,10 +8,8 @@
     concurrent: true
     properties:
       - build-discarder:
-          days-to-keep: -1
-          num-to-keep: 25
-          artifact-days-to-keep: -1
-          artifact-num-to-keep: -1
+          days-to-keep: 14
+          artifact-days-to-keep: 14
       - github:
           url: https://github.com/ceph/ceph
       - copyartifact:

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -10,10 +10,8 @@
     block-upstream: false
     properties:
       - build-discarder:
-          days-to-keep: -1
-          num-to-keep: 25
-          artifact-days-to-keep: 25
-          artifact-num-to-keep: 25
+          days-to-keep: 14
+          artifact-days-to-keep: 14
       - github:
           url: https://github.com/ceph/ceph
 


### PR DESCRIPTION
multijob projects only keep the lowest number of builds specified in build-discarder config.  So we only had 25 builds.  That only correlates to 3-5 days which isn't log enough to debug failed builds from a week ago, for example.

Signed-off-by: David Galloway <dgallowa@redhat.com>