### PR TITLE
Modify scripts/{sync-pull,sign-rpms,sync-push} to handle ceph-iscsi

### DIFF
--- a/scripts/sign-rpms
+++ b/scripts/sign-rpms
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+# vim: ts=2:sw=2:expandtab
 # This script is meant to be used when signing RPMs on a "signer" box. Such
 # a box needs to have the actual signing keys and follow the structure for
 # a repository layout. The layout follows this convention:

--- a/scripts/sign-rpms
+++ b/scripts/sign-rpms
@@ -20,6 +20,14 @@
 
 keyid=460F3994
 
+function usage() {
+	echo "sign-rpms <project> [ release [ release ..]]"
+}
+
+if [[ $# -lt 1 ]] ; then usage ; exit 1 ; fi
+
+project=$1; shift
+
 if [ $# -eq 0 ]; then
   # Default releases if no arguments passed
   releases=( quincy reef squid )
@@ -43,9 +51,8 @@ echo
 for release in "${releases[@]}"; do
   for distro in  "${distros[@]}"; do
     for distro_version in  "${distro_versions[@]}"; do
-      for path in /opt/repos/ceph/$release*; do
+      for path in /opt/repos/$project/$release*; do
         if [ -d "$path/$distro/$distro_version" ]; then
-          #path="/opt/repos/ceph/$release/$distro/$distro_version"
           echo "Checking packages in: $path/$distro/$distro_version"
           update_repo=0
           cd $path/$distro/$distro_version

--- a/scripts/sync-pull
+++ b/scripts/sync-pull
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+# vim: ts=2:sw=2:expandtab
 
 : ${3?"Usage: $0 \$project \$release \$sha1"}
   #  Script exits here if command-line parameter absent,

--- a/scripts/sync-pull
+++ b/scripts/sync-pull
@@ -13,22 +13,24 @@ sha1=${3}
 echo "sync for: $project $release"
 echo "********************************************"
 
-# This ugly loop check all possible DEB combinations to see which repo has the most packages since that's likely the repo you want to sync.
-current_highest_count=0
-for combo in debian/bookworm debian/bullseye ubuntu/bionic ubuntu/focal ubuntu/jammy; do
-  combo_count=$(curl -s https://chacra.ceph.com/r/$project/$release/$sha1/${combo}/flavors/default/pool/main/c/ceph/ | wc -l)
-  if [ $combo_count -gt $current_highest_count ]; then
-    current_highest_count=$combo_count
-    highest_combo=$combo
-  fi
-done
+if [[ "$project" == "ceph" ]] ; then
+  # This ugly loop checks all possible DEB combinations to see which repo has the most packages since that's likely the repo you want to sync.
+  current_highest_count=0
+  for combo in debian/bookworm debian/bullseye ubuntu/bionic ubuntu/focal ubuntu/jammy; do
+    combo_count=$(curl -fs https://chacra.ceph.com/r/$project/$release/$sha1/${combo}/flavors/default/pool/main/c/ceph/ | wc -l)
+    if [ $combo_count -gt $current_highest_count ]; then
+      current_highest_count=$combo_count
+      highest_combo=$combo
+    fi
+  done
 
-echo "Found the most packages ($current_highest_count) in $highest_combo."
+  echo "Found the most packages ($current_highest_count) in $highest_combo."
+fi
 
 # Check the the DEB and RPM chacra endpoints to see if the repos are or need updating.
 # This helps prevent packages from getting missed when signing and pushing.
 need_rerun=false
-for endpoint in https://chacra.ceph.com/repos/$project/$release/$sha1/centos/{7,8,9} https://chacra.ceph.com/repos/$project/$release/$sha1/$highest_combo; do
+for endpoint in https://chacra.ceph.com/repos/$project/$release/$sha1/centos/{8,9} https://chacra.ceph.com/repos/$project/$release/$sha1/$highest_combo; do
   chacra_repo_status=$(curl -s -L $endpoint)
   chacra_needs_update=$(echo $chacra_repo_status | jq .needs_update)
   chacra_is_updating=$(echo $chacra_repo_status  | jq .is_updating)
@@ -38,39 +40,45 @@ for endpoint in https://chacra.ceph.com/repos/$project/$release/$sha1/centos/{7,
   fi
 done
 
-# We started using the new /opt/repos/ceph/$release-X.X.X format with Octopus.
-# Older releases have all packages in one big $release dir without a trailing "-X.X.X" so we need to adjust paths accordingly.
-if [[ "$release" =~ ^[a-n].* ]]; then
-  newgen=false
-else
-  newgen=true
-  # Get numerical version number (we only need this with Octopus or later because of the new directory/path scheme).
-  version=$(echo $chacra_repo_status | jq -r .extra.version)
-  [[ -d /opt/repos/$project/$release-$version ]] | mkdir -p /opt/repos/$project/$release-$version/{debian/jessie,centos/{7,8,9}}
-fi
+relver=$release
 
-# Replace $highest_combo with your own DISTRO/VERSION if you don't want to sync from the repo with the most packages.
-if $newgen; then
-  deb_cmd="ubuntu@chacra.ceph.com:/opt/repos/$project/$release/$sha1/$highest_combo/flavors/default/* /opt/repos/$project/$release-$version/debian/jessie/"
-else
-  deb_cmd="ubuntu@chacra.ceph.com:/opt/repos/$project/$release/$sha1/$highest_combo/flavors/default/* /opt/repos/$project/$release/debian/jessie/"
-fi
-echo $deb_cmd
-echo "--------------------------------------------"
-rsync -Lavh --progress --exclude '*lockfile*' $deb_cmd
-
-for el_version in 7 8 9; do
-  if $newgen; then
-    el_cmd="ubuntu@chacra.ceph.com:/opt/repos/$project/$release/$sha1/centos/$el_version/flavors/default/* /opt/repos/$project/$release-$version/centos/$el_version/"
+if [[ "$project" == "ceph" ]] ; then
+  # We started using the new /opt/repos/ceph/$release-X.X.X format with Octopus.
+  # Older releases have all packages in one big $release dir without a trailing "-X.X.X" so we need to adjust paths accordingly.
+  if [[ "$release" =~ ^[a-n].* ]]; then
+    newgen=false
   else
-    el_cmd="ubuntu@chacra.ceph.com:/opt/repos/$project/$release/$sha1/centos/$el_version/flavors/default/* /opt/repos/$project/$release/centos/$el_version/"
+    newgen=true
+    # Get numerical version number (we only need this with Octopus or later because of the new directory/path scheme).
+    version=$(echo $chacra_repo_status | jq -r .extra.version)
+    relver=$release-$version
   fi
+  [[ -d /opt/repos/$project/$relver ]] || mkdir -p /opt/repos/$project/$relver/{debian/jessie,centos/{8,9}}
+else
+  # not ceph (i.e. ceph-iscsi)
+  [[ -d /opt/repos/$project/$relver ]] || mkdir -p /opt/repos/$project/$relver/centos/{8,9}
+fi
+
+if [[ "$project" == "ceph" ]] ; then
+  # Replace $highest_combo with your own DISTRO/VERSION if you don't want to sync from the repo with the most packages.
+  if [[ $highest_combo -gt 0 ]] ; then
+    deb_cmd="ubuntu@chacra.ceph.com:/opt/repos/$project/$release/$sha1/$highest_combo/flavors/default/* /opt/repos/$project/$relver/debian/jessie/"
+    echo $deb_cmd
+    echo "--------------------------------------------"
+    rsync -Lavh --progress --exclude '*lockfile*' $deb_cmd
+  fi
+fi
+
+for el_version in 8 9; do
+  el_cmd="ubuntu@chacra.ceph.com:/opt/repos/$project/$release/$sha1/centos/$el_version/flavors/default/* /opt/repos/$project/$relver/centos/$el_version/"
   echo $el_cmd
   echo "--------------------------------------------"
   rsync -Lavh --progress $el_cmd
 done
 
-ssh signer@download.ceph.com "/home/signer/bin/get-tarballs.sh $release $sha1 $version"
+if [[ "$project" == "ceph" ]]; then
+  ssh signer@download.ceph.com "/home/signer/bin/get-tarballs.sh $release $sha1 $version"
+fi
 
 if $need_rerun; then
   echo

--- a/scripts/sync-push
+++ b/scripts/sync-push
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+# vim:ts=2 sw=2 expandtab
 # This script will push repository files from the signer box to the upstream repositories.
 # By default it will sync all releases defined, but can optionally take one or more
 # releases to sync:

--- a/scripts/sync-push
+++ b/scripts/sync-push
@@ -11,48 +11,93 @@
 
 # this directory is auth-protected so anxious users don't try to
 # pull an in-progress release
-prerelease_dir=/data/download.ceph.com/www/prerelease
 
-releases=${*:-"quincy reef squid"}
+function usage() {
+  echo "sync-push <project> [ release [ release ..]]"
+}
 
-ceph_sync() {
-  release=$1
-  for path in $(ls -d /opt/repos/ceph/* | grep $release | sort -V); do
+if [[ $# -lt 1 ]] ; then usage ; exit 1 ; fi
 
-    # We started using the new /opt/repos/ceph/$release-X.X.X format with Octopus.
-    # Older releases have all packages in one big $release dir without a trailing "-X.X.X" so we need to adjust paths accordingly.
-    if [[ "$release" =~ ^[a-n].* ]]; then
-      # Nautilus and older
-      newgen=false
-    else
-      # Octopus and newer
-      newgen=true
-    fi
+project=$1; shift
+prerelease_dir=/data/download.ceph.com/www/prerelease/${project}
 
-    if $newgen; then
+if [[ "$project" == "ceph" ]] ; then
+  releases=${*:-"quincy reef squid"}
+else
+  releases=$*
+fi
+
+make_repofile() {
+  project=$1
+  release=$2
+  el_version=$3
+  echo "[${project}]
+name=ceph-iscsi noarch packages
+baseurl=http://download.ceph.com/prerelease/${project}/${release}/rpm/el${el_version}/noarch
+enabled=1
+gpgcheck=0
+gpgkey=https://download.ceph.com/keys/release.asc
+type=rpm-md
+
+[${project}-source]
+name=ceph-iscsi source packages
+baseurl=http://download.ceph.com/prerelease/ceph-iscsi/${release}/rpm/el${el_version}/SRPMS
+enabled=0
+gpgcheck=1
+gpgkey=https://download.ceph.com/keys/release.asc
+type=rpm-md
+  "
+}
+
+project_sync() {
+  project=$1
+  release=$2
+  newgen=false
+  for path in $(ls -d /opt/repos/$project/* | grep $release | sort -V); do
+    if [[ "$project" == "ceph" ]] ; then
       version=$(echo $path | cut -d '-' -f2)
       release=$(echo $release | cut -d '-' -f1)
-      ssh signer@download.ceph.com "mkdir -p ${prerelease_dir}/debian-$version"
-
-      deb_cmd="$path/debian/jessie/* signer@download.ceph.com:${prerelease_dir}/debian-$version/"
-    else
-      deb_cmd="$path/debian/jessie/* signer@download.ceph.com:${prerelease_dir}/debian-$release/"
-    fi
-    rsync --progress --exclude '*lockfile*' -avr $deb_cmd
-
-    for el_version in 7 8 9; do
-      if $newgen; then
-        ssh signer@download.ceph.com "mkdir -p ${prerelease_dir}/rpm-$version/el$el_version"
-
-        el_cmd="$path/centos/$el_version/* signer@download.ceph.com:${prerelease_dir}/rpm-$version/el${el_version}/"
+      # We started using the new /opt/repos/ceph/$release-X.X.X format with Octopus.
+      # Older releases have all packages in one big $release dir without a trailing "-X.X.X" so we need to adjust paths accordingly.
+      if [[ "$release" =~ ^[a-n].* ]]; then
+        # Nautilus and older
+        debian_path=debian-$release
+        rpm_path=rpm-$release
       else
-        el_cmd="$path/centos/$el_version/* signer@download.ceph.com:${prerelease_dir}/rpm-$release/el${el_version}/"
+        # Octopus and newer
+        newgen=true
+        debian_path=debian-$version
+        rpm_path=rpm-$version
       fi
-      if [ -d "$path/centos/$el_version" ]; then
-        rsync --progress -avr $el_cmd
-      fi
-    done
-  done
+      dcc_deb_path=${prerelease_dir}/${debian_path}
+      dcc_rpm_path=${prerelease_dir}/${rpm_path}
+    else
+      dcc_deb_path=""
+      dcc_rpm_path=${prerelease_dir}/${version}/rpm
+    fi
+
+    if [[ -n "${dcc_deb_path}" ]]; then
+      ssh signer@download.ceph.com "mkdir -p ${dcc_deb_path}"
+
+      deb_cmd="$path/debian/jessie/* signer@download.ceph.com:${prerelease_dir}/${debian_path}"
+      rsync --progress --exclude '*lockfile*' -avr $deb_cmd
+    fi
+
+    if [[ -n "${dcc_rpm_path}" ]] ; then
+      for el_version in 8 9; do
+        ssh signer@download.ceph.com "mkdir -p ${dcc_rpm_path}/el$el_version"
+        destpath="signer@download.ceph.com:${dcc_rpm_path}/el${el_version}"
+        el_cmd="$path/centos/$el_version/* ${destpath}"
+        if [ -d "$path/centos/$el_version" ]; then
+          rsync --progress -avr $el_cmd
+        fi
+        if [[ "$project" == "ceph-iscsi" ]]; then
+          echo "$(make_repofile ${project} ${release} ${el_version})" > ceph-iscsi.repo
+          rsync --progress -avr ceph-iscsi.repo ${destpath}
+        fi
+      done
+    fi
+done
 
   # Since paths are listed alphabetically/numerically in the first `for` loop, the last $version is what gets used for the new symlink below.
   if $newgen; then
@@ -64,8 +109,13 @@ ceph_sync() {
 
 for i in "${releases[@]}"
 do
-   ceph_sync $i
+   project_sync $project $i
 done
 
 echo "Once you've tested the repos at ${prerelease_dir}, don't forget to mv them
 up to the parent directory!"
+if [[ "$project" == "ceph-iscsi" ]]; then
+  echo "And for ceph-iscsi, modify the .repo files in */rpm/*/* to remove the prerelease/ part of the path in baseurl!"
+fi
+
+


### PR DESCRIPTION
All the tools and paths basically grow a "project" argument to distinguish ceph from ceph-iscsi.

In addition, drop el7, add vim modelines, and other minor cleanup.