### PR TITLE
ceph-build.yml: fix the name of the Jenkins cred

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -127,6 +127,6 @@
               credential-id: shaman-api-key
               variable: SHAMAN_API_KEY
           - username-password-separated:
-              credential-id: quay-ceph-io-ceph-prerelease
+              credential-id: quay.ceph.io-ceph-prerelease
               username: CONTAINER_REPO_USERNAME
               password: CONTAINER_REPO_PASSWORD


### PR DESCRIPTION
(this is why it's a bad idea to switch between . and _)