### PR TITLE
centos8: add yum Configs for  ceph/grpc copr https://copr.fedorainfracloud.org/coprs/ceph/grpc/

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1453,6 +1453,10 @@ setup_rpm_build_deps() {
             $SUDO yum-config-manager --enable centos-sclo-rh-testing
         fi
     elif [ "$RELEASE" = 8 ]; then
+        # for grpc-devel
+        # See https://copr.fedorainfracloud.org/coprs/ceph/grpc/
+        $SUDO yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+        $SUDO dnf copr enable -y ceph/grpc
         # centos 8.3 changes to lowercase repo names
         $SUDO dnf config-manager --set-enabled PowerTools || \
             $SUDO dnf config-manager --set-enabled powertools


### PR DESCRIPTION
centos8: add yum Configs for CentOS Cloud SIG in order to satisfy new build dependency `grpc-devel`

example of the [failing build](https://jenkins.ceph.com/job/ceph-dev-new-build/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=centos8,DIST=centos8,MACHINE_SIZE=gigantic/76580//consoleFull). 