### PR TITLE
ceph-website-prs/config/definitions: remove org filter for site compile check

### DIFF
--- a/ceph-website-prs/config/definitions/ceph-website-prs.yml
+++ b/ceph-website-prs/config/definitions/ceph-website-prs.yml
@@ -23,12 +23,6 @@
 
     triggers:
       - github-pull-request:
-          org-list:
-            - ceph
-          white-list:
-            - adamduncan
-            - Pete-Robelou
-            - zdover23
           cancel-builds-on-update: true
           trigger-phrase: 'jenkins test.*|jenkins retest.*'
           only-trigger-phrase: false


### PR DESCRIPTION
These filters block anyone outside the ceph org from having the site compile check run on their PRs. We do want people from outside the org to be able to raise PRs, so removing these filters will allow that check to run.