### PR TITLE
scripts/dashboard: kill existing xvfb process

### DIFF
--- a/scripts/dashboard/install-e2e-test-deps.sh
+++ b/scripts/dashboard/install-e2e-test-deps.sh
@@ -29,3 +29,6 @@ EOF
     sudo yum install -y python-requests pyOpenSSL python-jinja2 python-jwt scipy python-routes python3-routes
     sudo yum install -y xorg-x11-server-Xvfb.x86_64
 fi
+
+# kill any existing Xvfb process to avoid port conflict
+sudo killall Xvfb || true


### PR DESCRIPTION
To fix the below error on starting cypress
```
[STARTED] Task without title.
[FAILED] Xvfb exited with a non zero exit code.
[FAILED]
[FAILED] There was a problem spawning Xvfb.
[FAILED]
[FAILED] This is likely a problem with your system, permissions, or installation of Xvfb.
[FAILED]
[FAILED] ----------
[FAILED]
[FAILED] Error: _XSERVTransSocketUNIXCreateListener: ...SocketCreateListener() failed
[FAILED] _XSERVTransMakeAllCOTSServerListeners: server already running
[FAILED] (EE)
[FAILED] Fatal server error:
[FAILED] (EE) Cannot establish any listening sockets - Make sure an X server isn't already running(EE)
[FAILED]
[FAILED] ----------
[FAILED]
[FAILED] Platform: linux-x64 (Ubuntu - 22.04)
[FAILED] Cypress Version: 12.17.4
Xvfb exited with a non zero exit code.

There was a problem spawning Xvfb.

This is likely a problem with your system, permissions, or installation of Xvfb.
```