### PR TITLE
ceph-build: use correct quay.ceph.io credentials

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -127,6 +127,6 @@
               credential-id: shaman-api-key
               variable: SHAMAN_API_KEY
           - username-password-separated:
-              credential-id: quay-ceph-io-ceph-ci
+              credential-id: quay-ceph-io-ceph-prerelease
               username: CONTAINER_REPO_USERNAME
               password: CONTAINER_REPO_PASSWORD


### PR DESCRIPTION
ceph-build job needs to push to quay.ceph.io/ceph/prerelease, and the credentials for that are quay-ceph-io-ceph-prerelease