### PR TITLE
ceph-build-pull-requests: drop stale comment

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -3,8 +3,6 @@
 set -e
 
 # the following two methods exist in scripts/build_utils.sh
-# must pin urllib3 to 1.22 because 1.23 is incompatible with requests, which
-# is used by jenkins-job-builder
 pkgs=( "ansible" "jenkins-job-builder>=3.5.0" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin


### PR DESCRIPTION
now that we've bumped up the urllib3's version in
f2f9bec9da002ac07b27c5caf5131aeab196509c. the comment does not
apply anymore.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>