### PR TITLE
ansible: remove vault_password_file; jenkins-build doesn't have one

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,7 +1,6 @@
 [defaults]
 callback_plugins = callbacks
 retry_files_enabled = False
-vault_password_file = ~/.vault_pass.txt
 
 [ssh_connection]
 pipelining=True


### PR DESCRIPTION
Jenkins also uses ansible for some builds, and this config item breaks the run, because although the ansible secret isn't needed, if you configure it, ansible requires it.  <sigh>