### PR TITLE
ceph-dev-new-trigger: stop building focal packages on squid

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -170,7 +170,7 @@
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build squid on:
-      # default: jammy focal centos8 centos9 windows
+      # default: jammy centos8 centos9 windows
       # crimson: centos8 centos9
       - conditional-step:
           condition-kind: regex-match
@@ -187,7 +187,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy focal centos8 centos9 windows
+                    DISTROS=jammy centos8 centos9 windows
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}


### PR DESCRIPTION
depends on ~~https://github.com/ceph/ceph/pull/55976~~ (edit: merged) and its squid backport https://github.com/ceph/ceph/pull/56636, to remove the last dependencies on focal packages for quincy upgrade suites