### PR TITLE
utils: fix ssh_exec function

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1690,7 +1690,7 @@ function ssh_exec() {
         if [[ $EXIT_CODE -eq 124 ]]; then
             echo "ERROR: ssh command timed out"
         fi
-        exit $EXIT_CODE
+        return $EXIT_CODE
     }
 }
 


### PR DESCRIPTION
We need to use `return` inside the function to properly return the exit code of the function.

Using `exit` will abruptly exit the entire script, which is not what we want.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>