### PR TITLE
Clean up problematic rpm macro, install skopeo package for centos9

### DIFF
--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -731,7 +731,7 @@
             dest: "/home/{{ jenkins_user }}/.rpmmacros"
             regexp: '^%dist'
             line: '%dist .el{{ ansible_distribution_major_version }}'
-      when: ansible_os_family == "RedHat"
+      when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int <= 7
 
     ## tmpwatch/tmpreaper TASKS
     - name: tmpwatch/tmpreaper Tasks

--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -234,6 +234,7 @@
           - python3-pip
           - python3-devel
           - podman
+          - skopeo
         container_service_name: podman
         container_certs_path: "/etc/containers/certs.d/{{ container_mirror }}"
         hackery_packages:


### PR DESCRIPTION
couple small changes to the ansible for Jenkins builders:

1) don't set dist in rpmmacros; it was causing el9 packages to be labeled el8, and isn't necessary at all
2) add skopeo to installed packages (for container builds).

The package code ought to be cleaned up so that 'epel_packages' is what it says it is.