### PR TITLE
ceph-volume: update labels

### DIFF
--- a/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-ansible-prs/config/definitions/ceph-volume-pr.yml
@@ -49,7 +49,7 @@
 - job-template:
     name: 'ceph-volume-prs-{subcommand}-{distro}-{objectstore}-{scenario}'
     display-name: 'ceph-volume {subcommand}: Pull Request [{distro}-{objectstore}-{scenario}]'
-    node: vagrant&&libvirt&&centos8
+    node: vagrant&&libvirt&&centos9
     concurrent: true
     project-type: freestyle
     defaults: global

--- a/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
+++ b/ceph-volume-nightly/config/definitions/ceph-volume-nightly.yml
@@ -61,7 +61,7 @@
 - job-template:
     name: 'ceph-volume-nightly-{ceph_branch}-{subcommand}-{distro}-{objectstore}-{scenario}'
     display-name: 'ceph-volume {ceph_branch} {subcommand}: [{distro}-{objectstore}-{scenario}]'
-    node: vagrant&&libvirt&&centos8
+    node: vagrant&&libvirt&&centos9
     concurrent: true
     project-type: freestyle
     defaults: global

--- a/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-pr/config/definitions/ceph-volume-pr.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-volume-pr
     display-name: 'ceph-volume: Pull Request tox tests'
-    node: small && centos8
+    node: small && centos9
     project-type: freestyle
     defaults: global
     quiet-period: 5


### PR DESCRIPTION
These labels must be updated to make ceph-volume jobs use `centos9` workers.