### PR TITLE
ceph-container-prs: disable ceph-ansible tests

### DIFF
--- a/ceph-container-prs/config/definitions/ceph-container-prs.yml
+++ b/ceph-container-prs/config/definitions/ceph-container-prs.yml
@@ -40,7 +40,7 @@
             - ceph
           skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
           trigger-phrase: 'jenkins test ceph_ansible-{test}'
-          only-trigger-phrase: false
+          only-trigger-phrase: true
           github-hooks: true
           permit-all: true
           auto-close-on-fail: false


### PR DESCRIPTION
ceph-container repo is being reworked.
ceph-ansible is about to drop ceph/daemon entrypoints anyway so theses tests don't make sense anymore.

This disables ceph-ansible tests in the ceph-container CI.

Signed-off-by: Guillaume Abrioux <gabrioux@ibm.com>