### PR TITLE
ceph-windows: remove installed packages

### DIFF
--- a/scripts/ceph-windows/cleanup
+++ b/scripts/ceph-windows/cleanup
@@ -18,6 +18,20 @@ if [[ -x $WORKSPACE/cephadm ]]; then
     fi
 fi
 
+# Uninstall packages installed by "cephadm install ceph-common"
+sudo apt-get -y purge \
+    ceph-common  \
+    python3-ceph-argparse \
+    python3-ceph-common \
+    python3-cephfs \
+    librbd1 \
+    python3-rados \
+    python3-rbd \
+    python3-rgw \
+    libcephfs2 \
+    librados2 \
+    libradosstriper1
+
 # Cleanup repos
 sudo rm -f /etc/apt/sources.list.d/docker.list \
            /etc/apt/sources.list.d/ceph.list


### PR DESCRIPTION
`ceph-windows/run_tests` installs client side dependencies using
`cephadm install ceph-common`, which leaves us with a bunch ceph
packages after the test finishes. and they inteferes with succeeding
tests which, for instance, try to import python modules from test's
building directory.
but they end up with importing the python modules installed in system.

in this change, the installed package and its ceph dependencies are
removed in the cleanup script. the list of packages is collected by
inspecting `/var/log/dpkg.log` on the system where the test failures
were spotted and `ceph/debian/control` 's "ceph-common" section.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>