### PR TITLE
Add sync-images job

### DIFF
--- a/sync-images/build/build
+++ b/sync-images/build/build
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# shellcheck disable=SC2034
+WORKDIR=$(mktemp -td tox.XXXXXXXXXX)
+
+podman run --rm -v ./sync.yml:/sync.yml quay.io/skopeo/stable sync --src yaml --dest docker /sync.yml "${DEST_REGISTRY}" --dest-username "${DEST_USERNAME}" --dest-password "${DEST_PASSWORD}"

--- a/sync-images/build/sync.yml
+++ b/sync-images/build/sync.yml
@@ -1,0 +1,3 @@
+docker.io:
+  images-by-tag-regex:
+    grafana/grafana: ^(9\.?|[0-9]{2,}\.?)([0-9]*\.?){1,}$

--- a/sync-images/config/JENKINS_URL
+++ b/sync-images/config/JENKINS_URL
@@ -1,0 +1,1 @@
+jenkins.ceph.com

--- a/sync-images/config/definitions/sync-images.yml
+++ b/sync-images/config/definitions/sync-images.yml
@@ -1,0 +1,41 @@
+- job:
+    name: sync-images
+    id: sync-images
+    node: small && centos8
+    defaults: global
+    display-name: sync-images
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: -1
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: -1
+
+    triggers:
+      - timed: '@daily'
+
+    parameters:
+      - string:
+          name: DEST_REGISTRY
+          description: "The destination registry hostname. Eg: quay.io"
+          default: "quay.io/ceph"
+
+    builders:
+      - shell:
+          !include-raw-escape:
+            - ../../../scripts/build_utils.sh
+            - ../../build/build
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: sync-images-from-docker-to-quay
+              username: DEST_USERNAME
+              password: DEST_PASSWORD


### PR DESCRIPTION
This adds a nightly job in order to mirror some container images (grafana image only for now) from docker.io to quay.io