### PR TITLE
ceph-dev-trigger/config/definitions: don't build crimson for pacific

### DIFF
--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -79,7 +79,6 @@
                     DISTROS=focal bionic centos7 centos8 leap15
       # build pacific on:
       # default: focal bionic centos8 leap15
-      # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*pacific.*
@@ -96,12 +95,6 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal bionic centos8 leap15
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=crimson
       # build quincy on:
       # default: focal centos8 leap15
       # crimson: centos8


### PR DESCRIPTION
Crimson changes will not be backported to pacific, so it doesn't make sense to keep building it.