### PR TITLE
ceph-pr-api: Avoid artifact archive plugin hang

### DIFF
--- a/ceph-pr-api/build/build
+++ b/ceph-pr-api/build/build
@@ -3,6 +3,8 @@
 docs_pr_only
 if [ "$DOCS_ONLY" = true ]; then
     echo "Only the doc/ dir changed.  No need to run make check or API tests."
+    mkdir -p $WORKSPACE/build/out
+    echo "File created to avoid Jenkins' Artifact Archiving plugin from hanging" > $WORKSPACE/build/out/mgr.foo.log
     exit 0
 fi
 


### PR DESCRIPTION
More often than not, docs-only PRs hang during this job for 45-50 minutes then crash like this:

```
+ '[' true = true ']'
+ echo 'Only the doc/ dir changed.  No need to run make check or API tests.'
Only the doc/ dir changed.  No need to run make check or API tests.
+ exit 0
[PostBuildScript] - [INFO] Executing post build scripts.
[PostBuildScript] - [INFO] Build does not have any of the results [ABORTED]. Did not execute build step #0.
Archiving artifacts
java.lang.OutOfMemoryError: Java heap space
	at java.base/java.util.Arrays.copyOf(Arrays.java:3689)
	at java.base/java.util.Vector.grow(Vector.java:261)
	at java.base/java.util.Vector.ensureCapacity(Vector.java:241)
	at org.apache.tools.ant.util.VectorSet.doAdd(VectorSet.java:86)
	at org.apache.tools.ant.util.VectorSet.addElement(VectorSet.java:98)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1245)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1267)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1194)
	at org.apache.tools.ant.DirectoryScanner.scandir(DirectoryScanner.java:1156)
	at org.apache.tools.ant.DirectoryScanner.checkIncludePatterns(DirectoryScanner.java:954)
	at org.apache.tools.ant.DirectoryScanner.scan(DirectoryScanner.java:912)
	at org.apache.tools.ant.types.AbstractFileSet.getDirectoryScanner(AbstractFileSet.java:528)
	at hudson.FilePath$ValidateAntFileMask.invoke(FilePath.java:3159)
Caused: java.io.IOException: Remote call on JNLP4-connect connection from 8.43.84.3/8.43.84.3:42699 failed
	at hudson.remoting.Channel.call(Channel.java:1004)
	at hudson.FilePath.act(FilePath.java:1194)
	at hudson.FilePath.act(FilePath.java:1183)
	at hudson.FilePath.validateAntFileMask(FilePath.java:3095)
	at hudson.tasks.ArtifactArchiver.perform(ArtifactArchiver.java:271)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:79)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:816)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:765)
	at hudson.model.Build$BuildExecution.post2(Build.java:179)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:709)
	at hudson.model.Run.execute(Run.java:1922)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:44)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:442)
No artifacts found that match the file pattern "build/out/mgr.*.log". Configuration error?
```

Signed-off-by: David Galloway <dgallowa@redhat.com>