### PR TITLE
ceph-windows: Add more Windows testing

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -60,3 +60,8 @@ trap collect_artifacts EXIT
 # Run the Windows tests
 #
 SSH_TIMEOUT=1h ssh_exec powershell.exe /workspace/repos/ceph-win32-tests/test_host/run_tests.ps1 -workerCount 4
+
+ssh_exec curl.exe -s -L -o /workspace/test_rbd_wnbd.py https://raw.githubusercontent.com/ceph/ceph/main/qa/workunits/windows/test_rbd_wnbd.py
+SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdTest --iterations 100
+SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFioTest --iterations 100
+SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdStampTest --iterations 100


### PR DESCRIPTION
Run `test_rbd_wnbd.py` script from the upstream Ceph QA Windows workunit scripts
as part of the `script/ceph-windows/run_tests`.

The new test cases don't take a lot of time to execute (unless something is wrong with Ceph on Windows or Linux).
So, we won't have any noticeable jobs' execute time penalty.

This adds more Windows tests to the Jenkins jobs:
* `ceph-windows-test`
* `ceph-windows-pull-requests`

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>