### PR TITLE
ceph-dev-*: bump pbuilder dist when targeting Windows

### DIFF
--- a/ceph-dev-build/build/build_mingw
+++ b/ceph-dev-build/build/build_mingw
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -ex
 
-# We need Ubuntu Focal to cross-compile Ceph for Windows.
-# Previous versions provide broken Mingw packages.
+# We need Ubuntu Jammy to cross-compile Ceph for Windows.
 # "DIST" will be set to "windows", so we're currently overriding it with
 # a hardcoded value.
 tmp_pbuild_script=$(mktemp /tmp/build_mingw_pbuild.XXXXXX)
@@ -17,8 +16,8 @@ EOF
 chmod a+x $tmp_pbuild_script
 sudo pbuilder execute \
     --bindmounts "$(pwd):/mnt/ceph" \
-    --distribution "focal" \
-    --basetgz $basedir/focal.tgz \
+    --distribution "jammy" \
+    --basetgz $basedir/jammy.tgz \
     -- $tmp_pbuild_script
 rm $tmp_pbuild_script
 

--- a/ceph-dev-build/build/setup_mingw
+++ b/ceph-dev-build/build/setup_mingw
@@ -68,10 +68,9 @@ if [ "$THROWAWAY" = false ] ; then
     check_binary_existence $VENV $chacra_check_url
 fi
 
-# We need Ubuntu Focal to cross-compile Ceph for Windows.
-# Previous versions provide broken Mingw packages.
+# We need Ubuntu Jammy to cross-compile Ceph for Windows.
 # "DIST" will be set to "windows", so we're currently overriding it with
 # a hardcoded value.
-DIST="focal"
+DIST="jammy"
 setup_pbuilder use_gcc
 DIST="$NORMAL_DISTRO"

--- a/ceph-dev-new-build/build/build_mingw
+++ b/ceph-dev-new-build/build/build_mingw
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -ex
 
-# We need Ubuntu Focal to cross-compile Ceph for Windows.
-# Previous versions provide broken Mingw packages.
+# We need Ubuntu Jammy to cross-compile Ceph for Windows.
 # "DIST" will be set to "windows", so we're currently overriding it with
 # a hardcoded value.
 tmp_pbuild_script=$(mktemp /tmp/build_mingw_pbuild.XXXXXX)
@@ -17,8 +16,8 @@ EOF
 chmod a+x $tmp_pbuild_script
 sudo pbuilder execute \
     --bindmounts "$(pwd):/mnt/ceph" \
-    --distribution "focal" \
-    --basetgz $basedir/focal.tgz \
+    --distribution "jammy" \
+    --basetgz $basedir/jammy.tgz \
     -- $tmp_pbuild_script
 rm $tmp_pbuild_script
 

--- a/ceph-dev-new-build/build/setup_mingw
+++ b/ceph-dev-new-build/build/setup_mingw
@@ -68,10 +68,9 @@ if [ "$THROWAWAY" = false ] ; then
     check_binary_existence $VENV $chacra_check_url
 fi
 
-# We need Ubuntu Focal to cross-compile Ceph for Windows.
-# Previous versions provide broken Mingw packages.
+# We need Ubuntu Jammy to cross-compile Ceph for Windows.
 # "DIST" will be set to "windows", so we're currently overriding it with
 # a hardcoded value.
-DIST="focal"
+DIST="jammy"
 setup_pbuilder use_gcc
 DIST="$NORMAL_DISTRO"


### PR DESCRIPTION
Ceph now uses c++ 20, thus requiring gcc 10 or later.

We'll need to update Windows jobs that leverage pbuilder to from Ubuntu Focal (20.04) to Ubuntu Jammy (22.04) to get mingw 8.0 and gcc 10.3.0.

Fixes: https://tracker.ceph.com/issues/58562

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>