### PR TITLE
ceph-dev: revive centos 8 builds for quincy and reef using vault.centos.org repos

### DIFF
--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -57,7 +57,7 @@
                     FORCE=True
                     DISTROS=focal centos8 centos9 leap15
       # build reef on:
-      # default: jammy focal centos9 windows
+      # default: jammy focal centos8 centos9 windows
       # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
@@ -74,7 +74,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy focal centos9 windows
+                    DISTROS=jammy focal centos8 centos9 windows
                 - project: 'ceph-dev'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -39,7 +39,7 @@
 
     builders:
       # build quincy on:
-      # default: focal centos9 leap15
+      # default: focal centos8 centos9 leap15
       - conditional-step:
           condition-kind: regex-match
           regex: .*quincy.*
@@ -55,7 +55,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal centos9 leap15
+                    DISTROS=focal centos8 centos9 leap15
       # build reef on:
       # default: jammy focal centos9 windows
       # crimson: centos9

--- a/ceph-dev-new-build/build/setup_rpm
+++ b/ceph-dev-new-build/build/setup_rpm
@@ -18,9 +18,16 @@ if test $(id -u) != 0 ; then
 fi
 export LC_ALL=C # the following is vulnerable to i18n
 
-$SUDO yum install -y yum-utils
-
 get_rpm_dist
+
+if [ "$DIST" = el8 ]; then
+    # after centos stream 8 eol, its repos were moved to vault.centos.org
+    $SUDO sed -i -e 's|mirrorlist|#mirrorlist|g' \
+-e 's|#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g' \
+/etc/yum.repos.d/*.repo
+fi
+
+$SUDO yum install -y yum-utils
 
 BRANCH=`branch_slash_filter $BRANCH`
 

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -118,7 +118,7 @@
                     FORCE=True
                     DISTROS=focal bionic centos8 windows
       # build quincy on:
-      # default: focal jammy centos9 leap15
+      # default: focal jammy centos8 centos9 leap15
       - conditional-step:
           condition-kind: regex-match
           regex: .*quincy.*
@@ -134,7 +134,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=focal jammy centos9 leap15
+                    DISTROS=focal jammy centos8 centos9 leap15
       # build reef on:
       # default: jammy focal centos9 windows
       # crimson: centos9

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -136,7 +136,7 @@
                     FORCE=True
                     DISTROS=focal jammy centos8 centos9 leap15
       # build reef on:
-      # default: jammy focal centos9 windows
+      # default: jammy focal centos8 centos9 windows
       # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
@@ -153,7 +153,7 @@
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
-                    DISTROS=jammy focal centos9 windows
+                    DISTROS=jammy focal centos8 centos9 windows
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
                     BRANCH=${GIT_BRANCH}


### PR DESCRIPTION
point at vault.centos.org mirrors for centos 8 as suggested by @k0ste on the ceph-users mailing list thread [Reef 18.2.4 EL8 packages ?](https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/message/URFKM7L3Q3VHZNNGZRE2XVAIMOL7ZNGV/)

revert the commits from https://github.com/ceph/ceph-build/pull/2235 that removed centos 8 from the build matrix for quincy and reef branches