### PR TITLE
ceph-volume: drop pacific nightly testing

### DIFF
--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -13,7 +13,6 @@
       - main
       - reef
       - quincy
-      - pacific
 
     jobs:
       - 'ceph-volume-nightly-{ceph_branch}-{subcommand}-{distro}-{objectstore}-{scenario}'
@@ -33,7 +32,6 @@
       - main
       - reef
       - quincy
-      - pacific
 
     jobs:
       - 'ceph-volume-nightly-{ceph_branch}-{subcommand}-{distro}-{objectstore}-{scenario}'
@@ -55,7 +53,6 @@
       - main
       - reef
       - quincy
-      - pacific
 
     jobs:
       - 'ceph-volume-nightly-{ceph_branch}-{subcommand}-{distro}-{objectstore}-{scenario}'


### PR DESCRIPTION
This drops the pacific nightly ceph-volume testing