### PR TITLE
windows: Check for cephadm binary before attempting to use it

### DIFF
--- a/scripts/ceph-windows/cleanup
+++ b/scripts/ceph-windows/cleanup
@@ -8,15 +8,17 @@ delete_libvirt_vms
 clear_libvirt_networks
 
 # Cleanup Ceph clusters spawned via cephadm
-if [[ -x $WORKSPACE/cephadm ]] && [[ -d /var/lib/ceph ]]; then
-    for FSID in $(sudo ls /var/lib/ceph); do
-        echo "Removing Ceph cluster $FSID"
-        sudo $WORKSPACE/cephadm rm-cluster --fsid $FSID --force
-    done
+if [[ -x $WORKSPACE/cephadm ]]; then
+    sudo $WORKSPACE/cephadm rm-repo
+    if [[ -d /var/lib/ceph ]]; then
+        for FSID in $(sudo ls /var/lib/ceph); do
+            echo "Removing Ceph cluster $FSID"
+            sudo $WORKSPACE/cephadm rm-cluster --fsid $FSID --force
+        done
+    fi
 fi
 
-# Cleanup remaning files / directories
-sudo $WORKSPACE/cephadm rm-repo
+# Cleanup remaining files / directories
 sudo rm -rf \
     $WORKSPACE/ceph.conf $WORKSPACE/keyring $WORKSPACE/cephadm \
     $WORKSPACE/ceph.zip $WORKSPACE/known_hosts \


### PR DESCRIPTION
Fixes:
```
+ [[ -x /home/jenkins-build/build/workspace/wnbd-build/cephadm ]]
+ sudo /home/jenkins-build/build/workspace/wnbd-build/cephadm rm-repo
[sudo] password for jenkins-build:
sudo: no password was provided
sudo: a password is required
Build step 'Execute scripts' changed build result to FAILURE
Build step 'Execute scripts' marked build as failure
```

Signed-off-by: David Galloway <dgallowa@redhat.com>