### PR TITLE
Use createrepo_c, and change order of signing operations to avoid invalid repomd.xml sigs

### DIFF
--- a/scripts/sign-rpms
+++ b/scripts/sign-rpms
@@ -70,15 +70,7 @@ for release in "${releases[@]}"; do
             fi
           done
 
-          # now sign the repomd.xml files
-          if [[ $update_repo -eq 1 ]]; then
-            for repomd in `find -name repomd.xml`; do
-              echo "signing repomd: $repomd"
-              gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --detach-sign --armor -u $keyid $repomd
-            done
-          fi
-
-          # finally, update the repo metadata
+          # now, update the repo metadata
           if [[ $update_repo -eq 1 ]]; then
             for directory in $(ls $path/$distro/$distro_version); do
               cd $directory
@@ -93,6 +85,14 @@ for release in "${releases[@]}"; do
                 createrepo_c --compatibility --no-database .
               fi
               cd -
+            done
+          fi
+
+          # finally, sign the repomd.xml files
+          if [[ $update_repo -eq 1 ]]; then
+            for repomd in `find -name repomd.xml`; do
+              echo "signing repomd: $repomd"
+              gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --detach-sign --armor -u $keyid $repomd
             done
           fi
 

--- a/scripts/sign-rpms
+++ b/scripts/sign-rpms
@@ -84,7 +84,14 @@ for release in "${releases[@]}"; do
               cd $directory
               # use the --no-database to workaround the large dbg packages issues
               # https://tracker.ceph.com/issues/39387
-              createrepo --no-database .
+              # later debian no longer has the (Python) createrepo; it's been replaced
+              # by a mostly-compatible C version called createrepo_c.  Use it if we can't
+              # find createrepo.
+              if command -v createrepo >/dev/null 2>&1 ; then
+                createrepo --no-database .
+              else
+                createrepo_c --compatibility --no-database .
+              fi
               cd -
             done
           fi


### PR DESCRIPTION
I couldn't validate repomd.xml.asc against repomd.xml without swapping these stanzas.