### PR TITLE
ceph-docs-rtd: Create job to keep releases docs up-to-date

### DIFF
--- a/ceph-doc-releases-rtd/config/definitions/ceph-doc-releases-rtd.yml
+++ b/ceph-doc-releases-rtd/config/definitions/ceph-doc-releases-rtd.yml
@@ -1,0 +1,47 @@
+- job:
+    name: ceph-doc-releases-rtd
+    description: Rebuilds release branch docs so that https://docs.ceph.com/en/$release/releases is always up to date with the main branch. See https://github.com/ceph/ceph/pull/46917.
+    node: small
+    project-type: freestyle
+    defaults: global
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 10
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+      - github:
+          url: https://github.com/ceph/ceph
+    discard-old-builds: true
+
+    triggers:
+      - github
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph
+          browser: auto
+          branches:
+            - 'origin/main'
+          shallow-clone: true
+          depth: 1
+          skip-tag: true
+          timeout: 20
+          wipe-workspace: true
+          included-regions:
+            - 'doc/releases'
+    builders:
+      - shell: |
+          RELEASES="quincy pacific octopus"
+          for release in $RELEASES; do
+            curl -X POST -H "Authorization: Token $READTHEDOCS_TOKEN" https://readthedocs.org/api/v3/projects/ceph/versions/$release/builds/
+          done
+
+    wrappers:
+      - credentials-binding:
+          - text:
+              credential-id: readthedocs-token
+              variable: READTHEDOCS_TOKEN


### PR DESCRIPTION
See https://github.com/ceph/ceph/pull/46917

This Jenkins job will receive webhooks from the github plugin.  It will then check if the main branch is what was updated and if the `doc/releases` dir was updated.

If true, it will trigger a build for each active Ceph release's docs.

https://github.com/ceph/ceph/pull/47442
https://github.com/ceph/ceph/pull/47443
https://github.com/ceph/ceph/pull/47444

Signed-off-by: David Galloway <dgallowa@redhat.com>