### PR TITLE
windows: reduce Linux VM memory

### DIFF
--- a/scripts/ceph-windows/setup_libvirt_ubuntu_vm
+++ b/scripts/ceph-windows/setup_libvirt_ubuntu_vm
@@ -7,7 +7,7 @@ if [[ -z $LIBVIRT_DIR ]]; then echo "ERROR: The env variable LIBVIRT_DIR is not 
 export UBUNTU_VM_IMAGE_URL=${UBUNTU_VM_IMAGE_URL:-"https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img"}
 export UBUNTU_VM_NAME=${UBUNTU_VM_NAME:-"ceph-ubuntu-vstart-${JOB_NAME}-${BUILD_ID}"}
 export UBUNTU_VM_VCPUS="$(nproc)"  # use all the CPU cores avaiable on the host
-export UBUNTU_VM_MEMORY="65536"    # 64 GB
+export UBUNTU_VM_MEMORY=${UBUNTU_VM_MEMORY:-"16384"}  # 16 GB
 export UBUNTU_SSH_USER="ubuntu"
 
 #


### PR DESCRIPTION
There have been a lot of Windows job failures lately due to qemu errors caused by insufficient Jenkins slave memory:

```
  ERROR    internal error: process exited while connecting to
  monitor: 2024-04-21T11:37:28.922183Z qemu-system-x86_64: cannot
  set up guest memory 'pc.ram': Cannot allocate memory
```

Each Windows job spins up two virtual machines: a Linux one with 64GB of ram and a Windows VM with 8GB of ram. Since the Windows job no longer uses memstore, we can probably reduce the Linux vm memory to 16GB.