### PR TITLE
ceph-ansible-prs: run rbdmirror against stable branches

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -33,7 +33,6 @@ popd
 rm -rf $HOME/ansible/facts/*
 
 # Skip these scenarios, they don't exist.
-[[ "$ghprbTargetBranch" =~ stable && "$SCENARIO" == rbdmirror ]] ||
 [[ "$ghprbTargetBranch" != stable-4.0 && "$SCENARIO" == podman ]] ||
 [[ "$ghprbTargetBranch" =~ stable-4.0|stable-3 && "$SCENARIO" =~ cephadm|cephadm_adopt ]] ||
 [[ "$ghprbTargetBranch" != stable-3.2 && "$SCENARIO" == shrink_osd_legacy ]] ||


### PR DESCRIPTION
Corresponding PRs:

- ceph/ceph-ansible/pull/7269 (stable-7.0)
- ceph/ceph-ansible/pull/7268 (stable-6.0)

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>