### PR TITLE
ceph-ansible-nightly: Don't search tags endlessly

### DIFF
--- a/ceph-ansible-nightly/build/build
+++ b/ceph-ansible-nightly/build/build
@@ -25,6 +25,11 @@ function find_latest_tag {
   page=1
   while response=$(curl -s "https://quay.ceph.io/api/v1/repository/ceph-ci/daemon/tag/?page=${page}&limit=${page_size}"); do
     tag=$(echo "${response}" | jq -r ".tags[] | select((.name | contains(\"stable\")) and (.name | contains(\"${release}-centos-${el}-x86_64\"))) | .name")
+    local code=$?
+    if [ $code != 0 ]; then
+      echo "Error listing tags!" >&2
+      exit $code
+    fi
     if [ -n "${tag}" ]; then
       echo "${tag}" | head -n 1 | cut -d '"' -f 2
       return


### PR DESCRIPTION
If the reponse is in an unexpected format (e.g. it's an error response), we were looping infinitely; one job got to over 60k pages!

Signed-off-by: Zack Cerza <zack@redhat.com>