### PR TITLE
ceph-dev-new-setup/config/definitions: increase timeout for cloning ci repo

### DIFF
--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -29,6 +29,7 @@
           credentials-id: 'jenkins-build'
           branches:
             - $BRANCH
+          timeout: 20
           skip-tag: true
           wipe-workspace: true
 


### PR DESCRIPTION
Might help address failures like
```
fatal: fetch-pack: invalid index-pack output`
```
and
```
error: rev-list died of signal 15
error: github.com:ceph/ceph-ci.git did not send all necessary objects
```