### PR TITLE
enable centos9 builds for ceph-iscsi, tcmu-runner

### DIFF
--- a/ceph-iscsi/config/definitions/ceph-iscsi.yml
+++ b/ceph-iscsi/config/definitions/ceph-iscsi.yml
@@ -14,8 +14,8 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: centos7, centos8"
-          default: "centos7 centos8"
+          description: "A list of distros to build for. Available options are: centos7, centos8, centos9"
+          default: "centos7 centos8 centos9"
 
       - string:
           name: ARCHS
@@ -37,7 +37,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
     execution-strategy:
        combination-filter: |
          DIST == AVAILABLE_DIST && ARCH == AVAILABLE_ARCH &&
-         (ARCH == "x86_64" || (ARCH == "arm64" && ["centos7", "centos8"].contains(DIST)))
+         (ARCH == "x86_64" || (ARCH == "arm64" && ["centos7", "centos8", "centos9"].contains(DIST)))
     axes:
       - axis:
           type: label-expression
@@ -55,6 +55,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           values:
             - centos7
             - centos8
+            - centos9
       - axis:
           type: dynamic
           name: DIST

--- a/tcmu-runner/build/build_rpm
+++ b/tcmu-runner/build/build_rpm
@@ -86,9 +86,10 @@ echo "\"\"\"" >> tcmu-runner.cfg
 cat tcmu-runner.cfg
 
 ## Build the binaries with mock
+# disable 'glfs' because centos9 packages aren't available
 echo "Building RPMs"
-sudo mock --verbose -r tcmu-runner.cfg --scrub=all
-sudo mock --verbose -r tcmu-runner.cfg --resultdir=$WORKSPACE/dist/RPMS/ ${SRPM} || ( tail -n +1 $WORKSPACE/dist/RPMS/{root,build}.log && exit 1 )
+sudo mock --verbose --without glfs -r tcmu-runner.cfg --scrub=all
+sudo mock --verbose --without glfs -r tcmu-runner.cfg --resultdir=$WORKSPACE/dist/RPMS/ ${SRPM} || ( tail -n +1 $WORKSPACE/dist/RPMS/{root,build}.log && exit 1 )
 
 ## Upload the created RPMs to chacra
 chacra_endpoint="tcmu-runner/${BRANCH}/${GIT_COMMIT}/${DISTRO}/${RELEASE}"

--- a/tcmu-runner/config/definitions/tcmu-runner.yml
+++ b/tcmu-runner/config/definitions/tcmu-runner.yml
@@ -24,8 +24,8 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: centos7, centos8"
-          default: "centos7 centos8"
+          description: "A list of distros to build for. Available options are: centos7, centos8, centos9"
+          default: "centos7 centos8 centos9"
 
       - string:
           name: ARCHS
@@ -47,7 +47,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
     execution-strategy:
        combination-filter: |
          DIST == AVAILABLE_DIST && ARCH == AVAILABLE_ARCH &&
-         (ARCH == "x86_64" || (ARCH == "arm64" && DIST == "centos8"))
+         (ARCH == "x86_64" || (ARCH == "arm64" && ["centos8", "centos9"].contains(DIST)))
     axes:
       - axis:
           type: label-expression
@@ -66,6 +66,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           values:
             - centos7
             - centos8
+            - centos9
       - axis:
           type: dynamic
           name: DIST


### PR DESCRIPTION
adds centos9 to AVAILABLE_DIST for these packages

the build script for nfs-ganesha looked like the only one that needed a small change to handle centos9