### PR TITLE
build_utils/build_debs: use variable when appropriate

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -949,7 +949,7 @@ build_debs() {
         $releasedir/$cephver/ceph_$bpvers.dsc
 
     if $PBUILDER_IN_TMPFS; then
-        sudo umount /var/cache/pbuilder/build
+        sudo umount $pbuild_build_dir
     fi
 
     # do lintian checks


### PR DESCRIPTION
less "magic numbers" this way.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>