### PR TITLE
windows: ignore "apt-get update" errors

### DIFF
--- a/ceph-windows-image-build/build/build
+++ b/ceph-windows-image-build/build/build
@@ -37,15 +37,15 @@ function restart_windows_vm() {
 
 
 if ! which virt-install >/dev/null; then
-    sudo apt-get update
+    sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none || true
     sudo apt-get install -y virtinst
 fi
 if ! which xmllint >/dev/null; then
-    sudo apt-get update
+    sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none || true
     sudo apt-get install -y libxml2-utils
 fi
 if ! which jq >/dev/null; then
-    sudo apt-get update
+    sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none || true
     sudo apt-get install -y jq
 fi
 

--- a/ceph-windows-installer-build/build/setup
+++ b/ceph-windows-installer-build/build/setup
@@ -42,7 +42,7 @@ update_build_status "started" "ceph-windows-installer" $DISTRO $DISTRO_VERSION $
 # Install requirements (if needed)
 #
 if ! which unzip >/dev/null; then
-    sudo apt-get update
+    sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none || true
     sudo apt-get install -y unzip
 fi
 

--- a/scripts/ceph-windows/setup_libvirt
+++ b/scripts/ceph-windows/setup_libvirt
@@ -22,11 +22,11 @@ function get_libvirt_vm_ssh_address() {
     fi
 
     if ! which xmllint >/dev/null; then
-        sudo apt-get update
+        sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none || true
         sudo apt-get install -y libxml2-utils
     fi
     if ! which jq >/dev/null; then
-        sudo apt-get update
+        sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none || true
         sudo apt-get install -y jq
     fi
 
@@ -74,7 +74,7 @@ function get_libvirt_vm_ssh_address() {
 #
 # Setup requirements (if needed)
 #
-sudo apt-get update
+sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none || true
 sudo apt-get install -y libvirt-daemon-system virtinst cloud-image-utils qemu-kvm
 
 # Ensure that the libvirt socket is available, otherwise virsh commands will fail.

--- a/scripts/ceph-windows/win32_build
+++ b/scripts/ceph-windows/win32_build
@@ -25,7 +25,7 @@ set -o pipefail
 
 cd ~/ceph
 
-sudo apt-get update
+sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none || true
 sudo apt-get install -y git
 git submodule update --init --recursive
 

--- a/wnbd-build/build/build
+++ b/wnbd-build/build/build
@@ -15,7 +15,7 @@ BUILD_CONFIGURATION=${BUILD_CONFIGURATION:-"Release"}
 # Install requirements (if needed)
 #
 if ! which zip >/dev/null; then
-    sudo apt-get update
+    sudo apt-get update -o Acquire::Languages=none -o Acquire::Translation=none || true
     sudo apt-get install -y zip
 fi
 


### PR DESCRIPTION
... as they are ignored in scripts/build_utils.sh since commit 3517941ef2aa ("script/build_utils.sh: don't fail if any mirror is not accessible").  This is prompted by an issue with libboost repo, which started returning 403 Forbidden errors.

While at it, skip fetching language and translation packs.