### PR TITLE
ceph-container-flake8: migrate to alpine/flake8 image

### DIFF
--- a/ceph-container-flake8/build/build
+++ b/ceph-container-flake8/build/build
@@ -21,7 +21,7 @@ function check(){
     while read -r filename; do
         pushd "$(dirname "$filename")"
         file=$(basename "$filename")
-        sudo docker run --rm -v "$workspace"/ceph-container/tox.ini:/tox.ini:z -v "$(pwd)"/"$file":/code/"$file":z eeacms/flake8
+        sudo docker run --rm -v "$(pwd)"/"$file":/apps/"$file":z docker.io/alpine/flake8 "$file"
         popd
     done
     return $?


### PR DESCRIPTION
the current image is old and uses a flake8 build based on py2.7.

It means we are checking python 3.x code with a python 2.7 version of flake8. That doesn't work very well.