### PR TITLE
ceph-dev-setup: save only 25 builds (rather than 2 weeks)

### DIFF
--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -8,8 +8,7 @@
     concurrent: true
     properties:
       - build-discarder:
-          days-to-keep: 14
-          artifact-days-to-keep: 14
+          num-to-keep: 25
       - github:
           url: https://github.com/ceph/ceph
       - copyartifact:


### PR DESCRIPTION
ceph-dev-setup is using 67G out of the 200G on /var/lib/jenkins, far larger than any other job.  There's no reason to save all these jobs.