### PR TITLE
kernel: unbreak RPM builds

### DIFF
--- a/kernel/build/build_rpm
+++ b/kernel/build/build_rpm
@@ -24,21 +24,18 @@ env
 echo "*****"
 
 # Clean rpmbuild structure
-rm -rf ~/rpmbuild/
+rm -rf ./rpmbuild/
 
 # Build the rpms
 echo "Building RPMs"
 make -j$(getconf _NPROCESSORS_ONLN) binrpm-pkg
 
-# Make sure we execute at the top level directory
-cd "$WORKSPACE"
-
 [ "$FORCE" = true ] && chacra_flags="--force" || chacra_flags=""
 
 if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
-    find ~/rpmbuild/ | egrep '\.rpm$' | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/$ARCH/
-    PACKAGE_MANAGER_VERSION=$(rpm --queryformat '%{VERSION}-%{RELEASE}\n' -qp $(find ~/rpmbuild/ | egrep "\.$ARCH\.rpm" | head -1))
+    find ./rpmbuild/ | egrep '\.rpm$' | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/$ARCH/
+    PACKAGE_MANAGER_VERSION=$(rpm --queryformat '%{VERSION}-%{RELEASE}\n' -qp $(find ./rpmbuild/ | egrep "\.$ARCH\.rpm" | head -1))
 
     # write json file with build info
     cat > $WORKSPACE/repo-extra.json << EOF

--- a/kernel/build/setup
+++ b/kernel/build/setup
@@ -32,6 +32,7 @@ export LC_ALL=C # the following is vulnerable to i18n
 if test -f /etc/redhat-release ; then
     $SUDO yum install -y elfutils-libelf-devel  # for ORC unwinder
     $SUDO yum install -y flex bison  # for Kconfig
+    $SUDO yum install -y dwarves
 
     # Set vars for shaman status updating
     get_rpm_dist
@@ -43,6 +44,7 @@ if which apt-get > /dev/null ; then
     $SUDO apt-get install -y lsb-release
     $SUDO apt-get install -y libelf-dev  # for ORC unwinder
     $SUDO apt-get install -y flex bison  # for Kconfig
+    $SUDO apt-get install -y dwarves
 
     # Set vars for shaman status updating
     DISTRO=$(lsb_release -si)


### PR DESCRIPTION
A bunch of kbuild changes went into 6.6-rc1.  In particular, the location of rpmbuild structure has changed and BuildRequires clauses are now applied universally so we need dwarves to be installed.