### PR TITLE
ceph-release-rpm build script missing space before =

### DIFF
--- a/ceph-release-rpm/build/build
+++ b/ceph-release-rpm/build/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 HOST=$(hostname --short)
 echo "Building on ${HOST}"
@@ -33,7 +33,7 @@ if [ "$target" = "centos8" ] ; then
     target=el8
     chacra_baseurl="ceph-release/${chacra_ref}/HEAD/centos/8"
 fi
-if [ "$target"= "centos9" ] ; then
+if [ "$target" = "centos9" ] ; then
     target=el9
     chacra_baseurl="ceph-release/${chacra_ref}/HEAD/centos/9"
 fi


### PR DESCRIPTION
This causes a syntax error.  Also, the script didn't have -e set, so the error went unnoticed