### PR TITLE
Revert "nfs-ganesha/rpm: Fix tcmalloc allocator setup"

### DIFF
--- a/nfs-ganesha/build/build_rpm
+++ b/nfs-ganesha/build/build_rpm
@@ -124,8 +124,6 @@ fi
 sed -i 's/libcephfs1-devel/libcephfs-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 sed -i 's/librgw2-devel/librgw-devel/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 sed -i 's/CMAKE_BUILD_TYPE=Debug/CMAKE_BUILD_TYPE=RelWithDebInfo/' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
-sed -i '/^BuildRequires:.*cmake$/a\BuildRequires:  gperftools-devel\' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
-sed -i '/-DSANITIZE_ADDRESS/a\        -DALLOCATOR=tcmalloc\' $WORKSPACE/nfs-ganesha/src/nfs-ganesha.spec
 
 ## Create the source rpm
 echo "Building SRPM"


### PR DESCRIPTION
This reverts commit 953f385e4b410fb7c560b47295ef2fd34e25d44a.

This isn't needed anymore since the changes in nfs-ganesha have been merged [1]

[1] https://github.com/nfs-ganesha/nfs-ganesha/commit/5eada8d

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>