### PR TITLE
ceph-volume-nightly: fix broken tests

### DIFF
--- a/ceph-volume-nightly/build/build
+++ b/ceph-volume-nightly/build/build
@@ -16,8 +16,10 @@ update_vagrant_boxes
 
 cd src/ceph-volume/ceph_volume/tests/functional/$SUBCOMMAND
 
-if [ "$CEPH_BRANCH" = "nautilus" ]; then
-    CEPH_ANSIBLE_BRANCH="stable-4.0"
+if [[ "$CEPH_BRANCH" == "pacific" ]]; then
+    CEPH_ANSIBLE_BRANCH="stable-6.0"
+elif [[ "$CEPH_BRANCH" == "quincy" ]]; then
+    CEPH_ANSIBLE_BRANCH="stable-7.0"
 else
     CEPH_ANSIBLE_BRANCH="main"
 fi

--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -1,7 +1,6 @@
 - project:
     name: ceph-volume-nightly-lvm
     distro:
-      - focal
       - centos8
     objectstore:
       - bluestore
@@ -22,7 +21,6 @@
 - project:
     name: ceph-volume-nightly-batch
     distro:
-      - focal
       - centos8
     objectstore:
       - bluestore
@@ -43,7 +41,6 @@
 - project:
     name: ceph-volume-nightly-batch-mixed
     distro:
-      - focal
       - centos8
     objectstore:
       - bluestore


### PR DESCRIPTION
ceph-volume nightly jobs are broken for a while because it picks 'main' as ceph-ansible branch for any ceph release being tested.

With this commit, the right ceph-ansible branch will be picked.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>