### PR TITLE
sepia-fog-images: Work around ansible-galaxy installation problem

### DIFF
--- a/sepia-fog-images/build/build
+++ b/sepia-fog-images/build/build
@@ -186,7 +186,12 @@ while [[ $(echo $remaininghosts | wc -w) != 0 ]]; do
       # Set DHCP back
       ssh ubuntu@store01.front.sepia.ceph.com "sudo /usr/local/sbin/set-next-server.sh $host fog"
       # Prep the host for FOG image capture
+      #
+      # this pushd/popd should not be necessary, but I'm trying to get ansible to find
+      # its galaxy modules in teuthology/.ansible
+      pushd $WORKSPACE/teuthology
       ansible-playbook $WORKSPACE/ceph-cm-ansible/tools/prep-fog-capture.yml -e ansible_ssh_user=ubuntu --limit="$host*"
+      popd
       remaininghosts=${remaininghosts//$host/}
     else
       # This gets noisy


### PR DESCRIPTION
The mount module is now ansible.posix.mount, and ansible-playbook can't seem to find it when executed from the parent directory. Change to teuthology/ to make it work, in lieu of being able to find any documentation at all about how it ought to be working