### PR TITLE
scripts/build_utils.sh: set DOCS_ONLY for PRs with only admin/ files,…

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1705,7 +1705,7 @@ docs_pr_only() {
     files="$(git diff --name-only origin/${ghprbTargetBranch}...origin/pr/${ghprbPullId}/head)"
   fi
   echo -e "changed files:\n$files"
-  if [ $(echo "$files" | grep -v '^doc/' | wc -l) -gt 0 ]; then
+  if [ $(echo "$files" | egrep -v '^(doc/|admin/)' | wc -l) -gt 0 ]; then
       DOCS_ONLY=false
   else
       DOCS_ONLY=true


### PR DESCRIPTION
… too

DOCS_ONLY is set if the filenames all start with docs/, but it's also true that if the filenames start with admin/, it's strictly docs related (discovered for https://github.com/ceph/ceph/pull/57649)