### PR TITLE
dashboard-cephadm-e2e: bump node version to 14

### DIFF
--- a/scripts/dashboard/install-cephadm-e2e-deps.sh
+++ b/scripts/dashboard/install-cephadm-e2e-deps.sh
@@ -20,7 +20,7 @@ sudo apt update -y
 sudo apt install -y apt-transport-https ca-certificates curl gnupg lsb-release \
     openssh-server software-properties-common
 
-NODEJS_MAJOR_VERSION=12
+NODEJS_MAJOR_VERSION=14
 DISTRO="$(lsb_release -cs)"
 if [[ ! $(command -v node) || $(node --version | grep -oE "v([0-9])+" | cut -c 2-) < ${NODEJS_MAJOR_VERSION} ]]; then
     sudo add-apt-repository -y -r ppa:chris-lea/node.js


### PR DESCRIPTION
as node.js 12 is being deprecated. and the oldest node.js which is
packaged by https://github.com/nodesource is node.js 14. see
https://github.com/nodesource/distributions#debinstall

Signed-off-by: Kefu Chai <tchaikov@gmail.com>