### PR TITLE
ceph-ansible: remove el8 test scenario

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -23,7 +23,7 @@
 
 - project:
     name: ceph-ansible-prs
-    builder_labels: 'vagrant && libvirt && (smithi || braggi || centos8)'
+    builder_labels: 'vagrant && libvirt && (smithi || braggi)'
     distribution:
       - centos
     deployment:
@@ -40,7 +40,7 @@
 
 - project:
     name: ceph-ansible-prs-docker2podman
-    builder_labels: 'vagrant && libvirt && (smithi || braggi || centos8)'
+    builder_labels: 'vagrant && libvirt && (smithi || braggi)'
     distribution:
       - centos
     deployment:
@@ -78,7 +78,7 @@
 
 - project:
     name: ceph-ansible-prs-common-trigger
-    builder_labels: 'vagrant && libvirt && (smithi || braggi || centos8)'
+    builder_labels: 'vagrant && libvirt && (smithi || braggi)'
     distribution:
       - centos
     deployment:


### PR DESCRIPTION
Due to CentOS 8 eol on May 31, 2024*, cephadm-ansible testing against CentOS 8 is removed

*https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/