### PR TITLE
ceph-build-pull-requests: pin jenkins-job-builder to <6.0.0

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -3,7 +3,7 @@
 set -e
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "ansible" "ansible-core<=2.15.4" "jenkins-job-builder>=3.5.0" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" )
+pkgs=( "ansible" "ansible-core<=2.15.4" "jenkins-job-builder>=3.5.0,<6.0.0" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"

--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -9,7 +9,7 @@
 set -euxo pipefail
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "dataclasses" "jenkins-job-builder>=3.5.0" )
+pkgs=( "dataclasses" "jenkins-job-builder>=3.5.0,<6.0.0" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]" latest


### PR DESCRIPTION
Something's happened in the new release of jjb that breaks our yml templates.  There are hints here, perhaps.

https://groups.google.com/g/jenkins-job-builder/c/FQOIorLgi9g

For now, 5.1.0 seems to work.

Also pin it in jenkins-job-builder.