### PR TITLE
ceph-api-nightly, ceph-dashboard-cephadm-e2e-nightly: stop emails

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -94,9 +94,6 @@
       - ansicolor
 
     publishers:
-      - email:
-          recipients: ceph-qa@ceph.io
-
       - archive:
           artifacts: 'build/out/*.log, build/run/1/out/*.log, build/run/2/out/*.log'
           allow-empty: true

--- a/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
+++ b/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
@@ -68,8 +68,6 @@
       - ansicolor
 
     publishers:
-      - email:
-          recipients: ceph-qa@ceph.io
       - archive:
           artifacts: 'logs/**'
           allow-empty: true


### PR DESCRIPTION
Remove the email notifications from the configuration.  They're just cluttering the ceph-qa inbox and no one is acting on them.