### PR TITLE
build_utils.sh, various PR build scripts: skip if container/

### DIFF
--- a/ceph-pr-api/build/build
+++ b/ceph-pr-api/build/build
@@ -1,8 +1,9 @@
 #!/bin/bash -e
 
 docs_pr_only
-if [ "$DOCS_ONLY" = true ]; then
-    echo "Only the doc/ dir changed.  No need to run make check or API tests."
+container_pr_only
+if [[ "$DOCS_ONLY" = true || "$CONTAINER_ONLY" = true ]]; then
+    echo "Only the doc/ or container/ dir changed.  No need to run make check or API tests."
     mkdir -p $WORKSPACE/build/out
     echo "File created to avoid Jenkins' Artifact Archiving plugin from hanging" > $WORKSPACE/build/out/mgr.foo.log
     exit 0

--- a/ceph-pull-requests-arm64/build/build
+++ b/ceph-pull-requests-arm64/build/build
@@ -1,8 +1,9 @@
 #!/bin/bash -ex
 
 docs_pr_only
-if [ "$DOCS_ONLY" = true ]; then
-    echo "Only the doc/ dir changed.  No need to run make check."
+container_pr_only
+if [[ "$DOCS_ONLY" = true || "$CONTAINER_ONLY" = true ]]; then
+    echo "Only the doc/ or container/ dir changed.  No need to run make check."
     exit 0
 fi
 

--- a/ceph-pull-requests/build/build
+++ b/ceph-pull-requests/build/build
@@ -1,8 +1,9 @@
 #!/bin/bash -ex
 
 docs_pr_only
-if [ "$DOCS_ONLY" = true ]; then
-    echo "Only the doc/ dir changed.  No need to run make check."
+container_pr_only
+if [[ "$DOCS_ONLY" = true || "$CONTAINER_ONLY" = true ]]; then
+    echo "Only the doc/ or container/ dir changed.  No need to run make check."
     exit 0
 fi
 

--- a/ceph-windows-pull-requests/build/check_docs_pr_only
+++ b/ceph-windows-pull-requests/build/check_docs_pr_only
@@ -3,7 +3,8 @@ set -o errexit
 set -o pipefail
 
 docs_pr_only
-if [ "$DOCS_ONLY" = true ]; then
-    echo "Only the doc/ dir changed. No need to run Ceph Windows tests."
+container_pr_only
+if [[ "$DOCS_ONLY" = true || "$CONTAINER_ONLY" = true ]]; then
+    echo "Only the doc/ or container/ dir changed. No need to run Ceph Windows tests."
     exit 0
 fi


### PR DESCRIPTION
Parallel to the docs-only test, skip PR checks (api, make check, etc.) if the only changes are to the container/ subdirectory

Signed-off-by: Dan Mick <dan.mick@redhat.com>