### PR TITLE
Fix broken jenkins-job-builder job

### DIFF
--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -9,7 +9,7 @@
 set -euxo pipefail
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "jenkins-job-builder>=3.5.0" )
+pkgs=( "dataclasses" "jenkins-job-builder>=3.5.0" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]" latest

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -163,6 +163,9 @@ install_python_packages_no_binary () {
         $venv/pip install "pip==20.3.4"
     fi
 
+    echo "Ensuring latest wheel is installed"
+    $venv/pip install -U wheel
+
     echo "Updating setuptools"
     pip_download $VENV setuptools
 
@@ -225,6 +228,9 @@ install_python_packages () {
         echo "Installing pip 20.3.4"
         $venv/pip install "pip==20.3.4"
     fi
+
+    echo "Ensuring latest wheel is installed"
+    $venv/pip install -U wheel
 
     echo "Updating setuptools"
     pip_download $venv setuptools


### PR DESCRIPTION
I'm unsure if this is exactly the right way to solve the issues I saw, but here's my rationale:

When the jjb job executes, sometimes it picks adami02, whose system python is 3.6; newer jjb versions appear to require `dataclasses`, which was new in 3.7 - a version that itself is EOL.

Other times, braggi02 gets selected. That host has 3.10, but was failing because of a lack of `wheel`.