### PR TITLE
Add squid to ceph-dev-cron and other jobs (except for ceph-volume)

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -5,7 +5,6 @@
       - squid
       - reef
       - quincy
-      - pacific
     test_suite:
       - backend:
           test_suite_script: run-backend-api-tests.sh

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -65,7 +65,7 @@
             - condition-kind: and
               condition-operands:
                 - condition-kind: regex-match
-                  regex: (mimic|nautilus|octopus|pacific|quincy|reef)
+                  regex: (mimic|nautilus|octopus|pacific|quincy|reef|squid)
                   label: '${BRANCH}'
                 - condition-kind: regex-match
                   regex: (xenial|bionic|focal|jammy|centos7|centos8|centos9|buster|bullseye|bookworm)

--- a/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
+++ b/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
@@ -5,7 +5,6 @@
       - squid
       - reef
       - quincy
-      - pacific
     jobs:
       - '{name}-{ceph_branch}'
 

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -30,32 +30,14 @@
           browser: auto
           branches:
             - origin/main
+            - origin/squid
             - origin/reef
             - origin/quincy
-            - origin/pacific
           skip-tag: true
           timeout: 20
           wipe-workspace: true
 
     builders:
-      # build pacific on:
-      # default: focal bionic centos8 leap15
-      - conditional-step:
-          condition-kind: regex-match
-          regex: .*pacific.*
-          label: '${GIT_BRANCH}'
-          on-evaluation-failure: dont-run
-          steps:
-            - shell:
-                !include-raw:
-                - ../../../scripts/build_utils.sh
-                - ../../build/notify
-            - trigger-builds:
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=focal bionic centos8 leap15
       # build quincy on:
       # default: focal centos8 centos9 leap15
       # crimson: centos8
@@ -88,6 +70,32 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=jammy focal centos8 centos9 windows
+                - project: 'ceph-dev'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=centos8 centos9
+                    FLAVOR=crimson
+                    ARCHS=x86_64
+      # build squid on:
+      # default: jammy focal centos8 centos9 windows
+      # crimson: centos8 centos9
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*squid.*
           label: '${GIT_BRANCH}'
           on-evaluation-failure: dont-run
           steps:

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -169,12 +169,38 @@
                     DISTROS=centos8 centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
+      # build squid on:
+      # default: jammy focal centos8 centos9 windows
+      # crimson: centos8 centos9
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*squid.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=jammy focal centos8 centos9 windows
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=centos8 centos9
+                    FLAVOR=crimson
+                    ARCHS=x86_64
       # If no release name is found in branch, build on all possible distro/flavor combos (except xenial and bionic).
       # regex matching and 'on-evaluation-failure: run' doesn't work here so triple negative it is.
       - conditional-step:
           condition-kind: shell
           condition-command: |
-            echo "${GIT_BRANCH}" | grep -v '\(luminous\|mimic\|nautilus\|octopus\|pacific\|quincy\|reef\|centos9-only\|crimson-only\|jaeger\)'
+            echo "${GIT_BRANCH}" | grep -v '\(luminous\|mimic\|nautilus\|octopus\|pacific\|quincy\|reef\|squid\|centos9-only\|crimson-only\|jaeger\)'
           on-evaluation-failure: dont-run
           steps:
             - shell:

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -26,75 +26,14 @@
           browser: auto
           branches:
             - 'origin/main'
-            - 'origin/jewel'
-            - 'origin/kraken'
-            - 'origin/hammer'
-            - 'origin/luminous'
-            - 'origin/mimic*'
-            - 'origin/nautilus'
-            - 'origin/octopus'
-            - 'origin/pacific'
             - 'origin/quincy'
             - 'origin/reef'
+            - 'origin/squid'
           skip-tag: true
           timeout: 20
           wipe-workspace: true
 
     builders:
