### PR TITLE
ceph-windows-pull-requests: constrain to windows label

### DIFF
--- a/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
+++ b/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: amd64 && focal && libvirt
+    node: amd64 && focal && libvirt && windows
     display-name: 'ceph-windows: Pull Requests'
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
Currently, the intersection of focal && libvirt labels returns some smithi (nproc == 8) and mira (nproc == 4) nodes, which are inadequate for the two VMs that the Windows job spawns.  It turns we already have a windows label, which, after dropping it from mira015, seems to be on point (i.e. would filter those low CPU nodes out).  Let's use it!