### PR TITLE
windows: install libvirt

### DIFF
--- a/scripts/ceph-windows/setup_libvirt
+++ b/scripts/ceph-windows/setup_libvirt
@@ -74,14 +74,9 @@ function get_libvirt_vm_ssh_address() {
 #
 # Setup requirements (if needed)
 #
-if ! which virt-install >/dev/null; then
-    sudo apt-get update
-    sudo apt-get install -y virtinst
-fi
-if ! which cloud-localds >/dev/null; then
-    sudo apt-get update
-    sudo apt-get install -y cloud-image-utils
-fi
+sudo apt-get update
+sudo apt-get install -y libvirt-daemon-system virtinst cloud-image-utils
+
 if ! sudo virsh net-info default &>/dev/null; then
     cat << EOF > $LIBVIRT_DIR/default-net.xml
 <network>


### PR DESCRIPTION
The Windows jobs use Libvirt VMs to build Ceph and run the tests.

The issue is that we're assuming Libvirt to be preinstalled, which isn't necessarily the case.

This change will explicitly install Libvirt.