### PR TITLE
ceph-windows: re-enable rbd-wnbd stamp test

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -64,6 +64,9 @@ SSH_TIMEOUT=1h ssh_exec powershell.exe /workspace/repos/ceph-win32-tests/test_ho
 ssh_exec curl.exe -s -L -o /workspace/test_rbd_wnbd.py https://raw.githubusercontent.com/ceph/ceph/main/qa/workunits/windows/test_rbd_wnbd.py
 SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdTest --iterations 100
 SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFioTest --iterations 100
-# We're temporarily disabling this test, see the following for more details:
-#   https://github.com/ceph/ceph/pull/48929
-# SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdStampTest --iterations 100
+SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdStampTest --iterations 100
+
+# It can take a while to setup the partition (~10s), we'll use fewer iterations.
+SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsTest --iterations 4
+SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsFioTest --iterations 4
+SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsStampTest --iterations 4


### PR DESCRIPTION
We had to disable one of the rbd-wnbd tests while investigating the reason why disks started coming up as read-only.

This was actually caused by the wnbd bus type, which changed from virtual to SAS. The default Windows policy (offlineShared) doesn't automatically bring online such disks, SAS being considered a shared bus.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>