### PR TITLE
sepia-fog-images: Unlock on failure

### DIFF
--- a/sepia-fog-images/build/failure
+++ b/sepia-fog-images/build/failure
@@ -12,6 +12,13 @@ funPowerCycle () {
   fi
 }
 
+# Should we use teuthology-lock to lock systems?
+if [ "$DEFINEDHOSTS" == "" ]; then
+  use_teuthologylock=true
+else
+  use_teuthologylock=false
+fi
+
 # Clone or update teuthology
 if [ ! -d teuthology ]; then
   git clone https://github.com/ceph/teuthology


### PR DESCRIPTION
Tested here: https://jenkins.ceph.com/job/sepia-fog-images/816/console

The tracebacks are ugly but aren't causing problems; their root cause is that the job expects teuthology to _not_ have any fog configuration present.