### PR TITLE
ceph-release-rpm: add CentOS 9 build

### DIFF
--- a/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
+++ b/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
@@ -38,6 +38,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           values:
             - centos7
             - centos8
+            - centos9
 
     builders:
       - shell:


### PR DESCRIPTION
Builds CentOS 9 build for ceph-release rpm.