### PR TITLE
build_utils: bump ubuntu jammy to gcc-12

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -802,7 +802,13 @@ setup_pbuilder_for_old_gcc() {
         focal)
             old=9;;
         jammy)
-            old=12;;
+            # jammy has gcc-12 but it may not be installed
+            old=12
+            cat >> $hookdir/D05install-old-gcc <<EOF
+env DEBIAN_FRONTEND=noninteractive apt-get install -y g++-$old
+EOF
+            chmod +x $hookdir/D05install-old-gcc
+            ;;
     esac
     setup_gcc_hook $old > $hookdir/D10update-gcc-alternatives
     chmod +x $hookdir/D10update-gcc-alternatives

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -802,7 +802,7 @@ setup_pbuilder_for_old_gcc() {
         focal)
             old=9;;
         jammy)
-            old=11;;
+            old=12;;
     esac
     setup_gcc_hook $old > $hookdir/D10update-gcc-alternatives
     chmod +x $hookdir/D10update-gcc-alternatives


### PR DESCRIPTION
jammy provides gcc-12, so we don't need to set `use_ppa=true` or call `setup_pbuilder_for_new_gcc()` to get it

`setup_pbuilder_for_old_gcc()` just selects gcc-12 for jammy and adds a `D05install-old-gcc` hook to make sure it's installed (similar to `D05install-new-gcc` from `setup_pbuilder_for_new_gcc()` but without ppa stuff)