### PR TITLE
ceph-pull-requests-arm64: enable RWL mode on arm64

### DIFF
--- a/ceph-pull-requests-arm64/build/build
+++ b/ceph-pull-requests-arm64/build/build
@@ -11,6 +11,7 @@ n_test_jobs=${n_build_jobs}
 export CHECK_MAKEOPTS="-j${n_test_jobs}"
 export BUILD_MAKEOPTS="-j${n_build_jobs}"
 export WITH_SEASTAR=true
+export WITH_RBD_RWL=true
 timeout 3h ./run-make-check.sh
 sleep 5
 ps -ef | grep -v jnlp | grep ceph || true


### PR DESCRIPTION
WITH_RBD_RWL variable is added in https://github.com/ceph/ceph/pull/45872.