### PR TITLE
windows: add Ceph dir to Windows Defender exclusion list

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -40,6 +40,7 @@ scp_upload $CEPH_KEYRING /ProgramData/ceph/keyring
 #
 SSH_TIMEOUT=5m scp_upload $WORKSPACE/ceph.zip /ceph.zip
 SSH_TIMEOUT=10m ssh_exec powershell.exe "\$ProgressPreference='SilentlyContinue'; Expand-Archive -Path /ceph.zip -DestinationPath / -Force"
+ssh_exec powershell.exe "Add-MpPreference -ExclusionPath 'C:\ceph'"
 ssh_exec powershell.exe "New-Service -Name ceph-rbd -BinaryPathName 'c:\ceph\rbd-wnbd.exe service'"
 ssh_exec powershell.exe net.exe start ceph-rbd
 


### PR DESCRIPTION
We're getting occasional false positives from Windows Defender. For this reason, we'll add the Ceph dir to the exclusion list.

```
  ERROR - Test exception: [WinError 225] Operation did not complete
  successfully because the file contains a virus or potentially unwanted
  software. Total exceptions: 22

   Windows Defender Antivirus has taken action to protect this machine from
   malware or other potentially unwanted software.
    For more information please see the following:
   https://go.microsoft.com/fwlink/?linkid=37020&name=Trojan:Win32/Bearfoos.A!m
   l&threatid=2147731250&enterprise=0
        Name: Trojan:Win32/Bearfoos.A!ml
        ID: 2147731250
        Severity: Severe
        Category: Trojan
        Path: file:_C:\ceph\rbd-wnbd.exe
        Detection Origin: Local machine
        Detection Type: Concrete
        Detection Source: Real-Time Protection
        User: NT AUTHORITY\SYSTEM
        Process Name: C:\Program Files\Python311\python.exe
        Action: Quarantine
        Action Status:  No additional actions required
        Error Code: 0x80508023
        Error description: The program could not find the malware and other
                       potentially unwanted software on this device.
```