### PR TITLE
build_utils.sh: Disable cephfs_java with Crimson

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1452,6 +1452,7 @@ setup_rpm_build_deps() {
     case "${FLAVOR}" in
     crimson)
       sed -i -e 's/%bcond_with seastar/%bcond_without seastar/g' $DIR/ceph.spec
+      sed -i -e 's/%bcond_without cephfs_java/%bcond_with cephfs_java/g' $DIR/ceph.spec
         ;;
     jaeger)
       sed -i -e 's/%bcond_with jaeger/%bcond_without jaeger/g' $DIR/ceph.spec


### PR DESCRIPTION
In continuation to: https://github.com/ceph/ceph/pull/49678
Jenkins uses `build_utils.sh` (not `install-deps.sh` from ceph/main).

This should affect centos 8 **Crimson** builds only.

Tested by editing `ceph.spec.in` before pushing to Shaman.
Successful test Run: https://shaman.ceph.com/builds/ceph/wip-matanb-c-disable-ceph-fs-java/1c5cdf90ab6fca5c575e0cc90dba1d44802fb08c/crimson/328749/

Signed-off-by: Matan Breizman <mbreizma@redhat.com>