### PR TITLE
ceph-dev: allow for a strictly centos9 build

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -157,7 +157,7 @@
       - conditional-step:
           condition-kind: shell
           condition-command: |
-            echo "${GIT_BRANCH}" | grep -v '\(luminous\|mimic\|nautilus\|octopus\|pacific\|quincy\|crimson-only\|jaeger\)'
+            echo "${GIT_BRANCH}" | grep -v '\(luminous\|mimic\|nautilus\|octopus\|pacific\|quincy\|centos9-only\|crimson-only\|jaeger\)'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -177,6 +177,24 @@
                     FORCE=True
                     DISTROS=centos8
                     FLAVOR=crimson
+                    ARCHS=x86_64
+      # build only centos9, no crimson, no jaeger
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*centos9-only.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=centos9
                     ARCHS=x86_64
       # Build only the `crimson` flavour, don't waste resources on the default one.
       # Useful for the crimson's bug-hunt at Sepia


### PR DESCRIPTION
For those working on details of a centos9 build, testing should not involve a bunch of other builds. Presenting this as a potential solution.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>

**I don't know if this is the best solution to limiting builds. I'm not sure that it scales well. But I thought I'd offer this PR to start a discussion and see what the best approach is.**