### PR TITLE
Fix up quay-pruner

### DIFF
--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -10,7 +10,6 @@ QUAYBASE = "https://quay.ceph.io/api/v1"
 REPO = "ceph-ci/ceph"
 
 # cache shaman search results so we only have to ask once
-short_sha1_cache = set()
 sha1_cache = set()
 
 # quay page ranges to fetch; hackable for testing
@@ -123,11 +122,6 @@ def ref_present_in_shaman(ref, short_sha1, el, arch, verbose):
     if ref is None:
         return False
 
-    if short_sha1 in short_sha1_cache:
-        if verbose:
-            print('Found %s in shaman short_sha1_cache' % short_sha1)
-        return True
-
     error, matches = query_shaman(ref, None, el)
     if error:
         print('Shaman request failed')
@@ -141,7 +135,6 @@ def ref_present_in_shaman(ref, short_sha1, el, arch, verbose):
         if match['sha1'][0:7] == short_sha1:
             if verbose:
                 print('Found %s in shaman: sha1 %s' % (ref, match['sha1']))
-            short_sha1_cache.add(short_sha1)
             return True
     return False
 

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -289,11 +289,14 @@ def main():
                 if args.verbose:
                     print('Skipping %s, present in shaman' % name)
                 continue
-            if args.verbose:
-                print(
-                    'Marking %s for deletion: orphaned sha1 tag' % name
-                )
-            tags_to_delete.add(name)
+            # <sha1>-crimson tags don't have full or ref tags to go with.
+            # Delete them iff the default <sha1> tag is to be deleted
+            if (match[2] == '-crimson') and (sha1 in tags_to_delete):
+                if args.verbose:
+                    print(
+                        'Marking %s for deletion: orphaned sha1 tag' % name
+                    )
+                tags_to_delete.add(name)
 
     if args.verbose:
         print('\nDeleting tags:', sorted(tags_to_delete))

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -302,7 +302,7 @@ def main():
         print('\nDeleting tags:', sorted(tags_to_delete))
 
     # and now delete all the ones we found
-    for tagname in sorted(tags_to_delete):
+    for tagname in tags_to_delete:
         delete_from_quay(tagname, quaytoken, args.dryrun)
 
 

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -74,6 +74,7 @@ def query_shaman(ref, sha1, el):
 
     error = False
     if shaman_data is None:
+        print('Getting repo data from shaman for ceph builds', file=sys.stderr)
         params = {
             'project': 'ceph',
             'flavor': 'default',
@@ -215,6 +216,7 @@ def main():
                 'rb'
             ).read().strip().decode()
 
+    print('Getting ceph-ci container tags from quay.ceph.io', file=sys.stderr)
     quaytags = get_all_quay_tags(quaytoken)
 
     # build a map of digest to name(s) for detecting "same image"

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -224,7 +224,7 @@ def main():
     for tag in quaytags:
         digest = tag['manifest_digest']
         if digest in digest_map:
-           digest_map[digest].add(tag['name'])
+            digest_map[digest].add(tag['name'])
         else:
             digest_map[digest] = set((tag['name'],))
 

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -230,7 +230,6 @@ def main():
 
     # find all full tags to delete, put them and ref tag on list
     tags_to_delete = set()
-    short_sha1s_to_delete = list()
     for tag in quaytags:
         name = tag['name']
         if 'expiration' in tag or 'end_ts' in tag:
@@ -271,28 +270,13 @@ def main():
                 if args.verbose:
                     print(f'Also marking {digest_map[digest]}, same digest')
 
-        if short_sha1:
-            if args.verbose:
-                print('Marking %s for 2nd-pass deletion' % short_sha1)
-            short_sha1s_to_delete.append(short_sha1)
-
     # now find all the full-sha1 tags to delete by making a second
-    # pass and seeing if the tagname starts with a short_sha1 we
-    # know we want deleted, or if it matches SHA1_RE but is gone from
+    # pass and seeing if the tagname matches SHA1_RE but is gone from
     # shaman
     for tag in quaytags:
 
         name = tag['name']
         if 'expiration' in tag or 'end_ts' in tag:
-            continue
-
-        if name[0:7] in short_sha1s_to_delete:
-            if args.verbose:
-                print('Marking %s for deletion: matches short_sha1 %s' %
-                      (name, name[0:7]))
-
-            tags_to_delete.add(name)
-            # already selected a SHA1 tag; no point in checking for orphaned
             continue
 
         match = SHA1_RE.match(name)

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -227,6 +227,9 @@ def main():
             digest_map[digest].add(tag['name'])
         else:
             digest_map[digest] = set((tag['name'],))
+    if args.verbose:
+        for d,l in digest_map.items():
+            print(f'{d}: {l}')
 
     # find all full tags to delete, put them and ref tag on list
     tags_to_delete = set()

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -18,7 +18,7 @@ start_page = 1
 page_limit = 100000
 
 NAME_RE = re.compile(
-    r'(.*)-([0-9a-f]{7})-centos-([78])-(x86_64|aarch64)-devel'
+    r'(.*)-([0-9a-f]{7})-centos-.*([0-9]+)-(x86_64|aarch64)-devel'
 )
 SHA1_RE = re.compile(r'([0-9a-f]{40})(-crimson|-aarch64)*')
 

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -32,7 +32,7 @@ def get_all_quay_tags(quaytoken):
         try:
             response = requests.get(
                 '/'.join((QUAYBASE, 'repository', REPO, 'tag')),
-                params={'page': page, 'limit': 100, 'onlyActiveTags': 'false'},
+                params={'page': page, 'limit': 100, 'onlyActiveTags': 'true'},
                 headers={'Authorization': 'Bearer %s' % quaytoken},
                 timeout=30,
             )


### PR DESCRIPTION
A number of issues and performance enhancements.  Primarily it was not finding recent images at all because we'd switched to 'stream8' rather than '8', and so it was not searching for the right tags.  There were almost 20000 saved images.  That's back down to about 450.  Also, there's no 'image_id' attribute for images anymore, so we must use the sha1 digest to identify same images/different tags.

Also added some performance enhancements; removed an inner loop-inside-loop for every image by building a digest-to-image map, snarfing up all the shaman results in one request so that we can do all the comparisons in local memory, and a few more progress messages.