### PR TITLE
scripts/build_utils: map 18.* to reef

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -13,6 +13,9 @@ function create_venv_dir() {
 function release_from_version() {
     local ver=$1
     case $ver in
+    18.*)
+        rel="reef"
+        ;;
     17.*)
         rel="quincy"
         ;;


### PR DESCRIPTION
otherwise, we'd have following failure when trying to build tip of main branch:
```
++ rel=unknown
++ echo 'ERROR: Unknown release for version '\''18.0.0'\''' ERROR: Unknown release for version '18.0.0'
++ echo unknown
++ exit 1
```
Signed-off-by: Kefu Chai <tchaikov@gmail.com>