### PR TITLE
windows: restart libvirtd.socket if the socket is missing

### DIFF
--- a/scripts/ceph-windows/setup_libvirt
+++ b/scripts/ceph-windows/setup_libvirt
@@ -77,8 +77,15 @@ function get_libvirt_vm_ssh_address() {
 sudo apt-get update
 sudo apt-get install -y libvirt-daemon-system virtinst cloud-image-utils qemu-kvm
 
-sudo systemctl start libvirtd
-sudo systemctl status libvirtd
+# Ensure that the libvirt socket is available, otherwise virsh commands will fail.
+# If missing, we'll restart the appropriate services.
+if [[ ! -S /var/run/libvirt/libvirt-sock ]]; then
+    sudo systemctl stop libvirtd.socket
+    sudo systemctl restart libvirtd
+
+    sudo systemctl status libvirtd.socket
+    sudo systemctl status libvirtd
+fi
 
 if ! sudo virsh net-info default &>/dev/null; then
     cat << EOF > $LIBVIRT_DIR/default-net.xml


### PR DESCRIPTION
The Windows job is failing because of libvirt failures, specifically the libvirt unix socket is missing.

After some trial and error, looks like the libvirtd.socket service needs to be restarted.