### PR TITLE
kernel-trigger: increase clone timeout

### DIFF
--- a/kernel-trigger/config/definitions/kernel-trigger.yml
+++ b/kernel-trigger/config/definitions/kernel-trigger.yml
@@ -61,7 +61,7 @@
               <hudson.plugins.git.extensions.impl.CloneOption>
                 <shallow>false</shallow>
                 <noTags>true</noTags>
-                <timeout>20</timeout>
+                <timeout>120</timeout>
               </hudson.plugins.git.extensions.impl.CloneOption>
               <hudson.plugins.git.extensions.impl.CheckoutOption>
                 <timeout>20</timeout>


### PR DESCRIPTION
From time to time Jenkins kills "git index-pack" due to a timeout:

 > git fetch --no-tags --progress -- https://github.com/ceph/ceph-client.git +refs/heads/*:refs/remotes/origin/* # timeout=20
ERROR: Timeout after 20 minutes
...
remote: Enumerating objects: 9769655, done.
remote: Counting objects:   0% (1/368573)
...
remote: Counting objects: 100% (368573/368573), done.
remote: Compressing objects:   0% (1/73615)
...
remote: Compressing objects: 100% (73615/73615), done.
Receiving objects:   0% (1/9769655)
...
Receiving objects:  99% (9762992/9769655), 2.61 GiB | 19.22 MiB/s
remote: Total 9769655 (delta 294178), reused 368051 (delta 293885), pack-reused 9401082
Receiving objects: 100% (9769655/9769655), 2.62 GiB | 19.00 MiB/s
Receiving objects: 100% (9769655/9769655), 2.63 GiB | 19.17 MiB/s, done.
Resolving deltas:   0% (0/8264128)
...
Resolving deltas:  15% (1312818/8264128)
error: index-pack died of signal 15
fatal: index-pack failed

This step is CPU intensive, but it's very hard to tell what was going on the worker node at the time and what made it slow.  As kernel builds are pretty infrequent, just bump the timeout drastically.