### PR TITLE
ceph-dev-build: change to use container/Containerfile

### DIFF
--- a/ceph-dev-build/build/build_rpm
+++ b/ceph-dev-build/build/build_rpm
@@ -88,7 +88,8 @@ if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" && "$RELEASE" =~ 8|9 ]] ; t
     loop=0
     ready=false
     while ((loop < 15)); do
-      if [[ $(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/${RELEASE}/${ARCH}&sha1=${SHA1}&ref=${BRANCH}&flavor=${FLAVOR}" | jq -r '.[0].status') == 'ready' ]] ; then ready=true; break; fi
+      curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/${RELEASE}/${ARCH}&sha1=${SHA1}&ref=${BRANCH}&flavor=${FLAVOR}" > shaman.status
++     if [[ ($(jq -r '.[0].extra.build_url' < shaman.status) == ${BUILD_URL}) && ($(jq -r '.[0].status' < shaman.status) == 'ready') ]] ; then ready=true; break; fi
       ((loop = loop + 1))
       sleep 60
     done
@@ -99,12 +100,9 @@ if [[ "$CI_CONTAINER" == true && $DISTRO == "centos" && "$RELEASE" =~ 8|9 ]] ; t
       # update_build_status "failed" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
       # exit 1
     fi
-
-    cd $WORKSPACE/ceph-container
-    sudo -E CI_CONTAINER=${CI_CONTAINER} SHA1=${SHA1} OSD_FLAVOR=${FLAVOR} CONTAINER_FLAVOR=${BRANCH},${DISTRO},${RELEASE} \
-      /bin/bash ./contrib/build-push-ceph-container-imgs.sh
-    cd $WORKSPACE
-    sudo rm -rf ceph-container
+    # get into $WORKSPACE/$dist/ceph-$cephver, where the copied source tree is
+    cd ${WORKSPACE}/dist/ceph-${cephver}/container
+    CEPH_SHA1=${SHA1} ./build.sh
 fi
 
 # update shaman with the completed build status

--- a/ceph-dev-build/build/failure
+++ b/ceph-dev-build/build/failure
@@ -1,12 +1,5 @@
 #!/bin/bash -ex
 
-# The ceph-container dir is supposed to get deleted in the build_rpm script.
-# We used to add '|| true' to the container build so the dir would still get
-# deleted even if it failed.  This changed in https://github.com/ceph/ceph-build/pull/1603
-# So now we need to delete the directory or the Wipe Workspace plugin will fail on the next build.
-cd $WORKSPACE
-sudo rm -rf ceph-container
-
 # note: the failed_build_status call relies on normalized variable names that
 # are infered by the builds themselves. If the build fails before these are
 # set, they will be posted with empty values

--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -44,6 +44,11 @@ pwd
 
 setup_rpm_build_deps
 
+if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && "$RELEASE" ~= 8|9 ]] ;
+then
+    podman login -u $CONTAINER_REPO_USERNAME -p $CONTAINER_REPO_PASSWORD $CONTAINER_REPO_HOSTNAME/$CONTAINER_REPO_ORGANIZATION
+fi
+
 cd $WORKSPACE
 
 pkgs=( "chacractl>=0.0.21" )

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -14,16 +14,6 @@
           days-to-keep: 14
           artifact-days-to-keep: 14
 
-    scm:
-      - git:
-          url: git@github.com:ceph/ceph-container.git
-          basedir: ceph-container
-          credentials-id: 'jenkins-build'
-          branches:
-            - $CONTAINER_BRANCH
-          skip-tag: true
-          wipe-workspace: true
-
     execution-strategy:
        combination-filter: |
          DIST == AVAILABLE_DIST && ARCH == AVAILABLE_ARCH &&

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -63,11 +63,6 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           default: true
 
       - string:
-          name: CONTAINER_BRANCH
-          description: "For CI_CONTAINER: Branch of ceph-container to use"
-          default: main
-
-      - string:
           name: CONTAINER_REPO_HOSTNAME
           description: "For CI_CONTAINER: Name of container repo server (i.e. 'quay.io')"
           default: "quay.ceph.io"


### PR DESCRIPTION
This is the same change as done by 6361c5c4bac7467893b1f629090712c8c0d736a8 and 435515fe481bd1752b630d23986249e90c0fa4f8 in ceph-dev-new-build, but for ceph-dev-build.  ceph-container is no longer used.

Also remove CONTAINER_BRANCH parameter from ceph-dev.