### PR TITLE
ceph-windows: Use locally cloned script, if possible

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -61,7 +61,15 @@ trap collect_artifacts EXIT
 #
 SSH_TIMEOUT=1h ssh_exec powershell.exe /workspace/repos/ceph-win32-tests/test_host/run_tests.ps1 -workerCount 4
 
-ssh_exec curl.exe -s -L -o /workspace/test_rbd_wnbd.py https://raw.githubusercontent.com/ceph/ceph/main/qa/workunits/windows/test_rbd_wnbd.py
+LOCAL_SCRIPT_PATH="$WORKSPACE/ceph/qa/workunits/windows/test_rbd_wnbd.py"
+if [[ -f $LOCAL_SCRIPT_PATH ]]; then
+    echo "Using locally cloned test script: $LOCAL_SCRIPT_PATH"
+    scp_upload $LOCAL_SCRIPT_PATH /workspace/test_rbd_wnbd.py
+else
+    REMOTE_SCRIPT_URL="https://raw.githubusercontent.com/ceph/ceph/main/qa/workunits/windows/test_rbd_wnbd.py"
+    echo "Using remote test script from: $REMOTE_SCRIPT_URL"
+    ssh_exec curl.exe -s -L -o /workspace/test_rbd_wnbd.py $REMOTE_SCRIPT_URL
+fi
 SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdTest --iterations 100
 SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFioTest --iterations 100
 SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdStampTest --iterations 100


### PR DESCRIPTION
Use the locally cloned `test_rbd_wnbd.py` script if `$WORKSPACE/ceph` repository was cloned as part of the Jenkins job.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>