### PR TITLE
build_utils: fix collect_ceph_logs function

### DIFF
--- a/ceph-volume-ansible-prs/build/teardown
+++ b/ceph-volume-ansible-prs/build/teardown
@@ -10,7 +10,9 @@ install_python_packages $TEMPVENV "pkgs[@]"
 
 GITHUB_STATUS_STATE="failure" $VENV/github-status create
 
-cd $WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
+CEPH_VOLUME_FUNCTIONAL_TESTS_PATH=$WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
+COLLECT_LOGS_PLAYBOOK_PATH="$CEPH_VOLUME_FUNCTIONAL_TESTS_PATH/$SUBCOMMAND/.tox/${DISTRO}-${OBJECTSTORE}-${SCENARIO}/tmp/ceph-ansible/tests/functional/collect-logs.yml"
+cd "$CEPH_VOLUME_FUNCTIONAL_TESTS_PATH"
 
 # the method exists in scripts/build_utils.sh
-teardown_vagrant_tests $VENV
+teardown_vagrant_tests "$VENV" "$COLLECT_LOGS_PLAYBOOK_PATH"

--- a/ceph-volume-nightly/build/teardown
+++ b/ceph-volume-nightly/build/teardown
@@ -3,9 +3,11 @@
 # for every Vagrantfile in scenarios and then just destroys whatever is left.
 
 
-cd $WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
+CEPH_VOLUME_FUNCTIONAL_TESTS_PATH=$WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
+COLLECT_LOGS_PLAYBOOK_PATH="$CEPH_VOLUME_FUNCTIONAL_TESTS_PATH/$SUBCOMMAND/.tox/${DISTRO}-${OBJECTSTORE}-${SCENARIO}/tmp/ceph-ansible/tests/functional/collect-logs.yml"
+cd "$CEPH_VOLUME_FUNCTIONAL_TESTS_PATH"
 
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 # the method exists in scripts/build_utils.sh
-teardown_vagrant_tests $VENV
+teardown_vagrant_tests "$VENV" "$COLLECT_LOGS_PLAYBOOK_PATH"

--- a/ceph-volume-scenario/build/teardown
+++ b/ceph-volume-scenario/build/teardown
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-cd $WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
+CEPH_VOLUME_FUNCTIONAL_TESTS_PATH=$WORKSPACE/src/ceph-volume/ceph_volume/tests/functional
+COLLECT_LOGS_PLAYBOOK_PATH="$CEPH_VOLUME_FUNCTIONAL_TESTS_PATH/$SUBCOMMAND/.tox/${DISTRO}-${OBJECTSTORE}-${SCENARIO}/tmp/ceph-ansible/tests/functional/collect-logs.yml"
+cd "$CEPH_VOLUME_FUNCTIONAL_TESTS_PATH"
 
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 # the method exists in scripts/build_utils.sh
-teardown_vagrant_tests $VENV
+teardown_vagrant_tests "$VENV" "$COLLECT_LOGS_PLAYBOOK_PATH"


### PR DESCRIPTION
typical error from ceph-volume tests:

```
ERROR! the playbook: /home/jenkins-build/build/workspace/ceph-volume-prs-lvm-centos8-bluestore-dmcrypt/tests/functional/collect-logs.yml could not be found
```

Since `collect-logs.yml` is maintained in ceph-ansible repository, when `collect_ceph_logs` is called from a job different from ceph-ansible, the path is incorrect.
The idea is to make ceph-volume jobs override this path.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>