### PR TITLE
windows: increase timeouts

### DIFF
--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -91,14 +91,14 @@ SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec ./ceph/build/bin/ce
 #
 # Run the Windows tests
 #
-SSH_TIMEOUT=1h ssh_exec powershell.exe /workspace/repos/ceph-win32-tests/test_host/run_tests.ps1 -workerCount 4
+SSH_TIMEOUT=2h ssh_exec powershell.exe /workspace/repos/ceph-win32-tests/test_host/run_tests.ps1 -workerCount 4
 
 WIN_WORKUNITS_DIR="$WORKSPACE/ceph/qa/workunits/windows"
 LOCAL_SCRIPT_PATH="$WIN_WORKUNITS_DIR/run-tests.ps1"
 if [[ -f $LOCAL_SCRIPT_PATH ]]; then
     echo "Using locally cloned test script: $LOCAL_SCRIPT_PATH"
     scp_upload $WIN_WORKUNITS_DIR /workspace/workunits
-    SSH_TIMEOUT=30m ssh_exec powershell.exe -File /workspace/workunits/run-tests.ps1
+    SSH_TIMEOUT=1h ssh_exec powershell.exe -File /workspace/workunits/run-tests.ps1
 else
     # The following is only used on Quincy, make sure to leave this in place while Quincy
     # is still being tested.
@@ -106,14 +106,14 @@ else
     echo "Using remote test script from: $REMOTE_SCRIPT_URL"
     ssh_exec curl.exe -s -L -o /workspace/test_rbd_wnbd.py $REMOTE_SCRIPT_URL
 
-    SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdTest --iterations 100
-    SSH_TIMEOUT=30m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFioTest --iterations 100
-    SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdStampTest --iterations 100
+    SSH_TIMEOUT=30m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdTest --iterations 100
+    SSH_TIMEOUT=60m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFioTest --iterations 100
+    SSH_TIMEOUT=30m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdStampTest --iterations 100
 
     # It can take a while to setup the partition (~10s), we'll use fewer iterations.
-    SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsTest --iterations 4
-    SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsFioTest --iterations 4
-    SSH_TIMEOUT=15m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsStampTest --iterations 4
+    SSH_TIMEOUT=30m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsTest --iterations 4
+    SSH_TIMEOUT=30m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsFioTest --iterations 4
+    SSH_TIMEOUT=30m ssh_exec python.exe /workspace/test_rbd_wnbd.py --test-name RbdFsStampTest --iterations 4
 fi
 
 echo "Windows tests succeeded."

--- a/scripts/ceph-windows/setup_ceph_vstart
+++ b/scripts/ceph-windows/setup_ceph_vstart
@@ -43,7 +43,7 @@ EOF
 chmod +x ${VSTART_DIR}/build-ceph-vstart.sh
 time rsync_cmd $WORKSPACE/ceph ${VSTART_DIR}/build-ceph-vstart.sh ${UBUNTU_SSH_USER}@${UBUNTU_VM_IP}:
 
-time SSH_TIMEOUT=1h ssh_exec ./build-ceph-vstart.sh
+time SSH_TIMEOUT=4h ssh_exec ./build-ceph-vstart.sh
 ssh_exec sudo apt-get install -y python3-prettytable
 
 if [[ "$USE_MEMSTORE" == "yes" ]]; then
@@ -79,7 +79,7 @@ EOF
 chmod +x ${VSTART_DIR}/ceph-vstart.sh
 
 rsync_cmd ${VSTART_DIR}/ceph-vstart.sh ${UBUNTU_SSH_USER}@${UBUNTU_VM_IP}:
-time SSH_TIMEOUT=30m ssh_exec ./ceph-vstart.sh
+time SSH_TIMEOUT=10m ssh_exec ./ceph-vstart.sh
 
 ssh_exec sudo mkdir -p /etc/ceph
 ssh_exec sudo cp ./ceph-vstart/ceph.conf ./ceph-vstart/keyring /etc/ceph


### PR DESCRIPTION
We've decreased the amount of resources allocated to Windows PR test jobs but as a result we're now experiencing timeouts.

We'll double the timeouts used by our test scripts.