### PR TITLE
Update jenkins-builder support

### DIFF
--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -17,7 +17,7 @@
     - api_uri: 'https://jenkins.ceph.com'
     - jenkins_credentials_uuid: 'jenkins-build'
     - nodename: '{{ nodename }}'
-    - labels: "{{ jenkins_labels[ansible_hostname] }}"
+    - labels: "{{ jenkins_labels[inventory_hostname] }}"
     - grant_sudo: true
     - osc_user: 'username'
     - osc_pass: 'password'

--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -645,7 +645,22 @@
             url: https://ftp-master.debian.org/keys/release-10.asc
             keyring: /etc/apt/trusted.gpg
             state: present
+
+        - name: Add the Debian Bookworm Key
+          apt_key:
+           id: 350947F8
+           url: https://ftp-master.debian.org/keys/archive-key-12.asc
+           keyring: /etc/apt/trusted.gpg
+           state: present
+
+        - name: Add the Debian Security Bookworm Key
+          apt_key:
+            id: AEC0A8F0
+            url: https://ftp-master.debian.org/keys/archive-key-12-security.asc
+            keyring: /etc/apt/trusted.gpg
+            state: present
       when: ansible_os_family == "Debian"
+      tags: debian-keys
 
     ## VAGRANT PLUGIN TASKS
     - name: Install vagrant-libvirt plugin

--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -17,7 +17,7 @@
     - api_uri: 'https://jenkins.ceph.com'
     - jenkins_credentials_uuid: 'jenkins-build'
     - nodename: '{{ nodename }}'
-    - labels: "{{ jenkins_labels[inventory_hostname] }}"
+    - label: "{{ jenkins_labels[inventory_hostname] }}"
     - grant_sudo: true
     - osc_user: 'username'
     - osc_pass: 'password'
@@ -896,7 +896,7 @@
         # mapping from Jenkins back to whatever service created the current
         # node
         name: "{{ ansible_default_ipv4.address }}+{{ nodename }}"
-        labels: "{{ labels | default('') }}"
+        label: "{{ label | default('') }}"
         host: "{{ ansible_default_ipv4.address }}"
         credentialsId: "{{ jenkins_credentials_uuid }}"
         remoteFS: '/home/{{ jenkins_user }}/build'
@@ -916,7 +916,7 @@
             # mapping from Jenkins back to whatever service created the current
             # node
             name: "{{ ansible_default_ipv4.address }}+{{ ansible_hostname }}"
-            labels: "{{ labels }}"
+            label: "{{ label }}"
             host: "{{ ansible_default_ipv4.address }}"
             credentialsId: "{{ jenkins_credentials_uuid }}"
             launcher: 'hudson.slaves.JNLPLauncher'

--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -322,14 +322,14 @@
     - set_fact:
         permanent: true
       with_items: "{{ ansible_all_ipv4_addresses }}"
-      when: "item.startswith('172.21.')"
+      when: "item.startswith('172.21.') or item.startswith('8.43')"
       tags: always
 
     ## Let's make sure nodename gets set using our Sepia hostnames if the builder's in Sepia
     - set_fact:
         nodename: "{{ ansible_hostname }}"
       with_items: "{{ ansible_all_ipv4_addresses }}"
-      when: "item.startswith('172.21.')"
+      when: "item.startswith('172.21.') or item.startswith('8.43')"
       tags: always
 
     ## EPHEMERAL SLAVE TASKS

--- a/ansible/library/jenkins_node
+++ b/ansible/library/jenkins_node
@@ -48,9 +48,9 @@ options:
     required: false
     default: null
 
-  labels:
+  label:
     description:
-      - Labels to associate with a node, like "amd64" or "python"
+      - List of labels in a string, space-separated, to associate with a node, like "amd64" or "python"
     required: false
     default: null
 
@@ -144,9 +144,6 @@ def maybe_convert_string_to_list(v):
 
 def sanitize_update_params(kw):
 
-    def translate_labels(labels):
-        return 'label', ' '.join(labels)
-
     # this list may be smaller than it needs to be, but these are
     # the only ones I want to support for now
     VALID_UPDATE_PARAMS = {
@@ -154,12 +151,11 @@ def sanitize_update_params(kw):
         'name': None,
         'remoteFS': None,
         'numExecutors': None,
-        'labels': translate_labels,
+        'label': None,
     }
     update_kws = dict()
     invalid = list()
     for k, v in kw.items():
-        v = maybe_convert_string_to_list(v)
         if k not in VALID_UPDATE_PARAMS:
             invalid.append(k)
         else:
@@ -191,6 +187,9 @@ def create_or_modify(uri, user, password, name, **kw):
 
         j.reconfig_node(name, new_xconfig)
     else:
+        if 'label' in params:
+            params['labels'] = params['label']
+            params.pop('label')
         j.create_node(name, launcher_params=launcher_params, **params)
         if not j.node_exists(name):
             return False, "Failed to create node '%s'." % name
@@ -234,7 +233,7 @@ def main():
             name=dict(required=True),
             executors=dict(required=False, default=2),
             description=dict(required=False, default=None),
-            labels=dict(required=False, default=None),
+            label=dict(required=False, default=None),
             host=dict(required=False, default=None),
             credentialsId=dict(required=False, default=None),
             launcher=dict(required=False, default='hudson.plugins.sshslaves.SSHLauncher'),
@@ -254,7 +253,7 @@ def main():
     name = module.params['name']
     executors = module.params['executors']
     description = module.params.get('description')
-    labels = module.params.get('labels')
+    label = module.params.get('label')
     exclusive = module.params.get('exclusive', False)
     host = module.params.get('host')
     remoteFS = module.params.get('remoteFS')
@@ -284,7 +283,7 @@ def main():
             name,
             executors=executors,
             description=description,
-            labels=labels,
+            label=label,
             exclusive=exclusive,
             host=host,
             credentialsId=credentialsId,


### PR DESCRIPTION
Several changes bundled together here: smoothing the jenkins_node library module, adding bookworm deb signing keys, changing some conventions in the jenkins-builder inventory entries (see also https://github.com/ceph/ceph-sepia-secrets/pull/836)