### PR TITLE
ceph-container: set PRERELEASE env var

### DIFF
--- a/ceph-container-build-ceph-base-push-imgs-arm64/build/build
+++ b/ceph-container-build-ceph-base-push-imgs-arm64/build/build
@@ -5,6 +5,7 @@ set -e
 sudo apt-get install jq -y
 
 cd "$WORKSPACE"/ceph-container/ || exit
+export PRERELEASE=false
 ARCH=aarch64 bash -x contrib/build-ceph-base.sh
 
 echo "Now running manifest script"

--- a/ceph-container-build-ceph-base-push-imgs/build/build
+++ b/ceph-container-build-ceph-base-push-imgs/build/build
@@ -5,6 +5,7 @@ set -e
 sudo apt-get install jq -y
 
 cd "$WORKSPACE"/ceph-container/ || exit
+export PRERELEASE=false
 ARCH=x86_64 bash -x contrib/build-ceph-base.sh
 
 echo "Now running manifest script"


### PR DESCRIPTION
otherwise, the build-ceph-base.sh script complains because this variable has no default value.