### PR TITLE
Revert "ceph-dev*: remove centos8 crimson builds"

### DIFF
--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -58,6 +58,7 @@
                     DISTROS=focal bionic centos8 leap15
       # build quincy on:
       # default: focal centos8 centos9 leap15
+      # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*quincy.*
@@ -74,9 +75,16 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal centos8 centos9 leap15
+                - project: 'ceph-dev'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=centos8
+                    FLAVOR=crimson
+                    ARCHS=x86_64
       # build reef on:
       # default: jammy focal centos8 centos9 windows
-      # crimson: centos9
+      # crimson: centos8 centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
@@ -97,12 +105,12 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos9
+                    DISTROS=centos8 centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build main on:
       # default: jammy focal centos8 centos9 windows
-      # crimson: centos9
+      # crimson: centos8 centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*main.*
@@ -123,7 +131,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos9
+                    DISTROS=centos8 centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
 

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -119,6 +119,7 @@
                     DISTROS=focal bionic centos8 windows
       # build quincy on:
       # default: focal centos8 centos9 leap15
+      # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*quincy.*
@@ -135,10 +136,16 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal centos8 centos9 leap15
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=centos8
+                    FLAVOR=crimson
                     ARCHS=x86_64
       # build reef on:
       # default: jammy focal centos8 centos9 windows
-      # crimson: centos9
+      # crimson: centos8 centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
@@ -159,7 +166,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos9
+                    DISTROS=centos8 centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # If no release name is found in branch, build on all possible distro/flavor combos (except xenial and bionic).
@@ -185,7 +192,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos9
+                    DISTROS=centos8 centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build only centos9, no crimson, no jaeger
@@ -208,7 +215,7 @@
                     ARCHS=x86_64
       # Build only the `crimson` flavour, don't waste resources on the default one.
       # Useful for the crimson's bug-hunt at Sepia
-      # crimson: centos9
+      # crimson: centos8 centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*crimson-only.*
@@ -224,7 +231,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos9
+                    DISTROS=centos8 centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # Build jaegertracing branch on needed env,  don't waste resources on the default one.

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -97,6 +97,7 @@
                     DISTROS=focal bionic centos8 leap15
       # build quincy on:
       # default: focal centos8 leap15
+      # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*quincy.*
@@ -113,9 +114,15 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal centos8 leap15
+                - project: 'ceph-dev'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=centos8
+                    FLAVOR=crimson
       # build reef on:
       # default: jammy focal centos8 centos9
-      # crimson: centos9
+      # crimson: centos8 centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*main.*
@@ -136,11 +143,11 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos9
+                    DISTROS=centos8 centos9
                     FLAVOR=crimson
       # build main on:
       # default: jammy focal centos8 centos9
-      # crimson: centos9
+      # crimson: centos8 centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*main.*
@@ -161,7 +168,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos9
+                    DISTROS=centos8 centos9
                     FLAVOR=crimson
 
     wrappers:


### PR DESCRIPTION
Reverting until the container machinery will support pulling c9 builds.

This reverts commit 1984464b9a80f6857877aac0620737cbc40fd67c.