### PR TITLE
Stop using lsb for rpm-based distros

### DIFF
--- a/ansible/files/rpmmacros.j2
+++ b/ansible/files/rpmmacros.j2
@@ -1,1 +1,1 @@
-%dist .el{{ ansible_lsb.major_release }}
+%dist .el{{ ansible_distribution_major_version }}

--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -18,8 +18,6 @@ if test $(id -u) != 0 ; then
 fi
 export LC_ALL=C # the following is vulnerable to i18n
 
-$SUDO yum install -y redhat-lsb-core
-
 mv ceph-build/ansible/ceph/dist .
 rm -rf ceph-build
 

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -18,7 +18,7 @@ if test $(id -u) != 0 ; then
 fi
 export LC_ALL=C # the following is vulnerable to i18n
 
-$SUDO yum install -y redhat-lsb-core yum-utils
+$SUDO yum install -y yum-utils
 
 get_rpm_dist
 

--- a/ceph-iscsi-cli/build/build_rpm
+++ b/ceph-iscsi-cli/build/build_rpm
@@ -14,7 +14,7 @@ sudo yum install -y mock
 
 ## Get some basic information about the system and the repository
 # Get version
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
+get_rpm_dist
 VERSION="$(git describe --abbrev=0 --tags HEAD)"
 REVISION="$(git describe --tags HEAD | cut -d - -f 2- | sed 's/-/./')"
 if [ "$VERSION" = "$REVISION" ]; then

--- a/ceph-iscsi-config/build/build_rpm
+++ b/ceph-iscsi-config/build/build_rpm
@@ -14,7 +14,7 @@ sudo yum install -y mock
 
 ## Get some basic information about the system and the repository
 # Get version
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
+get_rpm_dist
 VERSION="$(git describe --abbrev=0 --tags HEAD)"
 REVISION="$(git describe --tags HEAD | cut -d - -f 2- | sed 's/-/./')"
 if [ "$VERSION" = "$REVISION" ]; then

--- a/ceph-iscsi-stable/build/build_rpm
+++ b/ceph-iscsi-stable/build/build_rpm
@@ -13,7 +13,7 @@ for project in $(ls -h | grep -v dist); do
   cd $WORKSPACE/$PROJECT
 
   # Get some basic information about the system and the repository
-  RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
+  get_rpm_dist
   VERSION="$(git describe --abbrev=0 --tags HEAD)" # for ceph-iscsi, this will return the major version number (e.g., 2)
   MAJOR_VERSION=$(echo $VERSION | cut -d '.' -f1)
   if [ $MAJOR_VERSION -gt $REPO_MAJOR_VERSION ] ; then

--- a/ceph-iscsi-tools/build/build_rpm
+++ b/ceph-iscsi-tools/build/build_rpm
@@ -14,7 +14,7 @@ sudo yum install -y mock
 
 ## Get some basic information about the system and the repository
 # Get version
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
+get_rpm_dist
 VERSION="$(git describe --abbrev=0 --tags HEAD)"
 REVISION="$(git describe --tags HEAD | cut -d - -f 2- | sed 's/-/./')"
 if [ "$VERSION" = "$REVISION" ]; then

--- a/ceph-iscsi/build/build_rpm
+++ b/ceph-iscsi/build/build_rpm
@@ -14,7 +14,7 @@ sudo yum install -y mock
 
 ## Get some basic information about the system and the repository
 # Get version
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
+get_rpm_dist
 VERSION="$(git describe --abbrev=0 --tags HEAD)"
 REVISION="$(git describe --tags HEAD | cut -d - -f 2- | sed 's/-/./')"
 if [ "$VERSION" = "$REVISION" ]; then

--- a/cephmetrics-release/build/build_rpm
+++ b/cephmetrics-release/build/build_rpm
@@ -9,9 +9,7 @@ fi
 
 
 ## Install any setup-time deps (to make dist package)
-
-# We need this to get the major version from lsb_release
-sudo yum install -y redhat-lsb-core mock git wget
+sudo yum install -y mock git wget
 
 # Run the install-deps.sh upstream script if it exists
 if [ -x install-deps.sh ]; then
