### PR TITLE
ceph-ansible-prs: set black-list-labels

### DIFF
--- a/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
+++ b/ceph-ansible-prs/config/definitions/ceph-ansible-prs.yml
@@ -138,6 +138,7 @@
             - ceph
           skip-build-phrase: '^jenkins do not test.*|.*\[skip ci\].*'
           trigger-phrase: '^jenkins test {distribution}-{deployment}-{scenario}|jenkins test all.*'
+          black-list-labels: 'draft'
           only-trigger-phrase: false
           github-hooks: true
           permit-all: true


### PR DESCRIPTION
This makes the CI not trigger the jobs when "draft" label is set on PRs.