### PR TITLE
cephadm-ansible: add el9 testing

### DIFF
--- a/cephadm-ansible-prs/build/build
+++ b/cephadm-ansible-prs/build/build
@@ -25,4 +25,7 @@ else
   ENVIRONMENT="${SCENARIO}"
 fi
 
+# Skip the following scenarios as they are not valid:
+
+[[ "$ghprbTargetBranch" == pacific && "$DISTRIBUTION" == el9 ]] ||
 "${VENV}"/tox --workdir="${TEMPVENV}" -c tox.ini -e "${ENVIRONMENT}" -r -v -- --provider=libvirt

--- a/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
+++ b/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
@@ -13,7 +13,7 @@
     worker_labels: 'vagrant && libvirt && (braggi || adami)'
     distribution:
       - el8
-      # - el9
+      - el9
     scenario:
       - functional
     jobs:


### PR DESCRIPTION
el9 RPMs weren't available so `el9` distribution was left commented out so far. Given that we now have el9 packages, let's add el9 testing.