### PR TITLE
ceph-windows: Re-enable Windows event logs collection

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -76,12 +76,9 @@ function collect_artifacts() {
     scp_download /ProgramData/ceph/logs $WORKSPACE/artifacts/client/logs
     cp $CEPH_WINDOWS_CONF $WORKSPACE/artifacts/client
     ssh_exec /wnbd/wnbd-client.exe version
-    # Event log collection is temporarily disabled. The script terminates
-    # abruptly even if the error action is set to "ignore".
-    #
-    # ssh_exec curl.exe --retry-max-time 30 --retry 10 -L -o /workspace/collect-event-logs.ps1 $COLLECT_EVENT_LOGS_SCRIPT_URL
-    # ssh_exec powershell.exe /workspace/collect-event-logs.ps1 -LogDirectory /workspace/eventlogs
-    # scp_download /workspace/eventlogs $WORKSPACE/artifacts/client/eventlogs
+    ssh_exec curl.exe --retry-max-time 30 --retry 10 -L -o /workspace/collect-event-logs.ps1 $COLLECT_EVENT_LOGS_SCRIPT_URL
+    SSH_TIMEOUT=30m ssh_exec powershell.exe /workspace/collect-event-logs.ps1 -LogDirectory /workspace/eventlogs
+    scp_download /workspace/eventlogs $WORKSPACE/artifacts/client/eventlogs
 }
 trap collect_artifacts EXIT
 


### PR DESCRIPTION
Cleanup `collect-event-logs.ps1` script:

* Rely on the default `$ErrorActionPreference` value (which is `Continue`).
* Add new function `SanitizeName` that it's used to sanitize the name of the log files.
  The function code existed before, but it was duplicated in the script.
* General PowerShell code cleanup.

The Windows event log collection was failing due `ssh_exec` abruptly
closing the connection, because the default timeout of `30 secs` was exceeded.

This change re-enables the Windows event log collection by increasing the
SSH timeout to `30 minutes`.

Additionally, the `ssh_exec` function is updated to print an appropriate
error message when SSH timeout is exceeded.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>