### PR TITLE
temporarily disable windows RbdStampTest test

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -64,4 +64,6 @@ SSH_TIMEOUT=1h ssh_exec powershell.exe /workspace/repos/ceph-win32-tests/test_ho
 ssh_exec curl.exe -s -L -o /workspace/test_rbd_wnbd.py https://raw.githubusercontent.com/ceph/ceph/main/qa/workunits/windows/test_rbd_wnbd.py
 SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdTest --iterations 100
 SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFioTest --iterations 100
-SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdStampTest --iterations 100
+# We're temporarily disabling this test, see the following for more details:
+#   https://github.com/ceph/ceph/pull/48929
+# SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdStampTest --iterations 100


### PR DESCRIPTION
One of the rbd-wnbd tests has started failing after the Windows image got updated. The disks now show up as "read-only" by default.

https://pastebin.com/raw/JXmLXFnN

We'll temporarily disable this test to unblock the Windows job while doing further investigation.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>