### PR TITLE
windows: increase log collection timeout

### DIFF
--- a/ceph-windows-installer-build/build/build
+++ b/ceph-windows-installer-build/build/build
@@ -33,7 +33,7 @@ popd
 #
 # Upload ceph-windows-installer repo to the Windows VM
 #
-SSH_TIMEOUT=5m scp_upload $WORKSPACE/ceph-windows-installer /workspace/ceph-windows-installer
+scp_upload $WORKSPACE/ceph-windows-installer /workspace/ceph-windows-installer
 
 #
 # Build the Visual Studio project

--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -38,7 +38,7 @@ scp_upload $CEPH_KEYRING /ProgramData/ceph/keyring
 #
 # Setup the Ceph Windows build in the Windows VM
 #
-SSH_TIMEOUT=5m scp_upload $WORKSPACE/ceph.zip /ceph.zip
+scp_upload $WORKSPACE/ceph.zip /ceph.zip
 SSH_TIMEOUT=10m ssh_exec powershell.exe "\$ProgressPreference='SilentlyContinue'; Expand-Archive -Path /ceph.zip -DestinationPath / -Force"
 ssh_exec powershell.exe "Add-MpPreference -ExclusionPath 'C:\ceph'"
 ssh_exec powershell.exe "New-Service -Name ceph-rbd -BinaryPathName 'c:\ceph\rbd-wnbd.exe service'"
@@ -83,6 +83,7 @@ function collect_artifacts() {
     ssh_exec curl.exe --retry-max-time 30 --retry 10 -L -o /workspace/collect-event-logs.ps1 $COLLECT_EVENT_LOGS_SCRIPT_URL
     SSH_TIMEOUT=30m ssh_exec powershell.exe /workspace/collect-event-logs.ps1 -LogDirectory /workspace/eventlogs
     scp_download /workspace/eventlogs $WORKSPACE/artifacts/client/eventlogs
+    echo "Successfully retrieved artifacts."
 }
 trap collect_artifacts EXIT
 


### PR DESCRIPTION
Some failed Windows jobs are missing the build artifacts and it seems like the log collection function times out.

https://jenkins.ceph.com/job/ceph-windows-pull-requests/39380/

We'll increase the timeout from 30s to 10m.