### PR TITLE
sync-images: sync all images including their different aarch

### DIFF
--- a/sync-images/build/build
+++ b/sync-images/build/build
@@ -15,4 +15,4 @@ docker.io:
 EOF
 # make sure we pull the last stable image
 podman pull quay.io/skopeo/stable
-podman run --rm --security-opt label=disable -v ./sync.yml:/sync.yml:ro quay.io/skopeo/stable sync --src yaml --dest docker /sync.yml "${DEST_REGISTRY}" --dest-username "${DEST_USERNAME}" --dest-password "${DEST_PASSWORD}"
+podman run --rm --security-opt label=disable -v ./sync.yml:/sync.yml:ro quay.io/skopeo/stable sync --all --src yaml --dest docker /sync.yml "${DEST_REGISTRY}" --dest-username "${DEST_USERNAME}" --dest-password "${DEST_PASSWORD}"


### PR DESCRIPTION
The sync is not syncing the different architectures supported by the images atleast for grafana. And hence only the amd64 gets mirrored to the quay repo and causes issues to arm64 builds. I saw that skopeo supports an `--all` opton that copies images of every aarch.

Refer: https://github.com/containers/skopeo/blob/main/docs/skopeo-sync.1.md#options

Fixes: https://tracker.ceph.com/issues/68627