@@ -21,7 +19,7 @@ fi
 
 
 ## Get some basic information about the system and the repository
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
+get_rpm_dist
 VERSION="0.1"
 REVISION="$(git rev-list --count HEAD)-g$(git rev-parse --short HEAD)"
 RPM_RELEASE=$(echo $REVISION | tr '-' '_') # the '-' has a special meaning

--- a/cephmetrics/build/build_rpm
+++ b/cephmetrics/build/build_rpm
@@ -13,9 +13,7 @@ fi
 
 
 ## Install any setup-time deps (to make dist package)
-
-# We need this to get the major version from lsb_release
-sudo yum install -y redhat-lsb-core mock git wget
+sudo yum install -y mock git wget
 
 # Run the install-deps.sh upstream script if it exists
 if [ -x install-deps.sh ]; then
@@ -25,7 +23,7 @@ fi
 
 
 ## Get some basic information about the system and the repository
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
+get_rpm_dist
 DESCRIBE="$(git describe --tags 2>/dev/null | cut -b 2-)"
 test -z "$DESCRIBE" && DESCRIBE="0.1-$(git rev-list --count HEAD)-g$(git rev-parse --short HEAD)"
 VERSION="$(echo $DESCRIBE | cut -d - -f 1)"

--- a/configshell-fb/build/build_rpm
+++ b/configshell-fb/build/build_rpm
@@ -19,7 +19,7 @@ sudo gem install fpm
 
 ## Get some basic information about the system and the repository
 # Get version
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
+get_rpm_dist
 VERSION="$(git describe --abbrev=0 --tags HEAD | sed -e 's/v//1;')"
 REVISION="$(git describe --tags HEAD | sed -e 's/v//1;' | cut -d - -f 2- | sed 's/-/./')"
 if [ "$VERSION" = "$REVISION" ]; then

--- a/diamond-build/build/build_rpm
+++ b/diamond-build/build/build_rpm
@@ -8,51 +8,6 @@ fi
 
 cd $WORKSPACE
 
-get_rpm_dist() {
-    LSB_RELEASE=/usr/bin/lsb_release
-    [ ! -x $LSB_RELEASE ] && echo unknown && exit
-
-    ID=`$LSB_RELEASE --short --id`
-
-    case $ID in
-    RedHatEnterpriseServer)
-        RELEASE=`$LSB_RELEASE --short --release | cut -d. -f1`
-        DIST=rhel$RELEASE
-        DISTRO=rhel
-        ;;
-    CentOS)
-        RELEASE=`$LSB_RELEASE --short --release | cut -d. -f1`
-        DIST=el$RELEASE
-        DISTRO=centos
-        ;;
-    Fedora)
-        RELEASE=`$LSB_RELEASE --short --release`
-        DIST=fc$RELEASE
-        DISTRO=fedora
-        ;;
-    SUSE\ LINUX)
-        DESC=`$LSB_RELEASE --short --description`
-        RELEASE=`$LSB_RELEASE --short --release`
-        case $DESC in
-        *openSUSE*)
-                DIST=opensuse$RELEASE
-                DISTRO=opensuse
-            ;;
-        *Enterprise*)
-                DIST=sles$RELEASE
-                DISTRO=sles
-                ;;
-            esac
-        ;;
-    *)
-        DIST=unknown
-        DISTRO=unknown
-        ;;
-    esac
-
-    echo $DIST
-}
-
 get_rpm_dist
 dist=$DIST
 [ -z "$dist" ] && echo no dist && exit 1

--- a/kernel/build/setup
+++ b/kernel/build/setup
@@ -30,7 +30,6 @@ fi
 export LC_ALL=C # the following is vulnerable to i18n
 
 if test -f /etc/redhat-release ; then
-    $SUDO yum install -y redhat-lsb-core
     $SUDO yum install -y elfutils-libelf-devel  # for ORC unwinder
     $SUDO yum install -y flex bison  # for Kconfig
 
@@ -51,10 +50,10 @@ if which apt-get > /dev/null ; then
     NORMAL_DISTRO_VERSION=$AVAILABLE_DIST
 fi
 
