### PR TITLE
windows: use "net.exe start" instead of Start-Service

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -41,7 +41,7 @@ scp_upload $CEPH_KEYRING /ProgramData/ceph/keyring
 SSH_TIMEOUT=5m scp_upload $WORKSPACE/ceph.zip /ceph.zip
 SSH_TIMEOUT=10m ssh_exec powershell.exe "\$ProgressPreference='SilentlyContinue'; Expand-Archive -Path /ceph.zip -DestinationPath / -Force"
 ssh_exec powershell.exe "New-Service -Name ceph-rbd -BinaryPathName 'c:\ceph\rbd-wnbd.exe service'"
-ssh_exec powershell.exe Start-Service -Name ceph-rbd
+ssh_exec powershell.exe net.exe start ceph-rbd
 
 #
 # Collect artifacts on script exit


### PR DESCRIPTION
The "Start-Serice" command doesn't really say why the service could not be started:

```
  Start-Service : Service 'ceph-rbd (ceph-rbd)' cannot be started
  due to the following error: Cannot start service
```

We'll use the "net.exe start" command instead, which provides additional information.