### PR TITLE
windows: explicitly enable libvirtd and install qemu-kvm

### DIFF
--- a/scripts/ceph-windows/setup_libvirt
+++ b/scripts/ceph-windows/setup_libvirt
@@ -75,7 +75,10 @@ function get_libvirt_vm_ssh_address() {
 # Setup requirements (if needed)
 #
 sudo apt-get update
-sudo apt-get install -y libvirt-daemon-system virtinst cloud-image-utils
+sudo apt-get install -y libvirt-daemon-system virtinst cloud-image-utils qemu-kvm
+
+sudo systemctl start libvirtd
+sudo systemctl status libvirtd
 
 if ! sudo virsh net-info default &>/dev/null; then
     cat << EOF > $LIBVIRT_DIR/default-net.xml


### PR DESCRIPTION
Libvirt is still not available after installing the libvirt-daemon-system package.

We'll explicitly enable the libvirtd service and install qemu-kvm.