-case $(lsb_release -si) in
-CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
-        case $(lsb_release -si) in
-            SUSE*)
+case $DISTRO in
+rhel|centos|fedora|sles|opensuse-leap)
+        case $DISTRO in
+            opensuse)
                 $SUDO zypper -y yum-utils
                 ;;
             *)
@@ -63,7 +62,7 @@ CentOS|Fedora|SUSE*|RedHatEnterpriseServer)
         esac
         ;;
 *)
-        echo "$(lsb_release -si) is unknown, dependencies will have to be installed manually."
+        echo "$DISTRO is unknown, dependencies will have to be installed manually."
         ;;
 esac
 

--- a/nfs-ganesha-stable/build/build_rpm
+++ b/nfs-ganesha-stable/build/build_rpm
@@ -6,8 +6,7 @@ if test "$DISTRO" != "fedora" -a "$DISTRO" != "centos" -a "$DISTRO" != "rhel"; t
     exit 0
 fi
 
-## Get some basic information about the system and the repository
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
+get_rpm_dist
 
 # Make sure old rpms are not leftover on the system
 sudo yum remove -y librados2 librgw2 libcephfs2 librados-devel librgw-devel libcephfs-devel

--- a/nfs-ganesha/build/build_rpm
+++ b/nfs-ganesha/build/build_rpm
@@ -6,8 +6,7 @@ if test "$DISTRO" != "fedora" -a "$DISTRO" != "centos" -a "$DISTRO" != "rhel"; t
     exit 0
 fi
 
-## Get some basic information about the system and the repository
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
+get_rpm_dist
 
 # Disable the google-chrome repo on el7, which is not needed (el8 doesn't have this repo).
 if [ $DIST = centos7 ]

--- a/rtslib-fb/build/build_rpm
+++ b/rtslib-fb/build/build_rpm
@@ -19,7 +19,7 @@ sudo gem install fpm
 
 ## Get some basic information about the system and the repository
 # Get version
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
+get_rpm_dist
 VERSION="$(git describe --abbrev=0 --tags HEAD | sed -e 's/v//1;')"
 REVISION="$(git describe --tags HEAD | sed -e 's/v//1;' | cut -d - -f 2- | sed 's/-/./')"
 if [ "$VERSION" = "$REVISION" ]; then

--- a/samba/build/build_rpm
+++ b/samba/build/build_rpm
@@ -6,7 +6,7 @@ if test "$DISTRO" != "fedora" -a "$DISTRO" != "centos" -a "$DISTRO" != "rhel"; t
     exit 0
 fi
 
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
+get_rpm_dist
 
 ## Get the desired CEPH_BRANCH/CEPH_SHA1 ceph repo
 # Get .repo file from appropriate shaman build

--- a/tcmu-runner/build/build_rpm
+++ b/tcmu-runner/build/build_rpm
@@ -10,8 +10,6 @@ if test "$DISTRO" != "fedora" -a "$DISTRO" != "centos" -a "$DISTRO" != "rhel"; t
     exit 0
 fi
 
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # sytem release
-
 ## Get the desired CEPH_BRANCH/CEPH_SHA1 ceph repo
 # Get .repo file from appropriate shaman build
 REPO_URL="https://shaman.ceph.com/api/repos/ceph/$CEPH_BRANCH/$CEPH_SHA1/$DISTRO/$RELEASE/flavors/default/repo"
@@ -41,7 +39,7 @@ sudo yum install -y mock
 
 ## Get some basic information about the system and the repository
 # Get version
-RELEASE="$(lsb_release --short -r | cut -d '.' -f 1)" # system release
+get_rpm_dist
 VERSION="$(git describe --abbrev=0 --tags HEAD | sed -e 's/v//1;' | cut -d - -f 1)"
 REVISION="$(git describe --tags HEAD | sed -e 's/v//1;' | cut -d - -f 2- | sed 's/-/./g' | sed 's/^rc/0./')"
 if [ "$VERSION" = "$REVISION" ]; then


### PR DESCRIPTION
lsb_release was removed in EL9 and we already have functions to read /etc/os-release and return the values we want.

Signed-off-by: David Galloway <dgallowa@redhat.com>