### PR TITLE
windows: limit number of Linux VM vcpus

### DIFF
--- a/scripts/ceph-windows/setup_libvirt_ubuntu_vm
+++ b/scripts/ceph-windows/setup_libvirt_ubuntu_vm
@@ -4,9 +4,14 @@ set -o pipefail
 
 if [[ -z $LIBVIRT_DIR ]]; then echo "ERROR: The env variable LIBVIRT_DIR is not set"; exit 1; fi
 
+nproc=$(nproc)
+# By limiting the number of parallel build jobs, we avoid using excessive
+# amounts of memory.
+DEFAULT_UBUNTU_VM_VCPUS=$((nproc > 16 ? 16 : nproc))
+
 export UBUNTU_VM_IMAGE_URL=${UBUNTU_VM_IMAGE_URL:-"https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img"}
 export UBUNTU_VM_NAME=${UBUNTU_VM_NAME:-"ceph-ubuntu-vstart-${JOB_NAME}-${BUILD_ID}"}
-export UBUNTU_VM_VCPUS="$(nproc)"  # use all the CPU cores avaiable on the host
+export UBUNTU_VM_VCPUS=${UBUNTU_VM_VCPUS:-$DEFAULT_UBUNTU_VM_VCPUS}
 export UBUNTU_VM_MEMORY=${UBUNTU_VM_MEMORY:-"16384"}  # 16 GB
 export UBUNTU_SSH_USER="ubuntu"
 


### PR DESCRIPTION
We reduced the amount of memory allocated to Linux VMs used by the Windows PR jobs to 16GB but we're now hitting OOM errors while building Ceph.

To mitigate this, we'll limit the number of parallel jobs and allocated vcpus.