### PR TITLE
kernel: re-add master branch to the trigger list

### DIFF
--- a/kernel-trigger/config/definitions/kernel-trigger.yml
+++ b/kernel-trigger/config/definitions/kernel-trigger.yml
@@ -36,7 +36,7 @@
                 <name>origin/testing</name>
               </hudson.plugins.git.BranchSpec>
               <hudson.plugins.git.BranchSpec>
-                <name>origin/main</name>
+                <name>origin/master</name>
               </hudson.plugins.git.BranchSpec>
               <hudson.plugins.git.BranchSpec>
                 <name>origin/for-linus</name>


### PR DESCRIPTION
Commit 39e983f0198c ("master-> main") shouldn't have touched kernel-trigger job as ceph-client.git still has the master branch which feeds into linux-next.git.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>