### PR TITLE
ceph-build-pull-requests/build/build: pin ansible to 8.4.0

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -3,7 +3,7 @@
 set -e
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "ansible" "jenkins-job-builder>=3.5.0" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" )
+pkgs=( "ansible<=8.4.0" "jenkins-job-builder>=3.5.0" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"


### PR DESCRIPTION
ansible 8.5.0 includes a change to ansible-galaxy that breaks the installation of sensu and rabbitmq:

https://github.com/ansible/ansible/issues/82073

Work around that by pinning ansible to 8.4.0

Fixes: https://tracker.ceph.com/issues/63223