### PR TITLE
ceph-dev-new-trigger: stop building centos8 packages/container on squid

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -170,8 +170,8 @@
                     FLAVOR=crimson
                     ARCHS=x86_64
       # build squid on:
-      # default: jammy centos8 centos9 windows
-      # crimson: centos8 centos9
+      # default: jammy centos9 windows
+      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*squid.*
@@ -187,12 +187,12 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy centos8 centos9 windows
+                    DISTROS=jammy centos9 windows
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=centos8 centos9
+                    DISTROS=centos9
                     FLAVOR=crimson
                     ARCHS=x86_64
       # If no release name is found in branch, build on all possible distro/flavor combos (except xenial, bionic, focal).


### PR DESCRIPTION
staging as a draft until qa suites stop depending on centos8-based container images