### PR TITLE
ceph-container-flake8: fix test

### DIFF
--- a/ceph-container-flake8/build/build
+++ b/ceph-container-flake8/build/build
@@ -21,7 +21,7 @@ function check(){
     while read -r filename; do
         pushd "$(dirname "$filename")"
         file=$(basename "$filename")
-        sudo docker run --rm -v "$workspace"/ceph-container/tox.ini:/tox.ini:z -v "$(pwd)"/"$file":/"$file":z eeacms/flake8 /"$file"
+        sudo docker run --rm -v "$workspace"/ceph-container/tox.ini:/tox.ini:z -v "$(pwd)"/"$file":/code/"$file":z eeacms/flake8
         popd
     done
     return $?


### PR DESCRIPTION
Looks like this job has never worked.
The file should be bind-mounted in /code, not in / There's no need to pass arguments, the entrypoint automatically scan /code and run flake8 against any present files.