### PR TITLE
ceph-windows: update test timeouts

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -68,16 +68,18 @@ if [[ -f $LOCAL_SCRIPT_PATH ]]; then
     scp_upload $WIN_WORKUNITS_DIR /workspace/workunits
     SSH_TIMEOUT=30m ssh_exec powershell.exe -File /workspace/workunits/run-tests.ps1
 else
-    REMOTE_SCRIPT_URL="https://raw.githubusercontent.com/ceph/ceph/main/qa/workunits/windows/test_rbd_wnbd.py"
+    # The following is only used on Quincy, make sure to leave this in place while Quincy
+    # is still being tested.
+    REMOTE_SCRIPT_URL="https://raw.githubusercontent.com/ceph/ceph/1db85786588ad974621a6b669a3aae4e8799b1e6/qa/workunits/windows/test_rbd_wnbd.py"
     echo "Using remote test script from: $REMOTE_SCRIPT_URL"
     ssh_exec curl.exe -s -L -o /workspace/test_rbd_wnbd.py $REMOTE_SCRIPT_URL
 
-    SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdTest --iterations 100
-    SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFioTest --iterations 100
-    SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdStampTest --iterations 100
+    SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdTest --iterations 100
+    SSH_TIMEOUT=30m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFioTest --iterations 100
+    SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdStampTest --iterations 100
 
     # It can take a while to setup the partition (~10s), we'll use fewer iterations.
-    SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsTest --iterations 4
-    SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsFioTest --iterations 4
-    SSH_TIMEOUT=5m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsStampTest --iterations 4
+    SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsTest --iterations 4
+    SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsFioTest --iterations 4
+    SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsStampTest --iterations 4
 fi


### PR DESCRIPTION
The Python rbd-wnbd tests time out on stable branches. The reason is that if the test script is missing, we're fetching it from the main branch and then run the tests individually.

The issue is that while on the main branch the entire suite uses a 30m timeout, on stable branches we're excuting each individual test with a 5m timeout, which isn't enough for some of the tests (e.g. the FIO one).

For this reason, we're going to increase the timeout.

While at it, we're pinning the commit id when fetching the test script on older branches. That will allow us to move it or refactor it.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>