### PR TITLE
ansible/requirements: Use private github repo to fix include:

### DIFF
--- a/ansible/requirements/sensu-requirements.yml
+++ b/ansible/requirements/sensu-requirements.yml
@@ -3,5 +3,7 @@
   name: Mayeu.sensu
   version: remotes/origin/plugin-gem-install
 
-- src: Mayeu.RabbitMQ
-  version: 1.4.0
+- src: https://github.com/dmick/ansible-playbook-rabbitmq
+  scm: git
+  name: Mayeu.RabbitMQ
+  version: remotes/origin/master


### PR DESCRIPTION
ansible has removed include:.  Create a clone of the role to installs rabbitmq and change it to use import_tasks: instead.

@tchaikov this seems to enable ansible syntax checking again.  What do you think?