### PR TITLE
sign-rpms: remove GPG_PASSPHRASE

### DIFF
--- a/scripts/sign-rpms
+++ b/scripts/sign-rpms
@@ -34,11 +34,6 @@ distros=( centos rhel )
 # are the same values used by the build system.
 distro_versions=( 7 8 9 )
 
-# To unlock the gpg keys for the current run, it is requested over STDIN as
-# a password and later passed into GPG directly as a variable.
-read -s -p "Key Passphrase: " GPG_PASSPHRASE
-echo
-
 for release in "${releases[@]}"; do
   for distro in  "${distros[@]}"; do
     for distro_version in  "${distro_versions[@]}"; do
@@ -64,7 +59,7 @@ for release in "${releases[@]}"; do
                 --define "_gpg_name '$keyid'" \
                 --define '_signature gpg' \
                 --define '__gpg_check_password_cmd /bin/true' \
-                --define "__gpg_sign_cmd %{__gpg} gpg --no-tty --yes --batch --no-armor --passphrase '$GPG_PASSPHRASE' --no-secmem-warning -u "%{_gpg_name}" --sign --detach-sign --output %{__signature_filename} %{__plaintext_filename}" \
+                --define "__gpg_sign_cmd %{__gpg} gpg --no-tty --yes --batch --no-armor --no-secmem-warning -u "%{_gpg_name}" --sign --detach-sign --output %{__signature_filename} %{__plaintext_filename}" \
                 --resign "$rpm_path"
 
             fi
@@ -92,7 +87,7 @@ for release in "${releases[@]}"; do
           if [[ $update_repo -eq 1 ]]; then
             for repomd in `find -name repomd.xml`; do
               echo "signing repomd: $repomd"
-              gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --detach-sign --armor -u $keyid $repomd
+              gpg --batch --yes --detach-sign --armor -u $keyid $repomd
             done
           fi
 


### PR DESCRIPTION
We don't need this argument, and I'm not sure it ever worked.

I entered the passphrase (Nitrokey PIN) into `gpg-agent` prior to running this script, and that seems sufficient.