### PR TITLE
nfs-ganesha: pin the daily build to V5.7

### DIFF
--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -38,7 +38,7 @@
       - string:
           name: NFS_GANESHA_BRANCH
           description: "The git branch (or tag) to build"
-          default: "V5.5"
+          default: "V5.7"
 
       - string:
           name: NFS_GANESHA_DEBIAN_BRANCH


### PR DESCRIPTION
The latest upstream nfs-ganesha 5 tag was released. Bump from V5.5 to V5.7.