### PR TITLE
ceph-dev-new: Build centos9 for main and quincy based ceph-ci branches

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -127,7 +127,7 @@
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build quincy on:
-      # default: focal centos8 leap15
+      # default: focal centos8 centos9 leap15
       # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
@@ -144,7 +144,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal centos8 leap15
+                    DISTROS=focal centos8 centos9 leap15
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
@@ -169,7 +169,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy focal centos8 windows
+                    DISTROS=jammy focal centos8 centos9 windows
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>