### PR TITLE
ceph-dev: stop building centos8 packages/container on quincy/reef/squid/main

### DIFF
--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -39,7 +39,7 @@
 
     builders:
       # build quincy on:
-      # default: focal centos8 centos9 leap15
+      # default: focal centos9 leap15
       - conditional-step:
           condition-kind: regex-match
           regex: .*quincy.*
@@ -55,7 +55,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal centos8 centos9 leap15
+                    DISTROS=focal centos9 leap15
       # build reef on:
       # default: jammy focal centos8 centos9 windows
       # crimson: centos9

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -40,7 +40,6 @@
     builders:
       # build quincy on:
       # default: focal centos8 centos9 leap15
-      # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*quincy.*
@@ -57,16 +56,9 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal centos8 centos9 leap15
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=crimson
-                    ARCHS=x86_64
       # build reef on:
       # default: jammy focal centos8 centos9 windows
-      # crimson: centos8 centos9
+      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
@@ -87,7 +79,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos8 centos9
+                    DISTROS=centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build squid on:
@@ -118,7 +110,7 @@
                     ARCHS=x86_64
       # build main on:
       # default: jammy focal centos8 centos9 windows
-      # crimson: centos8 centos9
+      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*main.*
@@ -139,7 +131,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos8 centos9
+                    DISTROS=centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
 

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -83,8 +83,8 @@
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build squid on:
-      # default: jammy focal centos8 centos9 windows
-      # crimson: centos8 centos9
+      # default: jammy focal centos9 windows
+      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*squid.*
@@ -100,12 +100,12 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy focal centos8 centos9 windows
+                    DISTROS=jammy focal centos9 windows
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos8 centos9
+                    DISTROS=centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build main on:

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -109,7 +109,7 @@
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build main on:
-      # default: jammy focal centos8 centos9 windows
+      # default: jammy focal centos9 windows
       # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
@@ -126,7 +126,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy focal centos8 centos9 windows
+                    DISTROS=jammy focal centos9 windows
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -57,7 +57,7 @@
                     FORCE=True
                     DISTROS=focal centos9 leap15
       # build reef on:
-      # default: jammy focal centos8 centos9 windows
+      # default: jammy focal centos9 windows
       # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
@@ -74,7 +74,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy focal centos8 centos9 windows
+                    DISTROS=jammy focal centos9 windows
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -118,7 +118,7 @@
                     FORCE=True
                     DISTROS=focal bionic centos8 windows
       # build quincy on:
-      # default: focal jammy centos8 centos9 leap15
+      # default: focal jammy centos9 leap15
       - conditional-step:
           condition-kind: regex-match
           regex: .*quincy.*
@@ -134,7 +134,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal jammy centos8 centos9 leap15
+                    DISTROS=focal jammy centos9 leap15
       # build reef on:
       # default: jammy focal centos8 centos9 windows
       # crimson: centos9

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -119,7 +119,6 @@
                     DISTROS=focal bionic centos8 windows
       # build quincy on:
       # default: focal jammy centos8 centos9 leap15
-      # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*quincy.*
@@ -136,16 +135,9 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal jammy centos8 centos9 leap15
-                - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=crimson
-                    ARCHS=x86_64
       # build reef on:
       # default: jammy focal centos8 centos9 windows
-      # crimson: centos8 centos9
+      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
@@ -166,7 +158,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos8 centos9
+                    DISTROS=centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build squid on:
@@ -218,7 +210,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos8 centos9
+                    DISTROS=centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build only centos9, no crimson, no jaeger
@@ -241,7 +233,7 @@
                     ARCHS=x86_64
       # Build only the `crimson` flavour, don't waste resources on the default one.
       # Useful for the crimson's bug-hunt at Sepia
-      # crimson: centos8 centos9
+      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*crimson-only.*
@@ -257,7 +249,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos8 centos9
+                    DISTROS=centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # Build jaegertracing branch on needed env,  don't waste resources on the default one.

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -162,8 +162,8 @@
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build squid on:
-      # default: jammy centos8 centos9 windows
-      # crimson: centos8 centos9
+      # default: jammy centos9 windows
+      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*squid.*
@@ -179,12 +179,12 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy centos8 centos9 windows
+                    DISTROS=jammy centos9 windows
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos8 centos9
+                    DISTROS=centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # If no release name is found in branch, build on all possible distro/flavor combos (except xenial, bionic, focal).

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -204,7 +204,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy centos8 centos9 windows
+                    DISTROS=jammy centos9 windows
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -136,7 +136,7 @@
                     FORCE=True
                     DISTROS=focal jammy centos9 leap15
       # build reef on:
-      # default: jammy focal centos8 centos9 windows
+      # default: jammy focal centos9 windows
       # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
@@ -153,7 +153,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy focal centos8 centos9 windows
+                    DISTROS=jammy focal centos9 windows
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}

--- a/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -36,7 +36,6 @@
     builders:
       # build quincy on:
       # default: focal centos8 leap15
-      # crimson: centos8
       - conditional-step:
           condition-kind: regex-match
           regex: .*quincy.*
@@ -53,15 +52,9 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=focal centos8 leap15
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8
-                    FLAVOR=crimson
       # build reef on:
       # default: jammy focal centos8 centos9
-      # crimson: centos8 centos9
+      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
@@ -107,11 +100,11 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos8 centos9
+                    DISTROS=centos9
                     FLAVOR=crimson
       # build main on:
       # default: jammy focal centos8 centos9
-      # crimson: centos8 centos9
+      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*main.*
@@ -132,7 +125,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos8 centos9
+                    DISTROS=centos9
                     FLAVOR=crimson
 
     wrappers:


### PR DESCRIPTION
~~staging as a draft until qa suites stop depending on centos8-based container images~~

centos8 eol is causing all of the builds to fail now, so remove from all current releases