### PR TITLE
ceph-dev-new-build: add timestamps to the build log

### DIFF
--- a/ceph-dev-new-build/build/build_rpm
+++ b/ceph-dev-new-build/build/build_rpm
@@ -1,5 +1,8 @@
 #!/bin/bash
 # vim: ts=4 sw=4 expandtab
+
+# PS4 is expanded as the prefix for -x traces
+PS4="\$(date) :: "
 set -ex
 
 


### PR DESCRIPTION
A quick change to add timestamps to the execution logs