### PR TITLE
ceph-dev*build: Switch to using jammy pbuilder image

### DIFF
--- a/ceph-dev-build/build/build_mingw
+++ b/ceph-dev-build/build/build_mingw
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -ex
 
-# We need Ubuntu Focal to cross-compile Ceph for Windows.
-# Previous versions provide broken Mingw packages.
-# "DIST" will be set to "windows", so we're currently overriding it with
-# a hardcoded value.
 tmp_pbuild_script=$(mktemp /tmp/build_mingw_pbuild.XXXXXX)
 cat << EOF > $tmp_pbuild_script
 #!/bin/sh
@@ -17,8 +13,8 @@ EOF
 chmod a+x $tmp_pbuild_script
 sudo pbuilder execute \
     --bindmounts "$(pwd):/mnt/ceph" \
-    --distribution "focal" \
-    --basetgz $basedir/focal.tgz \
+    --distribution "jammy" \
+    --basetgz $basedir/jammy.tgz \
     -- $tmp_pbuild_script
 rm $tmp_pbuild_script
 

--- a/ceph-dev-build/build/setup_mingw
+++ b/ceph-dev-build/build/setup_mingw
@@ -68,10 +68,10 @@ if [ "$THROWAWAY" = false ] ; then
     check_binary_existence $VENV $chacra_check_url
 fi
 
-# We need Ubuntu Focal to cross-compile Ceph for Windows.
-# Previous versions provide broken Mingw packages.
+# We need Ubuntu >= Jammy to cross-compile Ceph for Windows.
+# Previous versions provide broken Mingw packages/too old gcc.
 # "DIST" will be set to "windows", so we're currently overriding it with
 # a hardcoded value.
-DIST="focal"
+DIST="jammy"
 setup_pbuilder use_gcc
 DIST="$NORMAL_DISTRO"

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -73,7 +73,7 @@
     builders:
       - shell: |
           echo "Cleaning up top-level workarea (shared among workspaces)"
-          rm -rf dist
+          sudo rm -rf dist
           rm -rf venv
           rm -rf release
       - copyartifact:

--- a/ceph-dev-new-build/build/build_mingw
+++ b/ceph-dev-new-build/build/build_mingw
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -ex
 
-# We need Ubuntu Focal to cross-compile Ceph for Windows.
-# Previous versions provide broken Mingw packages.
-# "DIST" will be set to "windows", so we're currently overriding it with
-# a hardcoded value.
 tmp_pbuild_script=$(mktemp /tmp/build_mingw_pbuild.XXXXXX)
 cat << EOF > $tmp_pbuild_script
 #!/bin/sh
@@ -17,8 +13,8 @@ EOF
 chmod a+x $tmp_pbuild_script
 sudo pbuilder execute \
     --bindmounts "$(pwd):/mnt/ceph" \
-    --distribution "focal" \
-    --basetgz $basedir/focal.tgz \
+    --distribution "jammy" \
+    --basetgz $basedir/jammy.tgz \
     -- $tmp_pbuild_script
 rm $tmp_pbuild_script
 

--- a/ceph-dev-new-build/build/setup_mingw
+++ b/ceph-dev-new-build/build/setup_mingw
@@ -68,10 +68,10 @@ if [ "$THROWAWAY" = false ] ; then
     check_binary_existence $VENV $chacra_check_url
 fi
 
-# We need Ubuntu Focal to cross-compile Ceph for Windows.
-# Previous versions provide broken Mingw packages.
+# We need Ubuntu >= Jammy to cross-compile Ceph for Windows.
+# Previous versions provide broken Mingw packages/too old gcc.
 # "DIST" will be set to "windows", so we're currently overriding it with
 # a hardcoded value.
-DIST="focal"
+DIST="jammy"
 setup_pbuilder use_gcc
 DIST="$NORMAL_DISTRO"


### PR DESCRIPTION
Jammy has the newer version of gcc we need.

Signed-off-by: David Galloway <dgallowa@redhat.com>