### PR TITLE
Replace obsolete "include:' in upstream ansible tasks

### DIFF
--- a/ansible/requirements/sensu-requirements.yml
+++ b/ansible/requirements/sensu-requirements.yml
@@ -1,7 +1,9 @@
-- src: https://github.com/andrewschoen/ansible-playbook-sensu
+- src: https://github.com/dmick/ansible-playbook-sensu
   scm: git
   name: Mayeu.sensu
   version: remotes/origin/plugin-gem-install
 
-- src: Mayeu.RabbitMQ
-  version: 1.4.0
+- src: https://github.com/dmick/ansible-playbook-rabbitmq
+  scm: git
+  name: Mayeu.RabbitMQ
+  version: remotes/origin/master

--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -31,7 +31,7 @@
             - andrewschoen
           org-list:
             - ceph
-          trigger-phrase: ''
+          trigger-phrase: '.*retest.*'
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false


### PR DESCRIPTION
Clone the upstream ansible task repos "Mayeu/ansible-playbook-rabbitmq" and "andrewschoen/ansible-playbook-sensu" (already a clone of "Mayeu/ansible-playbook-sensu"); add commits to transition from "include:" to "import_tasks:", and use the new clones as the ansible-galaxy dependency in this repo's pull-request tests.

also, add a trigger phrase to rerun the tests.