### PR TITLE
ceph*build: Do not build containers on CentOS9 for now

### DIFF
--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -84,7 +84,7 @@ fi
 
 # XXX perhaps use job parameters instead of literals; then
 # later stages can also use them to compare etc.
-if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" ]] ; then
+if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" && $RELEASE == "8" ]] ; then
     loop=0
     ready=false
     while ((loop < 15)); do

--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -84,7 +84,7 @@ fi
 # XXX perhaps use job parameters instead of literals; then
 # later stages can also use them to compare etc.
 # build container image that supports building crimson-osd
-if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" ]] ; then
+if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && $RELEASE == "8" ]] ; then
     loop=0
     ready=false
     while ((loop < 15)); do


### PR DESCRIPTION
ceph-container isn't ready yet.  There is work being done in https://github.com/ceph/ceph-container/pull/2038 but our build scripts still need a lot of adjustments.

Signed-off-by: David Galloway <dgallowa@redhat.com>