### PR TITLE
ceph-build-pull-requests: rather than ansible, pin ansible-core

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -3,7 +3,7 @@
 set -e
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "ansible<=8.4.0" "jenkins-job-builder>=3.5.0" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" )
+pkgs=( "ansible" "ansible-core<=2.15.4" "jenkins-job-builder>=3.5.0" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"


### PR DESCRIPTION
Last change pinned ansible to 8.4.0 to workaround a bug.  The buggy code is actually in ansible-core, so pin that instead. See https://github.com/ceph/ceph-build/pull/2173