### PR TITLE
ceph-dev-new: Default to internal quay instance

### DIFF
--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -73,7 +73,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
       - string:
           name: CONTAINER_REPO_HOSTNAME
           description: "For CI_CONTAINER: Name of container repo server (i.e. 'quay.io')"
-          default: "quay.ceph.io"
+          default: "quay-quay-quay.apps.os.sepia.ceph.com"
 
       - string:
           name: CONTAINER_REPO_ORGANIZATION


### PR DESCRIPTION
Temporarily, so we can unblock building on git push.

Signed-off-by: Zack Cerza <zack@redhat.com>