### PR TITLE
ceph-build-pull-requests: use a newer urllib3 when installing jjb

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -5,7 +5,7 @@ set -e
 # the following two methods exist in scripts/build_utils.sh
 # must pin urllib3 to 1.22 because 1.23 is incompatible with requests, which
 # is used by jenkins-job-builder
-pkgs=( "ansible" "jenkins-job-builder>=3.5.0" "urllib3==1.22" "pyopenssl" "ndg-httpsclient" "pyasn1" )
+pkgs=( "ansible" "jenkins-job-builder>=3.5.0" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"


### PR DESCRIPTION
as urllib3 v1.22 is not compatible with python3.10 which is shipped by
ubuntu jammy. see https://pypi.org/project/urllib3/1.22/

so, to run jjb in a python3.10 venv we should use a newer urllib.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>