### PR TITLE
ceph-volume-scenario: pin the tox version

### DIFF
--- a/ceph-volume-scenario/build/build
+++ b/ceph-volume-scenario/build/build
@@ -3,7 +3,7 @@ set -ex
 WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "tox" )
+pkgs=( "tox==4.2.8" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"


### PR DESCRIPTION
Due to a regression introduced in tox 4.3.1, we have to pin the version used in the CI in order to avoid the following error:

```
tox.report.HandledError: replace failed in centos8-filestore-create.commands with MatchRecursionError('circular chain between set env VAGRANT_UP_FLAGS, CEPH_DEV_BRANCH, CEPH_DEV_SHA1')
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>