### PR TITLE
ceph-windows: Cleanup logs dir before collecting new logs

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -72,5 +72,6 @@ SSH_TIMEOUT=1h ssh_exec powershell.exe /workspace/repos/ceph-win32-tests/test_ho
 #
 # Collect logs
 #
+rm -rf $WORKSPACE/logs
 mkdir -p $WORKSPACE/logs
 scp_download /workspace/test_results $WORKSPACE/logs/test_results


### PR DESCRIPTION
We noticed old logs in the Jenkins `ceph-windows-pull-requests` job artifacts. This is very likely due to the fact that there were existing logs from previous runs.

Make sure that there are no leftover logs from previous runs by cleaning up the `$WORKSPACE/logs` dir prior to collecting new logs from the Windows tests machine.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>