### PR TITLE
ceph,ceph-build: build prerelease containers (using container/)

### DIFF
--- a/ceph-build/build/build_rpm
+++ b/ceph-build/build/build_rpm
@@ -60,5 +60,28 @@ EOF
     $VENV/chacractl repo update ${chacra_repo_endpoint}
 fi
 
+# XXX perhaps use job parameters instead of literals; then
+# later stages can also use them to compare etc.
+if [[ $DISTRO == "centos" && "$RELEASE" =~ 8|9 ]] ; then
+    loop=0
+    ready=false
+    while ((loop < 15)); do
+      curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/${RELEASE}/${ARCH}&sha1=${SHA1}&ref=${BRANCH}&flavor=${FLAVOR}" > shaman.status
+      if [[ ($(jq -r '.[0].extra.build_url' < shaman.status) == ${BUILD_URL}) && ($(jq -r '.[0].status' < shaman.status) == 'ready') ]] ; then ready=true; break; fi
+      ((loop = loop + 1))
+      sleep 60
+    done
+
+    if [[ "$ready" == "false" ]] ; then
+      echo "FAIL: timed out waiting for shaman repo to be built:  https://shaman.ceph.com/api/repos/${chacra_endpoint}/flavors/${FLAVOR}/"
+      # don't fail the build here on purpose
+      # update_build_status "failed" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
+      # exit 1
+    fi
+    # get into $WORKSPACE/$dist/ceph-$cephver, where the copied source tree is
+    cd ${WORKSPACE}/dist/ceph-${cephver}/container
+    CEPH_SHA1=${SHA1} ./build.sh
+fi
+
 # update shaman with the completed build status
 update_build_status "completed" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH

--- a/ceph-build/build/setup_rpm
+++ b/ceph-build/build/setup_rpm
@@ -30,6 +30,12 @@ pwd
 get_rpm_dist
 setup_rpm_build_deps
 
+if [[ $DISTRO == "centos" && "$RELEASE" =~ 8|9 ]] ;
+then
+    podman login -u $CONTAINER_REPO_USERNAME -p $CONTAINER_REPO_PASSWORD $CONTAINER_REPO_HOSTNAME/$CONTAINER_REPO_ORGANIZATION
+fi
+
+
 BRANCH=`branch_slash_filter $BRANCH`
 
 if [[ ! -f /etc/redhat-release && ! -f /usr/bin/zypper ]] ; then

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -126,3 +126,7 @@
           - text:
               credential-id: shaman-api-key
               variable: SHAMAN_API_KEY
+          - username-password-separated:
+              credential-id: quay-ceph-io-ceph-ci
+              username: CONTAINER_REPO_USERNAME
+              password: CONTAINER_REPO_PASSWORD

--- a/ceph/config/definitions/ceph.yml
+++ b/ceph/config/definitions/ceph.yml
@@ -86,6 +86,16 @@ SECURITY: Builds from BRANCH-release branch in ceph-private.git (private repo)."
           description: "A list of architectures to build for. Available options are: x86_64, and arm64"
           default: "x86_64 arm64"
 
+      - string:
+          name: CONTAINER_REPO_HOSTNAME
+          description: "Name of (prerelease) container repo server (i.e. 'quay.ceph.io')"
+          default: "quay.ceph.io"
+
+      - string:
+          name: CONTAINER_REPO_ORGANIZATION
+          description: "Name of (prerelease) container repo organization (i.e. 'ceph').  Container build script will add prerelease-<arch>"
+          default: "ceph"
+
     builders:
       - multijob:
           name: 'ceph setup phase'


### PR DESCRIPTION
The final change to use container/build.sh rather than ceph-container: the release-build jobs "ceph/ceph-setup/ceph-build".  These changes cause builds to also build a container (they had not done so before) and push the images to quay.ceph.io/ceph/prerelease* for validation before promotion.  See container/make-manifest-list.py for the final container-release steps: building the 'fat' manifest-list image and promoting allt three images to quay.io/ceph/ceph.