### PR TITLE
scripts/build_utils.sh: pin urllib3 and requests

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -237,6 +237,11 @@ install_python_packages () {
         # install packages from the local pip cache, ignoring pypi
         $venv/pip install --upgrade --exists-action=i --find-links="file://$PIP_SDIST_INDEX" --no-index $package
     done
+
+    # See https://tracker.ceph.com/issues/59652
+    echo "Pinning urllib3 and requests"
+    $venv/pip install "urllib3<2.0.0"
+    $venv/pip install "requests<2.30.0"
 }
 
 make_chacractl_config () {


### PR DESCRIPTION
The latest version of chacractl requires requests-toolbelt==0.9.1. This is not compatible with the latest version of urllib3, which dropped support for appengine.

We need to pin urllib3 to an older version that still supports appengine, and requests to an older version that still supports the older urllib3 until charactl allows a higher version of requests-toolbelt.

Fixes: https://tracker.ceph.com/issues/59652
Signed-off-by: Laura Flores <lflores@redhat.com>