### PR TITLE
nfs-ganesha: pin the daily build to V5.5

### DIFF
--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -38,7 +38,7 @@
       - string:
           name: NFS_GANESHA_BRANCH
           description: "The git branch (or tag) to build"
-          default: "next"
+          default: "V5.5"
 
       - string:
           name: NFS_GANESHA_DEBIAN_BRANCH


### PR DESCRIPTION
Instead of just building the tip of whatever is in the "next" branch, let's pin the daily nfs-ganesha build to the latest stable tag: V5.5.