### PR TITLE
untested: suggestion for avoiding source package upload

### DIFF
--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -35,7 +35,7 @@ cd "$WORKSPACE"
 
 if [ "$THROWAWAY" = false ] ; then
     # push binaries to chacra
-    find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
+    [ "RELEASE_TYPE" != "SECURITY" ] && find release/${vers}/rpm/*/SRPMS | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/source
     find release/${vers}/rpm/*/RPMS/* | grep rpm | $VENV/chacractl binary ${chacra_flags} create ${chacra_endpoint}/${ARCH}
     # extract cephadm if it exists
     if [ -f ${BUILDAREA}/RPMS/noarch/cephadm-*.rpm ] ; then

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -984,8 +984,11 @@ build_debs() {
 
     if [ "$THROWAWAY" = false ] ; then
         # push binaries to chacra
+        egrep_pattern="*(\.changes|\.deb|\.ddeb|\.dsc|ceph[^/]*\.gz)$"
+        [ "$RELEASE_TYPE" = "SECURITY" ] && egrep_pattern = "*(\.deb\.ddeb)%"
+
         find release/$vers/ | \
-            egrep "*(\.changes|\.deb|\.ddeb|\.dsc|ceph[^/]*\.gz)$" | \
+            egrep "$egrep_pattern" | \
             egrep -v "(Packages|Sources|Contents)" | \
             $venv/chacractl binary ${chacra_flags} create ${chacra_endpoint}
 


### PR DESCRIPTION
when building RELEASE_TYPE=SECURITY, don't send source packages to chacra.