### PR TITLE
Add ceph-container-prerelease-build

### DIFF
--- a/ceph-container-prerelease-build/build/build
+++ b/ceph-container-prerelease-build/build/build
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+sudo apt-get install jq -y
+
+cd "$WORKSPACE"/ceph-container/ || exit
+TMPNAME=$(mktemp)
+
+ARCH=x86_64 \
+	TEST_BUILD_ONLY=true \
+	PRERELEASE=true \
+	FORCE_BUILD=true \
+	X86_64_FLAVORS_TO_BUILD=${X86_64_FLAVORS_TO_BUILD} \
+	AARCH64_FLAVORS_TO_BUILD="" \
+	FULL_BUILD_TAG_TMPFILE=${TMPNAME} \
+	bash -x contrib/build-ceph-base.sh
+
+imagename=$(<${TMPNAME})
+
+# strip leading path components, sub _ for : in name
+imagetag=${imagename##*/}
+imagetag=${imagetag//:/_}
+imagetag=quay.ceph.io/ceph/prerelease:${imagetag}
+
+docker tag ${imagename} ${imagetag}
+docker login --username ${QUAY_CEPH_IO_USERNAME} --password ${QUAY_CEPH_IO_PASSWORD} quay.ceph.io
+docker push ${imagetag}
+docker rmi ${imagename}

--- a/ceph-container-prerelease-build/config/JENKINS_URL
+++ b/ceph-container-prerelease-build/config/JENKINS_URL
@@ -1,0 +1,1 @@
+2.jenkins.ceph.com

--- a/ceph-container-prerelease-build/config/definitions/ceph-container-prerelease-build.yml
+++ b/ceph-container-prerelease-build/config/definitions/ceph-container-prerelease-build.yml
@@ -1,0 +1,58 @@
+- job:
+    name: ceph-container-prerelease-build
+    node: huge && trusty && x86_64
+    project-type: freestyle
+    defaults: global
+    display-name: 'ceph-container-prerelease-build: build prerelease container images and push to quay.ceph.io'
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: 1
+          num-to-keep: 1
+          artifact-days-to-keep: 1
+          artifact-num-to-keep: 1
+      - github:
+          url: https://github.com/ceph/ceph-container
+
+    parameters:
+      - string:
+          name: BRANCH
+          description: "Branch of ceph-container.git to use"
+          default: main
+
+      - string:
+          name: X86_64_FLAVORS_TO_BUILD
+          description: "x86 flavor(s) to build"
+          default: "reef,centos,8"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-container.git
+          branches:
+            - ${BRANCH}
+          browser: auto
+          basedir: "ceph-container"
+          timeout: 20
+
+    builders:
+      - shell:
+          !include-raw:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: release-build-quay-ceph-io
+              username: QUAY_CEPH_IO_USERNAME
+              password: QUAY_CEPH_IO_PASSWORD
+          - username-password-separated:
+              credential-id: download-ceph-com-prerelease
+              username: PRERELEASE_USERNAME
+              password: PRERELEASE_PASSWORD


### PR DESCRIPTION
Based on ceph-container-build-ceph-base-push-imgs, but for building containers for testing before the release is validated and committed.  Differences:

1) pulls packages from download.ceph.com/prerelease 2) does not attempt to build aarch64
3) pushes built container to quay.ceph.io:ceph/prerelease

The prerelease directories are password-protected to avoid any early exposure to in-progress builds.

This requires corresponding changes to ceph-container.git (see https://github.com/ceph/ceph-container/pull/2178)