### PR TITLE
ceph-pull-requests-arm64: only run make check (arm64) on focal and jammy

### DIFF
--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -9,7 +9,7 @@
     concurrent: true
     disabled: false
     name: ceph-pull-requests-arm64
-    node: 'arm64 && !centos7 && !centos8 && !centos9'
+    node: 'arm64 && (jammy || focal) && !centos7 && !centos8 && !centos9'
     parameters:
     - string:
         name: ghprbPullId


### PR DESCRIPTION
As the pr https://github.com/ceph/ceph/pull/40952 use build-profile to manage build deps. The feature `--build-profiles` is supported on focal and above, so let's only run make check (arm64) on focal and jammy.

Fixes: https://tracker.ceph.com/issues/64031