### PR TITLE
ceph-ansible-prs: pin tox version

### DIFF
--- a/ceph-ansible-prs/build/build
+++ b/ceph-ansible-prs/build/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "tox" )
+pkgs=( "tox==4.2.8" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 set_centos_python3_version "python3.9"


### PR DESCRIPTION
Due to a regression introduced in tox 4.3.1, multiple environment variable substitution is broken.
```
tox.report.HandledError: replace failed in centos-non_container-update.commands with MatchRecursionError('circular chain between set env DOCKER_HUB_USERNAME, DOCKER_HUB_PASSWORD, INVENTORY')
```

Let's pin to the last tox stable version where it used to work fine (4.2.8).

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>