### PR TITLE
Keep track of extra script get-tarballs.sh

### DIFF
--- a/scripts/get-tarballs.sh
+++ b/scripts/get-tarballs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Helper to get tarballs for releases
+# Does not do any placement, you must be on the destination directory.
+
+# There are two files it grabs, one with 'orig' and one without (unsure why we need both)
+
+: ${2?"Usage: $0 \$release \$sha1 \$version"}
+
+release=$1
+sha1=$2
+version=$3
+
+pushd /data/download.ceph.com/www/tarballs
+
+if [ ! -f ceph_$version.orig.tar.gz ]; then
+  wget https://chacra.ceph.com/binaries/ceph/$release/$sha1/ubuntu/focal/x86_64/flavors/default/ceph_$version.orig.tar.gz || wget https://chacra.ceph.com/binaries/ceph/$release/$sha1/ubuntu/jammy/x86_64/flavors/default/ceph_$version.orig.tar.gz
+  wget https://chacra.ceph.com/binaries/ceph/$release/$sha1/ubuntu/focal/x86_64/flavors/default/ceph-$version.tar.gz || wget https://chacra.ceph.com/binaries/ceph/$release/$sha1/ubuntu/jammy/x86_64/flavors/default/ceph-$version.tar.gz
+fi
+
+popd
+


### PR DESCRIPTION
This is used by sync-pull to fetch the tarballs when constructing a release, but needs modification for the prerelease/ directory structure.  It's invoked by ssh to download.ceph.com to run from /home/signer/bin, because it needs to copy large files from chacra to download.ceph.com and doing that on download.ceph.com is much more efficient.