-      # build nautilus on:
-      # default: bionic xenial centos7 centos8
-      - conditional-step:
-          condition-kind: regex-match
-          regex: .*nautilus.*
-          label: '${GIT_BRANCH}'
-          on-evaluation-failure: dont-run
-          steps:
-            - shell:
-                !include-raw:
-                - ../../../scripts/build_utils.sh
-                - ../../build/notify
-            - trigger-builds:
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=bionic xenial centos7 centos8
-      # build octopus on:
-      # default: focal bionic centos7 centos8 leap15
-      - conditional-step:
-          condition-kind: regex-match
-          regex: .*octopus.*
-          label: '${GIT_BRANCH}'
-          on-evaluation-failure: dont-run
-          steps:
-            - shell:
-                !include-raw:
-                - ../../../scripts/build_utils.sh
-                - ../../build/notify
-            - trigger-builds:
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=focal bionic centos7 centos8 leap15
-      # build pacific on:
-      # default: focal bionic centos8 leap15
-      - conditional-step:
-          condition-kind: regex-match
-          regex: .*pacific.*
-          label: '${GIT_BRANCH}'
-          on-evaluation-failure: dont-run
-          steps:
-            - shell:
-                !include-raw:
-                - ../../../scripts/build_utils.sh
-                - ../../build/notify
-            - trigger-builds:
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=focal bionic centos8 leap15
       # build quincy on:
       # default: focal centos8 leap15
       # crimson: centos8
@@ -126,6 +65,31 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=jammy focal centos8 centos9
+                - project: 'ceph-dev'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=centos8 centos9
+                    FLAVOR=crimson
+      # build squid on:
+      # default: jammy focal centos8 centos9
+      # crimson: centos8 centos9
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*squid.*
           label: '${GIT_BRANCH}'
           on-evaluation-failure: dont-run
           steps:

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -125,7 +125,7 @@
       # crimson: centos8 centos9
       - conditional-step:
           condition-kind: regex-match
-          regex: .*main.*
+          regex: .*reef.*
           label: '${GIT_BRANCH}'
           on-evaluation-failure: dont-run
           steps:

--- a/ceph-doc-releases-rtd/config/definitions/ceph-doc-releases-rtd.yml
+++ b/ceph-doc-releases-rtd/config/definitions/ceph-doc-releases-rtd.yml
@@ -35,7 +35,7 @@
             - 'doc/releases'
     builders:
       - shell: |
-          RELEASES="reef quincy pacific octopus"
+          RELEASES="squid reef quincy pacific octopus"
           for release in $RELEASES; do
             curl -X POST -H "Authorization: Token $READTHEDOCS_TOKEN" https://readthedocs.org/api/v3/projects/ceph/versions/$release/builds/
           done

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1178,7 +1178,7 @@ start_tox() {
         # dev runs will need to be set to the release
         # that matches what the current ceph main
         # branch is at
-        local release="reef"
+        local release="squid"
     fi
     TOX_RUN_ENV=("timeout 3h")
     if [ -n "$ceph_docker_image_tag" ]; then

--- a/scripts/sign-rpms
+++ b/scripts/sign-rpms
@@ -21,7 +21,7 @@ keyid=460F3994
 
 if [ $# -eq 0 ]; then
   # Default releases if no arguments passed
-  releases=( pacific quincy reef )
+  releases=( quincy reef squid )
 else
   releases=( "$@" )
 fi

--- a/scripts/sync-push
+++ b/scripts/sync-push
@@ -12,7 +12,7 @@
 # pull an in-progress release
 prerelease_dir=/data/download.ceph.com/www/prerelease
 
-releases=${*:-"pacific quincy reef"}
+releases=${*:-"quincy reef squid"}
 
 ceph_sync() {
   release=$1


### PR DESCRIPTION
Based on @jdurgin's commit from last year for reef.

> and other jobs (except for ceph-volume)

I'm clueless about `CEPH_ANSIBLE_BRANCH` and other version bits there, so I'm leaving ceph-volume jobs to @guits.