### PR TITLE
adding clang-tidy as a linter tool

### DIFF
--- a/ceph-pr-clang-tidy/build/build
+++ b/ceph-pr-clang-tidy/build/build
@@ -1,0 +1,1 @@
+sudo apt-get install -y clang-tidy

--- a/ceph-pr-clang-tidy/config/ceph-pr-clang-tidy.yml
+++ b/ceph-pr-clang-tidy/config/ceph-pr-clang-tidy.yml
@@ -1,0 +1,61 @@
+- job:
+    name: ceph-pr-clang-tidy
+    node: small
+    project-type: freestyle
+    defaults: global
+    display-name: 'ceph: Clang-tidy checks'
+    concurrent: true
+    quiet-period: 5
+    block-downstream: false
+    block-upstream: false
+    retry-count: 3
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          artifact-days-to-keep: 15
+      - github:
+          url: https://github.com/ceph/ceph/
+
+  parameters:
+  - string:
+      name: ghprbPullId
+      description: "the GitHub pull id, like '72' in 'ceph/pull/72'"
+      default: origin/main
+
+  scm:
+  - git:
+      url: https://github.com/ceph/ceph.git
+      name: origin
+      branches:
+        - origin/pr/${ghprbPullId}/merge
+      refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+      skip-tag: true
+      shallow-clone: true
+      honor-refspec: true
+      timeout: 20
+
+  triggers:
+  - github-pull-request:
+      allow-whitelist-orgs-as-admins: true
+      org-list:
+        - ceph
+      trigger-phrase: 'jenkins test clang-tidy'
+      only-trigger-phrase: false
+      github-hooks: true
+      permit-all: true
+      auto-close-on-fail: false
+      status-context: "Signed-off-by"
+      started-status: "checking if bugs exist in file"
+      success-status: "no bugs found"
+      failure-status: "bugs found"
+
+  builders:
+  - shell:
+      !include-raw:
+        - ../../../scripts/build_utils.sh
+        - ../../build/build
+
+  publishers:
+  - junit:
+      results: report.xml
+      allow-empty-results: true


### PR DESCRIPTION
The Ceph project has a huge codebase, and it faces the risk of containing suboptimal code that could jeopardize storage reliability or induce performance bottlenecks or cause resource inefficiencies. Identifying and rectifying such code issues is important to maintain the integrity and efficiency of the Ceph storage system. clang-tidy, a powerful static analysis tool, offers a systematic approach to uncover critical issues within the codebase and generate comprehensive reports highlighting potential vulnerabilities.

Integrating clang-tidy into the Jenkins CI pipeline of Ceph would be very beneficial for the development, as any new possible vulnerabilities would be identified early on. The goal is to enhance code quality, maintain performance, and ensure the reliability of the storage system by continuously monitoring and addressing potential issues through automated static analysis.
