### PR TITLE
ceph-dev-build/build/setup_rpm: fix syntax error

### DIFF
--- a/ceph-dev-build/build/setup_rpm
+++ b/ceph-dev-build/build/setup_rpm
@@ -44,7 +44,7 @@ pwd
 
 setup_rpm_build_deps
 
-if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && "$RELEASE" ~= 8|9 ]] ;
+if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && "$RELEASE" =~ 8|9 ]] ;
 then
     podman login -u $CONTAINER_REPO_USERNAME -p $CONTAINER_REPO_PASSWORD $CONTAINER_REPO_HOSTNAME/$CONTAINER_REPO_ORGANIZATION
 fi


### PR DESCRIPTION
Reversed the =~ operator when porting change from ceph-dev-new-build