### PR TITLE
Do not run make check or API tests on smithi due to OOM

### DIFF
--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && bionic && x86_64
+    node: huge && bionic && x86_64 && !smithi
     display-name: 'ceph: API'
     quiet-period: 5
     block-downstream: false

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -4,7 +4,7 @@
     defaults: global
     concurrent: true
     # We want make check to only run on Bionic b/c it has python2 and python3 and b/c all builds should build on Bionic
-    node: huge && bionic && x86_64
+    node: huge && bionic && x86_64 && !smithi
     display-name: 'ceph: Pull Requests'
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
Saw many jobs fail on smithi004.  dmesg shows lots of OOM kills.

![image](https://github.com/user-attachments/assets/e4fac8c5-6146-475c-bbb8-44f345b46a07)
