### PR TITLE
ceph-container: migrate to c9 jenkins workers

### DIFF
--- a/ceph-container-flake8/config/definitions/ceph-container-flake8.yml
+++ b/ceph-container-flake8/config/definitions/ceph-container-flake8.yml
@@ -14,7 +14,7 @@
 
 - job:
     name: ceph-container-flake8
-    node: small && centos8
+    node: small && centos9
     defaults: global
     display-name: 'ceph-container-flake8'
     properties:

--- a/ceph-container-lint/config/definitions/ceph-container-lint.yml
+++ b/ceph-container-lint/config/definitions/ceph-container-lint.yml
@@ -14,7 +14,7 @@
 
 - job:
     name: ceph-container-lint
-    node: small && centos8
+    node: small && centos9
     defaults: global
     display-name: 'ceph-container-lint'
     properties:


### PR DESCRIPTION
Due the the EOL of CentOS Stream 8, all the Jenkins workers were migrated to CentOS Stream 9. Therefore, we need to make these jobs pick these workers.