### PR TITLE
increase vm memory for windows test jobs

### DIFF
--- a/scripts/ceph-windows/setup_libvirt_ubuntu_vm
+++ b/scripts/ceph-windows/setup_libvirt_ubuntu_vm
@@ -7,7 +7,7 @@ if [[ -z $LIBVIRT_DIR ]]; then echo "ERROR: The env variable LIBVIRT_DIR is not 
 export UBUNTU_VM_IMAGE_URL=${UBUNTU_VM_IMAGE_URL:-"https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img"}
 export UBUNTU_VM_NAME=${UBUNTU_VM_NAME:-"ceph-ubuntu-vstart-${JOB_NAME}-${BUILD_ID}"}
 export UBUNTU_VM_VCPUS="$(nproc)"  # use all the CPU cores avaiable on the host
-export UBUNTU_VM_MEMORY="32768"    # 32 GB
+export UBUNTU_VM_MEMORY="65536"    # 64 GB
 export UBUNTU_SSH_USER="ubuntu"
 
 #


### PR DESCRIPTION
Windows test jobs use two vms: a windows vm that takes 8gb of ram and a linux one that currently uses 32gb of ram.

We're using memstore with 5gb per osd. It seems that the linux vm is running out of memory, which is why the OSDs can get terminated while running the tests.

We'll go ahead and increase the linux vm memory to 64gb.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>