### PR TITLE
ceph-windows: Bump `cephadm` dependency to quincy

### DIFF
--- a/scripts/ceph-windows/cleanup
+++ b/scripts/ceph-windows/cleanup
@@ -15,7 +15,7 @@ if [[ -x $WORKSPACE/cephadm ]] && [[ -d /var/lib/ceph ]]; then
     done
 fi
 
-# Cleanup remaning files / directories
+# Cleanup remaining files / directories
 sudo $WORKSPACE/cephadm rm-repo
 sudo rm -rf \
     $WORKSPACE/ceph.conf $WORKSPACE/keyring $WORKSPACE/cephadm \

--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -7,7 +7,7 @@ if [[ ! -f $WORKSPACE/ceph.zip ]]; then
     exit 1
 fi
 
-CEPHADM_RELEASE=${CEPHADM_RELEASE:-"pacific"}
+CEPHADM_RELEASE=${CEPHADM_RELEASE:-"quincy"}
 
 #
 # Install requirements (if needed)


### PR DESCRIPTION
Also, fix a typo in the cleanup script.