### PR TITLE
ceph-dev-cron: Build quincy on el9 daily

### DIFF
--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -83,7 +83,7 @@
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build quincy on:
-      # default: focal centos8 leap15
+      # default: focal centos8 centos9 leap15
       # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
@@ -100,7 +100,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal centos8 leap15
+                    DISTROS=focal centos8 centos9 leap15
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>