### PR TITLE
cephadm-ansible: remove el8 test scenario

### DIFF
--- a/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
+++ b/cephadm-ansible-prs/config/definitions/cephadm-ansible-prs.yml
@@ -12,7 +12,6 @@
     name: cephadm-ansible-prs-functional
     worker_labels: 'vagrant && libvirt && (braggi || adami)'
     distribution:
-      - el8
       - el9
     scenario:
       - functional


### PR DESCRIPTION
Due to CentOS 8 eol on May 31, 2024*, cephadm-ansible testing against CentOS 8 is removed

*https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/