### PR TITLE
ceph-dev-new-build/config/definitions: give proper permission to remove a folder

### DIFF
--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -73,9 +73,10 @@
     builders:
       - shell: |
           echo "Cleaning up top-level workarea (shared among workspaces)"
+          ls -la
           sudo rm -rf dist
           rm -rf venv
-          rm -rf release
+          sudo rm -rf release
       - copyartifact:
           project: ceph-dev-new-setup
           filter: 'dist/**'


### PR DESCRIPTION
Solution for this in ceph-dev-new-build:
```
[EnvInject] - Inject global passwords.
[EnvInject] - Mask passwords that will be passed as build parameters.
Failed to evaluate name macro:org.jenkinsci.plugins.tokenmacro.MacroEvaluationException: Error processing tokens
[gigantic] $ /bin/sh -xe /tmp/jenkins6948878898411108393.sh
+ echo 'Cleaning up top-level workarea (shared among workspaces)'
Cleaning up top-level workarea (shared among workspaces)
+ sudo rm -rf dist
+ rm -rf venv
+ rm -rf release
rm: cannot remove 'release/18.0.0-4267-g48627125/ceph-18.0.0-4267-g48627125': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/version': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/ceph_18.0.0-4267-g48627125.orig.tar.gz': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/branch': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/ceph_18.0.0-4267-g48627125-1.dsc': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/other_envvars': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/ceph.spec': Permission denied
...
rm: cannot remove 'release/18.0.0-4267-g48627125/rpm/el8/BUILD/ceph-18.0.0-4267-g48627125/qa/suites/rgw/dbstore/cluster.yaml': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/rpm/el8/BUILD/ceph-18.0.0-4267-g48627125/qa/suites/rgw/dbstore/overrides.yaml': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/rpm/el8/BUILD/ceph-18.0.0-4267-g48627125/qa/suites/rgw/dbstore/s3tests-branch.yaml': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/rpm/el8/BUILD/ceph-18.0.0-4267-g48627125/qa/suites/rgw/dbstore/supported-random-distro$': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/rpm/el8/BUILD/ceph-18.0.0-4267-g48627125/qa/suites/rgw/dbstore/tasks/rgw_s3tests.yaml': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/rpm/el8/BUILD/ceph-18.0.0-4267-g48627125/qa/suites/rgw/dbstore/tasks/.qa': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/rpm/el8/BUILD/ceph-18.0.0-4267-g48627125/qa/suites/rgw/dbstore/.qa': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/rpm/el8/BUILD/ceph-18.0.0-4267-g48627125/qa/suites/rgw/hadoop-s3a/%': Permission denied
rm: cannot remove 'release/18.0.0-4267-g48627125/rpm/el8/BUILD/ceph-18.0.0-4267-g48627125/qa/suites/rgw/hadoop-s3a/clusters/fixed-2.yaml': Permission denied
```

Also add a line to list ownership before removing folders.

Signed-off-by: Laura Flores <lflores@redhat.com>