### PR TITLE
ceph-dev-new-trigger: start building quincy packages on jammy

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -118,7 +118,7 @@
                     FORCE=True
                     DISTROS=focal bionic centos8 windows
       # build quincy on:
-      # default: focal centos8 centos9 leap15
+      # default: focal jammy centos8 centos9 leap15
       # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
@@ -135,7 +135,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal centos8 centos9 leap15
+                    DISTROS=focal jammy centos8 centos9 leap15
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}


### PR DESCRIPTION
as described in https://lists.ceph.io/hyperkitty/list/dev@ceph.io/thread/ONAWOAE7MPMT7CP6KH7Y4NGWIP5SZ7XR/, lack of jammy packages for quincy is an obstacle to dropping ubuntu focal support on squid