### PR TITLE
sync-images: fix the inclusion section

### DIFF
--- a/sync-images/config/definitions/sync-images.yml
+++ b/sync-images/config/definitions/sync-images.yml
@@ -26,7 +26,7 @@
 
     builders:
       - shell:
-          !include-raw-escape:
+          !include-raw:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 


### PR DESCRIPTION
according to the documentation [1], my understanding is that `!include-raw` should be used instead of `!include-raw-escape`.

[1] https://jenkins-job-builder.readthedocs.io/en/latest/definition.html#inclusion-tags