### PR TITLE
ceph-windows: Fixed txt event log dump

### DIFF
--- a/scripts/ceph-windows/collect-event-logs.ps1
+++ b/scripts/ceph-windows/collect-event-logs.ps1
@@ -26,7 +26,13 @@ function DumpEventLogTxt($path){
         $logName = $logName.replace(" ","-").replace("/", "-").replace("\", "-")
         Write-Output "exporting "$i.LogName" as "$logName
         $logFile = Join-Path $path $logName
-        Get-WinEvent -FilterHashtable @{LogName=$i.LogName;StartTime=$(Get-Date).AddHours(-24)} | Format-Table -AutoSize -Wrap > $logFile
+        Get-WinEvent `
+            -ErrorAction SilentlyContinue `
+            -FilterHashtable @{
+                LogName=$i.LogName;
+                StartTime=$(Get-Date).AddHours(-6)
+            } | `
+            Format-Table -AutoSize -Wrap > $logFile
     }
 }
 


### PR DESCRIPTION
The event log collection script was throwing an error if no event logs could be found for the filters applied. 
Therefore, the Get-WinEvent call in DumpEventLogTxt has been modified to silently continue if such case arises.