### PR TITLE
ceph-{dev-,}setup: Make git submodule operations much quieter.

### DIFF
--- a/ceph-dev-setup/build/build
+++ b/ceph-dev-setup/build/build
@@ -34,7 +34,7 @@ rm -rf release
 
 # run submodule updates regardless
 echo "Running submodule update ..."
-git submodule update --init
+git submodule update --init --quiet
 
 # export args for building optional packages
 ceph_build_args_from_flavor ${FLAVOR}

--- a/ceph-setup/build/build
+++ b/ceph-setup/build/build
@@ -31,7 +31,7 @@ rm -rf release
 
 # run submodule updates regardless
 echo "Running submodule update ..."
-git submodule update --init
+git submodule update --init --quiet
 
 CEPH_EXTRA_RPMBUILD_ARGS="--with tcmalloc"
 CEPH_EXTRA_CMAKE_ARGS="$CEPH_EXTRA_CMAKE_ARGS -DALLOCATOR=tcmalloc"


### PR DESCRIPTION
After f381e3f05fcb08a7b1a3a1aa8f86e066bd4718ba, which is quite the win for ceph-dev-new-setup, credit to zack@redhat.com