### PR TITLE
ceph-setup, ceph-tag: pin ansible to < 9

### DIFF
--- a/ceph-setup/build/create_tag
+++ b/ceph-setup/build/create_tag
@@ -3,7 +3,7 @@
 set -ex
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "ansible" )
+pkgs=( "ansible<9.0" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"

--- a/ceph-tag/build/build
+++ b/ceph-tag/build/build
@@ -6,7 +6,7 @@ if [ "$TAG" = false ] ; then
     echo "Assuming tagging process has succeeded before because TAG was set to false"
 else
     # the following two methods exist in scripts/build_utils.sh
-    pkgs=( "ansible" )
+    pkgs=( "ansible<9.0" )
     TEMPVENV=$(create_venv_dir)
     VENV=${TEMPVENV}/bin
     install_python_packages $TEMPVENV "pkgs[@]"


### PR DESCRIPTION
This is a temporary hack until we have time to properly test changing include to include_tasks, required by ansible 9 (include has been deprecated for some time, and now it's officially gone)