### PR TITLE
ceph-pull-requests-arm64: set test jobs number equal to build jobs number

### DIFF
--- a/ceph-pull-requests-arm64/build/build
+++ b/ceph-pull-requests-arm64/build/build
@@ -7,7 +7,7 @@ if [ "$DOCS_ONLY" = true ]; then
 fi
 
 n_build_jobs=$(get_nr_build_jobs)
-n_test_jobs=$(($(nproc) / 4))
+n_test_jobs=${n_build_jobs}
 export CHECK_MAKEOPTS="-j${n_test_jobs}"
 export BUILD_MAKEOPTS="-j${n_build_jobs}"
 export WITH_SEASTAR=true


### PR DESCRIPTION

On arm nodes confusa*, there are enough memory to run `nproc` build jobs, but the test jobs number `$(nproc) / 4` are too small, and make check test run pretty slow.