### PR TITLE
RFC: scripts/build_utils.sh: use clang for crimson builds

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -870,7 +870,8 @@ ceph_build_args_from_flavor() {
         ;;
     crimson)
         CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
-        CEPH_EXTRA_CMAKE_ARGS+=" -DCMAKE_BUILD_TYPE=Debug"
+	# use clang for crimson builds due to coroutine support, see https://tracker.ceph.com/issues/64375
+        CEPH_EXTRA_CMAKE_ARGS+=" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
         DEB_BUILD_PROFILES="pkg.ceph.crimson"
         ;;
     jaeger)


### PR DESCRIPTION
Due to https://tracker.ceph.com/issues/64375 and a bug @xxhdx1985126 ran into with std::counting_semaphore, we either need to start building on gcc13 or clang 17.  Due to better coroutine support, my vote is for clang.

@dmick @tchaikov Is this actually the right way to swap the default compiler for crimson shaman builds?