### PR TITLE
ceph-pull-requests-arm64: extend timeout to 4h

### DIFF
--- a/ceph-pull-requests-arm64/build/build
+++ b/ceph-pull-requests-arm64/build/build
@@ -12,6 +12,6 @@ export CHECK_MAKEOPTS="-j${n_test_jobs}"
 export BUILD_MAKEOPTS="-j${n_build_jobs}"
 export WITH_SEASTAR=true
 export WITH_RBD_RWL=true
-timeout 3h ./run-make-check.sh
+timeout 4h ./run-make-check.sh
 sleep 5
 ps -ef | grep -v jnlp | grep ceph || true


### PR DESCRIPTION
Because performance of omani series machine are not so well which caused make check often failed, especially when cache hit was low, extend timeout to 4h seems reasonable.

Ref build duration: https://jenkins.ceph.com/job/ceph-pull-requests-arm64/buildTimeTrend
![1715912933650](https://github.com/ceph/ceph-build/assets/9030731/00d047b0-91bb-4602-b495-59a47e7ba73b)
