### PR TITLE
ceph: Clarify branch name to enter

### DIFF
--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -20,7 +20,7 @@
     parameters:
       - string:
           name: BRANCH
-          description: "The git branch (or tag) to build"
+          description: "The git branch (or tag) to build (e.g., pacific) DO NOT INCLUDE '-release'"
 
     scm:
       - git:

--- a/ceph/config/definitions/ceph.yml
+++ b/ceph/config/definitions/ceph.yml
@@ -19,7 +19,7 @@
     parameters:
       - string:
           name: BRANCH
-          description: "The git branch (or tag) to build (e.g., pacific)"
+          description: "The git branch (or tag) to build (e.g., pacific) DO NOT INCLUDE '-release'"
           default: main
 
       - bool:


### PR DESCRIPTION
Despite adding some logic to strip '-release' if it was accidentally entered, the ceph-setup job will build a tarball successfully.  However stripping '-release' doesn't get carried over to the `ceph-build` job so https://github.com/ceph/ceph-build/blob/main/ceph-build/config/definitions/ceph-build.yml#L56-L70 immediately exits 0.

Signed-off-by: David Galloway <dgallowa@redhat.com>