### PR TITLE
ceph-dev-cron, ceph-dev-new-trigger: don't build crimson for pacific

### DIFF
--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -40,7 +40,6 @@
     builders:
       # build pacific on:
       # default: focal bionic centos8 leap15
-      # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*pacific.*
@@ -57,13 +56,6 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal bionic centos8 leap15
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=crimson
-                    ARCHS=x86_64
       # build quincy on:
       # default: focal centos8 centos9 leap15
       # crimson: centos8

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -101,7 +101,6 @@
                     DISTROS=focal bionic centos7 centos8 leap15
       # build pacific on:
       # default: focal bionic centos8
-      # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*pacific.*
@@ -118,13 +117,6 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal bionic centos8 windows
-                - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=crimson
-                    ARCHS=x86_64
       # build quincy on:
       # default: focal centos8 centos9 leap15
       # crimson: centos8


### PR DESCRIPTION
Followup to https://github.com/ceph/ceph-build/pull/2142; removes crimson pacific from additional build jobs.