### PR TITLE
kernel: enable centos9 build

### DIFF
--- a/kernel/config/definitions/kernel.yml
+++ b/kernel/config/definitions/kernel.yml
@@ -17,7 +17,7 @@
       - string:
           name: DISTROS
           description: "A list of distros to build for. Available options are: centos9, centos8, jammy, focal, bionic, xenial, and trusty"
-          default: "centos8 trusty xenial bionic focal jammy"
+          default: "centos9 centos8 trusty xenial bionic focal jammy"
 
       - string:
           name: ARCHS


### PR DESCRIPTION
commit 4b61a221e4e2f53dc7df3137fc34f418c3f3b879 just forgot to enable it after adding centos9.