### PR TITLE
windows: install jq package

### DIFF
--- a/scripts/ceph-windows/setup_libvirt_ubuntu_vm
+++ b/scripts/ceph-windows/setup_libvirt_ubuntu_vm
@@ -35,6 +35,7 @@ packages:
   - qemu-guest-agent
   - locales
   - rsync
+  - jq
 
 runcmd:
   - [localedef, -i, en_US, -c, -f, UTF-8, -A, /usr/share/locale/locale.alias, en_US.UTF-8]


### PR DESCRIPTION
Windows jobs run ceph clusters in Ubuntu VMs. This change ensures that the jq binary used by vstart will be available.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>