### PR TITLE
ceph-volume: use centos9 worker

### DIFF
--- a/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
+++ b/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
@@ -1,7 +1,7 @@
 
 - job:
     name: 'ceph-volume-scenario'
-    node: vagrant&&libvirt&&centos8
+    node: vagrant&&libvirt&&centos9
     concurrent: true
     defaults: global
     display-name: 'ceph-volume: individual scenario testing'


### PR DESCRIPTION
due to recent EOL of CentOS Stream 8, the workers were migrated to CentOS Stream 9.

This commit reflect that change to the ceph-volume-scenario job.