### PR TITLE
dashboard-deps: remove cortx from the apt-sources

### DIFF
--- a/scripts/dashboard/install-cephadm-e2e-deps.sh
+++ b/scripts/dashboard/install-cephadm-e2e-deps.sh
@@ -62,6 +62,7 @@ sudo chgrp "$(id -un)" /var/run/docker.sock
 docker info
 docker container prune -f
 
+rm -rf ${HOME}/.kcli
 KCLI_CONFIG_DIR="${HOME}/.kcli"
 mkdir -p ${KCLI_CONFIG_DIR}
 if [[ ! -f "${KCLI_CONFIG_DIR}/id_rsa" ]]; then
@@ -88,5 +89,6 @@ sudo chmod +x /usr/local/bin/kcli
 sudo mkdir -p /var/lib/libvirt/images/ceph-dashboard
 kcli delete plan ceph -y || true
 kcli delete network ceph-dashboard -y
+kcli delete pool ceph-dashboard -y
 kcli create pool -p /var/lib/libvirt/images/ceph-dashboard ceph-dashboard
 kcli create network -c 192.168.100.0/24 ceph-dashboard

--- a/scripts/dashboard/install-e2e-test-deps.sh
+++ b/scripts/dashboard/install-e2e-test-deps.sh
@@ -6,6 +6,8 @@ if [[ ! $(arch) =~ (i386|x86_64|amd64) ]]; then
     exit
 fi
 
+sudo rm -f /etc/apt/sources.list.d/cortx-motr.list
+
 if grep -q  debian /etc/*-release; then
     sudo bash -c 'echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list'
     curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -


### PR DESCRIPTION
dashboard e2e is constantly failing with this error for many days. So I went for the simple solution here which is to remove the cortx from the apt-sources. What I am not sure is the impact of this change. Will it affect any other tests?

I also did some cleanups around cephadm e2e. Ideally this should be done in the on_cleanup() function in our start-cluster.sh script in the ceph repo (which I'll be doing), but for extra safety I am putting it here too.

Signed-off-by: Nizamudeen A <nia@redhat.com>