### PR TITLE
ceph-dev-build: stop building on centos9/arm64 temporarily

### DIFF
--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -27,7 +27,7 @@
     execution-strategy:
        combination-filter: |
          DIST == AVAILABLE_DIST && ARCH == AVAILABLE_ARCH &&
-         (ARCH == "x86_64" || (ARCH == "arm64" && ["xenial", "bionic", "centos7", "centos8", "centos9"].contains(DIST)))
+         (ARCH == "x86_64" || (ARCH == "arm64" && ["xenial", "bionic", "centos7", "centos8"].contains(DIST)))
     axes:
       - axis:
           type: label-expression


### PR DESCRIPTION
2/3 builders are down.  Revert this when they're back