### PR TITLE
windows: install python3-bcrypt dependency

### DIFF
--- a/scripts/ceph-windows/setup_libvirt_ubuntu_vm
+++ b/scripts/ceph-windows/setup_libvirt_ubuntu_vm
@@ -36,6 +36,7 @@ packages:
   - locales
   - rsync
   - jq
+  - python3-bcrypt
 
 runcmd:
   - [localedef, -i, en_US, -c, -f, UTF-8, -A, /usr/share/locale/locale.alias, en_US.UTF-8]


### PR DESCRIPTION
The Windows job is failing because of a missing mgr dependency.

We'll update the setup script, ensuring that python3-bcrypt is installed.