### PR TITLE
windows: log available disk space

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -54,6 +54,9 @@ function collect_artifacts() {
 
     SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec ./ceph/build/bin/ceph status
     SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec free -h
+    SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec df -h
+    SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec \
+        "du -sh ./ceph-vstart/*"
 
     SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec \
         "journalctl -b > /tmp/journal"


### PR DESCRIPTION
Some Windows test jobs have failed after the OSDs ran out of disk space. Those jobs use Linux VMs with 128GBs of storage and run 3 OSDs, each having 15GB.

In order to get a better picture, we'll log the disk space usage, including the vstart directory contents.