### PR TITLE
sync-images: update worker labels

### DIFF
--- a/sync-images/config/definitions/sync-images.yml
+++ b/sync-images/config/definitions/sync-images.yml
@@ -1,7 +1,7 @@
 - job:
     name: sync-images
     id: sync-images
-    node: small && centos8
+    node: small && centos9
     defaults: global
     display-name: sync-images
     quiet-period: 5


### PR DESCRIPTION
This updates the labels for the `sync-images` job. (c8->c9)