### PR TITLE
nfs-ganesha/rpm: Fix tcmalloc allocator setup

### DIFF
--- a/nfs-ganesha/build/build_rpm
+++ b/nfs-ganesha/build/build_rpm
@@ -124,6 +124,8 @@ fi
 sed -i 's/libcephfs1-devel/libcephfs-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 sed -i 's/librgw2-devel/librgw-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 sed -i 's/CMAKE_BUILD_TYPE=Debug/CMAKE_BUILD_TYPE=RelWithDebInfo/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
+sed -i '/^BuildRequires:.*cmake$/a\BuildRequires:  gperftools-devel\' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
+sed -i '/-DSANITIZE_ADDRESS/a\        -DALLOCATOR=tcmalloc\' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 
 ## Create the source rpm
 echo "Building SRPM"


### PR DESCRIPTION
The previous commit installed the gperftools-devel package and set the cmake ALLOCATION variable to tcmalloc but this isn't used at all during the RPM package build via mock.
We also need those changes in the RPM spec file.
This is a temporary solution until the upstream nfs-ganesha RPM spec file will support such change.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>