### PR TITLE
ceph-dev-new-trigger: stop building focal packages on main

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -195,7 +195,7 @@
                     DISTROS=centos8 centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
-      # If no release name is found in branch, build on all possible distro/flavor combos (except xenial and bionic).
+      # If no release name is found in branch, build on all possible distro/flavor combos (except xenial, bionic, focal).
       # regex matching and 'on-evaluation-failure: run' doesn't work here so triple negative it is.
       - conditional-step:
           condition-kind: shell
@@ -212,7 +212,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy focal centos8 centos9 windows
+                    DISTROS=jammy centos8 centos9 windows
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |


### PR DESCRIPTION
depends on ~~https://github.com/ceph/ceph/pull/55976~~ (edit: merged) to remove the last dependencies on focal packages for quincy upgrade suites