### PR TITLE
archiving `ceph` directory for the job 'ceph-pr-clang-tidy'

### DIFF
--- a/ceph-pull-requests/build/build
+++ b/ceph-pull-requests/build/build
@@ -12,3 +12,5 @@ export WITH_RBD_RWL=true
 timeout 3h ./run-make-check.sh
 sleep 5
 ps -ef | grep -v jnlp | grep ceph || true
+
+sudo tar -czf ceph_build.tar.gz *

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -64,6 +64,8 @@
         !include-raw:
           - ../../../scripts/build_utils.sh
           - ../../build/build
+    - trigger-builds:
+        - project: 'ceph-pr-clang-tidy'
 
     publishers:
       - cobertura:
@@ -102,6 +104,10 @@
             - ctest:
                 pattern: "build/Testing/**/Test.xml"
                 skip-if-no-test-files: true
+      - archive:
+          artifacts: 'ceph_build.tar.gz'
+          allow-empty: false
+          latest-only: false
     wrappers:
       - ansicolor
       - credentials-binding:


### PR DESCRIPTION
The job `ceph-pr-clang-tidy` requires Ceph's build but since the job `ceph-pull-requests` is already building Ceph it is best to archive & copy the directory and work further upon it. It is done to save time and resources required to again build Ceph.

artifact required by: https://github.com/ceph/ceph-build/pull/2269