### PR TITLE
windows: fix log collection

### DIFF
--- a/scripts/ceph-windows/collect-event-logs.ps1
+++ b/scripts/ceph-windows/collect-event-logs.ps1
@@ -5,7 +5,7 @@ param (
     [switch]$CleanupEventLog = $false
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = "Ignore"
 
 function DumpEventLogEvtx($path){
     foreach ($i in (Get-WinEvent -ListLog * |  ? {$_.RecordCount -gt 0 })) {
@@ -15,7 +15,7 @@ function DumpEventLogEvtx($path){
         $logFile = Join-Path $path $logName
         & $Env:WinDir\System32\wevtutil.exe epl $i.LogName $logFile
         if ($LASTEXITCODE) {
-            Throw "Failed to export $($i.LogName) to $logFile"
+            Write-Output "Failed to export $($i.LogName) to $logFile"
         }
     }
 }
@@ -27,7 +27,7 @@ function DumpEventLogTxt($path){
         Write-Output "exporting "$i.LogName" as "$logName
         $logFile = Join-Path $path $logName
         Get-WinEvent `
-            -ErrorAction SilentlyContinue `
+            -ErrorAction "Ignore" `
             -FilterHashtable @{
                 LogName=$i.LogName;
                 StartTime=$(Get-Date).AddHours(-6)
@@ -40,7 +40,7 @@ function ClearEventLog(){
     foreach ($i in (Get-WinEvent -ListLog * |  ? {$_.RecordCount -gt 0 })) {
         & $Env:WinDir\System32\wevtutil.exe cl $i.LogName
         if ($LASTEXITCODE) {
-            Throw "Failed to clear $($i.LogName) from the event log"
+            Write-Output "Failed to clear $($i.LogName) from the event log"
         }
     }
 }
@@ -56,3 +56,5 @@ if ($IncludeEvtxFiles) {
 if ($CleanupEventLog) {
     ClearEventLog
 }
+
+Write-Output "Successfully collected Windows event logs."

--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -111,3 +111,5 @@ else
     SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsFioTest --iterations 4
     SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsStampTest --iterations 4
 fi
+
+echo "Windows tests succeeded."


### PR DESCRIPTION
The "Get-WinEvent" command used to retrieve Windows event log messages can fail if the specified log has no entries.

We're using the "SilentlyContinue" action to avoid erroring out in such cases.

However, the script still terminates abruptly while collecting logs. For this reason, we'll use the "Ignore" error action instead. We'd rather not have test failures just because we failed to retrieve some Windows event log entries.

Unlike "SilentlyContinue", "Ignore" doesn't populate the global $Error variable, which may be used when running the script remotely.

While at it, we're adding some log messages at the end of the "run_tests" and "collect-event-logs.ps1" scripts.