### PR TITLE
ceph-windows: Build Ceph on Windows inside libvirt VM

### DIFF
--- a/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
+++ b/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
@@ -67,8 +67,10 @@
         !include-raw:
           - ../../../scripts/build_utils.sh
           - ../../build/check_docs_pr_only
-          - ../../../scripts/ceph-windows/win32_build
           - ../../../scripts/ceph-windows/setup_libvirt
+          - ../../../scripts/ceph-windows/setup_libvirt_ubuntu_vm
+          - ../../../scripts/ceph-windows/win32_build
+          - ../../../scripts/ceph-windows/cleanup_libvirt_ubuntu_vm
           - ../../../scripts/ceph-windows/setup_libvirt_ubuntu_vm
           - ../../../scripts/ceph-windows/setup_libvirt_windows_vm
           - ../../../scripts/ceph-windows/setup_ceph_vstart

--- a/ceph-windows-test/config/definitions/ceph-windows-test.yml
+++ b/ceph-windows-test/config/definitions/ceph-windows-test.yml
@@ -55,8 +55,10 @@
       - shell:
           !include-raw:
             - ../../../scripts/build_utils.sh
-            - ../../../scripts/ceph-windows/win32_build
             - ../../../scripts/ceph-windows/setup_libvirt
+            - ../../../scripts/ceph-windows/setup_libvirt_ubuntu_vm
+            - ../../../scripts/ceph-windows/win32_build
+            - ../../../scripts/ceph-windows/cleanup_libvirt_ubuntu_vm
             - ../../../scripts/ceph-windows/setup_libvirt_ubuntu_vm
             - ../../../scripts/ceph-windows/setup_libvirt_windows_vm
             - ../../../scripts/ceph-windows/setup_ceph_vstart

--- a/scripts/ceph-windows/cleanup_libvirt_ubuntu_vm
+++ b/scripts/ceph-windows/cleanup_libvirt_ubuntu_vm
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+if [[ -z $UBUNTU_VM_NAME ]]; then echo "ERROR: The env variable UBUNTU_VM_NAME is not set"; exit 1; fi
+
+# Destroy and undefine the VM
+sudo virsh destroy $UBUNTU_VM_NAME
+sudo virsh undefine $UBUNTU_VM_NAME --remove-all-storage

--- a/scripts/ceph-windows/setup_ceph_vstart
+++ b/scripts/ceph-windows/setup_ceph_vstart
@@ -21,6 +21,10 @@ function rsync_cmd() {
 # Build Ceph vstart
 #
 cat > ${VSTART_DIR}/build-ceph-vstart.sh << EOF
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
 cd ~/ceph
 ./install-deps.sh
 ./do_cmake.sh \

--- a/scripts/ceph-windows/win32_build
+++ b/scripts/ceph-windows/win32_build
@@ -2,10 +2,37 @@
 set -o errexit
 set -o pipefail
 
+if [[ -z $SSH_KEY ]]; then echo "ERROR: The SSH_KEY env variable is not set"; exit 1; fi
+if [[ -z $SSH_KNOWN_HOSTS_FILE ]]; then echo "ERROR: The SSH_KNOWN_HOSTS_FILE env variable is not set"; exit 1; fi
+
+if [[ -z $UBUNTU_SSH_USER ]]; then echo "ERROR: The UBUNTU_SSH_USER env variable is not set"; exit 1; fi
+if [[ -z $UBUNTU_VM_IP ]]; then echo "ERROR: The UBUNTU_VM_IP env variable is not set"; exit 1; fi
+
+export SSH_USER=$UBUNTU_SSH_USER
+export SSH_ADDRESS=$UBUNTU_VM_IP
+
+function rsync_cmd() {
+    rsync -a --delete -e "ssh -i $SSH_KEY -o UserKnownHostsFile=$SSH_KNOWN_HOSTS_FILE" ${@}
+}
+
 #
 # Build Ceph Windows
 #
-cd $WORKSPACE/ceph
+cat > ${WORKSPACE}/build-ceph-windows.sh << EOF
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+cd ~/ceph
+
+sudo apt-get update
+sudo apt-get install -y git
 git submodule update --init --recursive
-ZIP_DEST=$WORKSPACE/ceph.zip $CEPH_WIN32_BUILD_FLAGS timeout 3h ./win32_build.sh
-rm -rf build
+
+ZIP_DEST=~/ceph.zip $CEPH_WIN32_BUILD_FLAGS timeout 3h ./win32_build.sh
+EOF
+chmod +x ${WORKSPACE}/build-ceph-windows.sh
+time rsync_cmd $WORKSPACE/ceph ${WORKSPACE}/build-ceph-windows.sh ${UBUNTU_SSH_USER}@${UBUNTU_VM_IP}:
+
+time SSH_TIMEOUT=3h ssh_exec ./build-ceph-windows.sh
+time rsync_cmd ${UBUNTU_SSH_USER}@${UBUNTU_VM_IP}:~/ceph.zip $WORKSPACE/ceph.zip


### PR DESCRIPTION
Make sure that the Ceph on Windows build is done inside an Ubuntu libvirt VM. This ensures that the build is done on a clean environment on each job run.

After the Windows build is done, the Ubuntu VM is rebuilt to ensure that Ceph vstart will have a clean environment as well.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>