### PR TITLE
ceph-container-build-ceph-base-push-imgs*: allow specifying FLAVOR

### DIFF
--- a/ceph-container-build-ceph-base-push-imgs-arm64/config/definitions/ceph-container-build-ceph-base-push-imgs-arm64.yml
+++ b/ceph-container-build-ceph-base-push-imgs-arm64/config/definitions/ceph-container-build-ceph-base-push-imgs-arm64.yml
@@ -20,6 +20,12 @@
     triggers:
       - timed: '@daily'
 
+    parameters:
+      - string:
+          name: AARCH64_FLAVORS_TO_BUILD
+          description: "arm64 flavor(s) to build"
+          default: "pacific,centos,8 quincy,centos,8 reef,centos,8"
+
     scm:
       - git:
           url: https://github.com/ceph/ceph-container.git

--- a/ceph-container-build-ceph-base-push-imgs/config/definitions/ceph-container-build-ceph-base-push-imgs.yml
+++ b/ceph-container-build-ceph-base-push-imgs/config/definitions/ceph-container-build-ceph-base-push-imgs.yml
@@ -20,6 +20,12 @@
     triggers:
       - timed: '@daily'
 
+    parameters:
+      - string:
+          name: X86_64_FLAVORS_TO_BUILD
+          description: "x86 flavor(s) to build"
+          default: "pacific,centos,8 quincy,centos,8 reef,centos,8"
+
     scm:
       - git:
           url: https://github.com/ceph/ceph-container.git


### PR DESCRIPTION
Add parameters to set variables that the job scripts will look for to choose which flavors to build.  This will override the defaults in ceph-container.git; the defaults are set to the same as ceph-container.git at this moment, but are probably soon to change to centos,9.