### PR TITLE
Revert "ceph-website-prs/config/definitions: remove org filter for site compile check

### DIFF
--- a/ceph-website-prs/config/definitions/ceph-website-prs.yml
+++ b/ceph-website-prs/config/definitions/ceph-website-prs.yml
@@ -23,6 +23,12 @@
 
     triggers:
       - github-pull-request:
+          org-list:
+            - ceph
+          white-list:
+            - adamduncan
+            - Pete-Robelou
+            - zdover23
           cancel-builds-on-update: true
           trigger-phrase: 'jenkins test.*|jenkins retest.*'
           only-trigger-phrase: false

--- a/ceph-website-prs/config/definitions/ceph-website-prs.yml
+++ b/ceph-website-prs/config/definitions/ceph-website-prs.yml
@@ -25,10 +25,6 @@
       - github-pull-request:
           org-list:
             - ceph
-          white-list:
-            - adamduncan
-            - Pete-Robelou
-            - zdover23
           cancel-builds-on-update: true
           trigger-phrase: 'jenkins test.*|jenkins retest.*'
           only-trigger-phrase: false


### PR DESCRIPTION
This reverts commit a227cbd01c628e9d98cf5cb3d96f0a299c4d12c3. We decided that this is too much of a security risk and are looking into better options.