### PR TITLE
update all jobs to jenkins-job-builder v6; add 'choose from 7 days old' to ceph-dev-new-trigger

### DIFF
--- a/attic/ceph-dev-container-only/config/definitions/ceph-dev-container-only.yml
+++ b/attic/ceph-dev-container-only/config/definitions/ceph-dev-container-only.yml
@@ -138,4 +138,4 @@
               username: CONTAINER_REPO_USERNAME
               password: CONTAINER_REPO_PASSWORD
       - build-name:
-          name: "#${BUILD_NUMBER} ${BRANCH}, ${DISTROS}, ${ARCH}, ${FLAVOR}"
+          name: "#${{BUILD_NUMBER}} ${{BRANCH}}, ${{DISTROS}}, ${{ARCH}}, ${{FLAVOR}}"

--- a/ceph-ansible-docs/config/definitions/ceph-ansible-docs.yml
+++ b/ceph-ansible-docs/config/definitions/ceph-ansible-docs.yml
@@ -39,6 +39,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/ceph-ansible-galaxy/config/definitions/ceph-ansible-galaxy.yml
+++ b/ceph-ansible-galaxy/config/definitions/ceph-ansible-galaxy.yml
@@ -31,7 +31,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 

--- a/ceph-ansible-rpm/config/definitions/ceph-ansible-rpm.yml
+++ b/ceph-ansible-rpm/config/definitions/ceph-ansible-rpm.yml
@@ -34,7 +34,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 

--- a/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
+++ b/ceph-ansible-scenario/config/definitions/ceph-ansible-scenario.yml
@@ -72,7 +72,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 
@@ -85,7 +85,7 @@
                   - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/teardown
 

--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -60,7 +60,7 @@
             - ../../build/cleanup
       - shell: "export NPROC=$(nproc); {ceph_build}"
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             -  ../../../scripts/dashboard/{test_deps_script}
       - shell: |
           export CYPRESS_ARGS="--record --key $CYPRESS_RECORD_KEY --tag $JOB_NAME" COMMIT_INFO_MESSAGE="$JOB_NAME"

--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -3,7 +3,7 @@
 set -e
 
 # the following two methods exist in scripts/build_utils.sh
-pkgs=( "ansible" "ansible-core" "jenkins-job-builder>=3.5.0,<6.0.0" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" )
+pkgs=( "ansible" "ansible-core" "git+https://opendev.org/jjb/jenkins-job-builder@60f0316389" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]"

--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -41,8 +41,8 @@
       - git:
           url: https://github.com/ceph/ceph-build.git
           branches:
-            - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - ${{sha1}}
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -50,6 +50,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -84,7 +84,7 @@
                 properties-file: ${WORKSPACE}/ceph-build/ansible/ceph/dist/other_envvars
             # debian build scripts
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                   - ../../build/validate_deb
                   - ../../../scripts/build_utils.sh
                   - ../../build/setup_deb
@@ -93,7 +93,7 @@
                   - ../../../scripts/status_completed
             # rpm build scripts
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                   - ../../build/validate_rpm
                   - ../../../scripts/build_utils.sh
                   - ../../build/setup_rpm
@@ -111,7 +111,7 @@
                 - inject:
                     properties-file: ${WORKSPACE}/build_info
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                   - ../../../scripts/build_utils.sh
                   - ../../build/failure
 

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -63,10 +63,10 @@
               condition-operands:
                 - condition-kind: regex-match
                   regex: (reef|squid)
-                  label: '${BRANCH}'
+                  label: '${{BRANCH}}'
                 - condition-kind: regex-match
                   regex: (focal|jammy|centos9|buster|bullseye|bookworm)
-                  label: '${DIST}'
+                  label: '${{DIST}}'
           on-evaluation-failure: dont-run
           steps:
             - shell: |
@@ -79,9 +79,9 @@
                 filter: 'ceph-build/ansible/ceph/dist/**'
                 which-build: multijob-build
             - inject:
-                properties-file: ${WORKSPACE}/ceph-build/ansible/ceph/dist/sha1
+                properties-file: ${{WORKSPACE}}/ceph-build/ansible/ceph/dist/sha1
             - inject:
-                properties-file: ${WORKSPACE}/ceph-build/ansible/ceph/dist/other_envvars
+                properties-file: ${{WORKSPACE}}/ceph-build/ansible/ceph/dist/other_envvars
             # debian build scripts
             - shell:
                 !include-raw-verbatim:
@@ -109,7 +109,7 @@
                   - ABORTED
               build-steps:
                 - inject:
-                    properties-file: ${WORKSPACE}/build_info
+                    properties-file: ${{WORKSPACE}}/build_info
                 - shell:
                     !include-raw-verbatim:
                   - ../../../scripts/build_utils.sh

--- a/ceph-cbt-lint/config/definitions/ceph-cbt-lint.yml
+++ b/ceph-cbt-lint/config/definitions/ceph-cbt-lint.yml
@@ -44,8 +44,8 @@
       - git:
           url: https://github.com/ceph/cbt
           branches:
-            - origin/pr/${ghprbPullId}/merge
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - origin/pr/${{ghprbPullId}}/merge
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           timeout: 20
           shallow-clone: true
           wipe-workspace: true
@@ -56,7 +56,7 @@
           . venv/bin/activate
           pip install tox
           pip install git+https://github.com/ceph/githubcheck.git
-          sha1=$(git rev-parse refs/remotes/origin/pr/${ghprbPullId}/head)
+          sha1=$(git rev-parse refs/remotes/origin/pr/${{ghprbPullId}}/head)
           tox -e pep8 | github-check   \
             --lint                        \
             --lint-tox-dir=.              \

--- a/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
+++ b/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
@@ -56,8 +56,8 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - origin/pr/${ghprbPullId}/merge
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - origin/pr/${{ghprbPullId}}/merge
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -108,4 +108,4 @@
                 - FAILURE
                 - ABORTED
               build-steps:
-                - shell: "${WORKSPACE}/ceph-build/ceph-dashboard-cephadm-e2e/build/cleanup"
+                - shell: "${{WORKSPACE}}/ceph-build/ceph-dashboard-cephadm-e2e/build/cleanup"

--- a/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
+++ b/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
@@ -72,7 +72,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/dashboard/install-e2e-test-deps.sh
             - ../../../scripts/dashboard/install-cephadm-e2e-deps.sh
       - shell: |

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -64,7 +64,7 @@
     builders:
       - shell: "export FOR_MAKE_CHECK=1; timeout 2h ./src/script/run-make.sh --cmake-args '-DWITH_TESTS=OFF -DENABLE_GIT_VERSION=OFF'"
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/dashboard/install-e2e-test-deps.sh
       - shell: |
           export CYPRESS_ARGS="--record --key $CYPRESS_RECORD_KEY --tag $ghprbTargetBranch" COMMIT_INFO_MESSAGE="$ghprbPullTitle"

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -53,8 +53,8 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - origin/pr/${ghprbPullId}/merge
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - origin/pr/${{ghprbPullId}}/merge
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -68,8 +68,8 @@
             - ../../../scripts/dashboard/install-e2e-test-deps.sh
       - shell: |
           export CYPRESS_ARGS="--record --key $CYPRESS_RECORD_KEY --tag $ghprbTargetBranch" COMMIT_INFO_MESSAGE="$ghprbPullTitle"
-          export APPLITOOLS_BATCH_ID="PR-${ghprbPullId}_${BUILD_TAG}"
-          export APPLITOOLS_BATCH_NAME="PR-${ghprbPullId}"
+          export APPLITOOLS_BATCH_ID="PR-${{ghprbPullId}}_${{BUILD_TAG}}"
+          export APPLITOOLS_BATCH_NAME="PR-${{ghprbPullId}}"
           export APPLITOOLS_BRANCH_NAME="$ghprbSourceBranch"
           export APPLITOOLS_PARENT_BRANCH_NAME="$ghprbTargetBranch"
           mkdir -p .applitools

--- a/ceph-deploy-build/config/definitions/ceph-deploy-build.yml
+++ b/ceph-deploy-build/config/definitions/ceph-deploy-build.yml
@@ -36,7 +36,7 @@
 
     builders:
       - shell:
-            !include-raw:
+            !include-raw-verbatim:
               - ../../../scripts/build_utils.sh
               - ../../build/setup
               - ../../build/build

--- a/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
+++ b/ceph-deploy-docs/config/definitions/ceph-deploy-docs.yml
@@ -31,6 +31,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -77,7 +77,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build

--- a/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
+++ b/ceph-deploy-pull-requests/config/definitions/ceph-deploy-pull-requests.yml
@@ -7,7 +7,7 @@
       - git:
           url: https://github.com/ceph/ceph-deploy.git
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/ceph-deploy-tag/config/definitions/ceph-tag.yml
+++ b/ceph-deploy-tag/config/definitions/ceph-tag.yml
@@ -40,7 +40,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -78,7 +78,7 @@
           properties-file: ${WORKSPACE}/dist/other_envvars
       # debian build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_deb
             - ../../../scripts/build_utils.sh
             - ../../build/setup_deb
@@ -87,7 +87,7 @@
             - ../../../scripts/status_completed
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup_rpm
@@ -96,7 +96,7 @@
             - ../../../scripts/status_completed
       # osc build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_osc
             - ../../../scripts/build_utils.sh
             - ../../build/setup_osc
@@ -104,7 +104,7 @@
             - ../../../scripts/status_completed
       # mingw build scripts (targeting Windows)
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_mingw
             - ../../../scripts/build_utils.sh
             - ../../build/setup_mingw
@@ -122,7 +122,7 @@
                 - inject:
                     properties-file: ${WORKSPACE}/build_info
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure
 

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -71,11 +71,11 @@
           filter: 'dist/**'
           which-build: multijob-build
       - inject:
-          properties-file: ${WORKSPACE}/dist/sha1
+          properties-file: ${{WORKSPACE}}/dist/sha1
       - inject:
-          properties-file: ${WORKSPACE}/dist/branch
+          properties-file: ${{WORKSPACE}}/dist/branch
       - inject:
-          properties-file: ${WORKSPACE}/dist/other_envvars
+          properties-file: ${{WORKSPACE}}/dist/other_envvars
       # debian build scripts
       - shell:
           !include-raw-verbatim:
@@ -120,7 +120,7 @@
                   - ABORTED
               build-steps:
                 - inject:
-                    properties-file: ${WORKSPACE}/build_info
+                    properties-file: ${{WORKSPACE}}/build_info
                 - shell:
                     !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
@@ -146,4 +146,4 @@
               username: DOCKER_HUB_USERNAME
               password: DOCKER_HUB_PASSWORD
       - build-name:
-          name: "#${BUILD_NUMBER} ${BRANCH}, ${SHA1}, ${DISTROS}, ${FLAVOR}"
+          name: "#${{BUILD_NUMBER}} ${{BRANCH}}, ${{SHA1}}, ${{DISTROS}}, ${{FLAVOR}}"

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -43,7 +43,7 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
-          label: '${GIT_BRANCH}'
+          label: '${{GIT_BRANCH}}'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -53,12 +53,12 @@
             - trigger-builds:
                 - project: 'ceph-dev'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=jammy focal centos9 windows
                 - project: 'ceph-dev'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
                     FLAVOR=crimson
@@ -69,7 +69,7 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*squid.*
-          label: '${GIT_BRANCH}'
+          label: '${{GIT_BRANCH}}'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -79,12 +79,12 @@
             - trigger-builds:
                 - project: 'ceph-dev'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=jammy centos9 windows
                 - project: 'ceph-dev'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
                     FLAVOR=crimson
@@ -95,7 +95,7 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*main.*
-          label: '${GIT_BRANCH}'
+          label: '${{GIT_BRANCH}}'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -105,12 +105,12 @@
             - trigger-builds:
                 - project: 'ceph-dev'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=jammy centos9 windows
                 - project: 'ceph-dev'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
                     FLAVOR=crimson

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -47,7 +47,7 @@
           on-evaluation-failure: dont-run
           steps:
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                 - ../../../scripts/build_utils.sh
                 - ../../build/notify
             - trigger-builds:
@@ -73,7 +73,7 @@
           on-evaluation-failure: dont-run
           steps:
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                 - ../../../scripts/build_utils.sh
                 - ../../build/notify
             - trigger-builds:
@@ -99,7 +99,7 @@
           on-evaluation-failure: dont-run
           steps:
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                 - ../../../scripts/build_utils.sh
                 - ../../build/notify
             - trigger-builds:

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -78,11 +78,11 @@
           which-build: build-param
           param: SETUP_BUILD_ID
       - inject:
-          properties-file: ${WORKSPACE}/dist/sha1
+          properties-file: ${{WORKSPACE}}/dist/sha1
       - inject:
-          properties-file: ${WORKSPACE}/dist/branch
+          properties-file: ${{WORKSPACE}}/dist/branch
       - inject:
-          properties-file: ${WORKSPACE}/dist/other_envvars
+          properties-file: ${{WORKSPACE}}/dist/other_envvars
       # debian build scripts
       - shell:
           !include-raw-verbatim:
@@ -128,7 +128,7 @@
                   - ABORTED
               build-steps:
                 - inject:
-                    properties-file: ${WORKSPACE}/build_info
+                    properties-file: ${{WORKSPACE}}/build_info
                 - shell:
                     !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
@@ -158,4 +158,4 @@
               username: AWS_ACCESS_KEY_ID
               password: AWS_SECRET_ACCESS_KEY
       - build-name:
-          name: "#${BUILD_NUMBER} ${BRANCH}, ${SHA1}, ${DISTROS}, ${FLAVOR}"
+          name: "#${{BUILD_NUMBER}} ${{BRANCH}}, ${{SHA1}}, ${{DISTROS}}, ${{FLAVOR}}"

--- a/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
+++ b/ceph-dev-new-build/config/definitions/ceph-dev-new-build.yml
@@ -85,7 +85,7 @@
           properties-file: ${WORKSPACE}/dist/other_envvars
       # debian build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_deb
             - ../../../scripts/build_utils.sh
             - ../../build/setup_deb
@@ -94,7 +94,7 @@
             - ../../../scripts/status_completed
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../../scripts/setup_sccache.sh
@@ -104,7 +104,7 @@
             - ../../../scripts/status_completed
       # osc build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_osc
             - ../../../scripts/build_utils.sh
             - ../../build/setup_osc
@@ -112,7 +112,7 @@
             - ../../../scripts/status_completed
       # mingw build scripts (targeting Windows)
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_mingw
             - ../../../scripts/build_utils.sh
             - ../../build/setup_mingw
@@ -130,7 +130,7 @@
                 - inject:
                     properties-file: ${WORKSPACE}/build_info
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure
 

--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -35,7 +35,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 
@@ -53,7 +53,7 @@
                   - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure
 

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -33,7 +33,7 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
-          label: '${GIT_BRANCH}'
+          label: '${{GIT_BRANCH}}'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -43,12 +43,12 @@
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=jammy focal centos9 windows
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
                     FLAVOR=crimson
@@ -59,7 +59,7 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*squid.*
-          label: '${GIT_BRANCH}'
+          label: '${{GIT_BRANCH}}'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -69,12 +69,12 @@
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=jammy centos9 windows
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
                     FLAVOR=crimson
@@ -84,7 +84,7 @@
       - conditional-step:
           condition-kind: shell
           condition-command: |
-            echo "${GIT_BRANCH}" | grep -v '\(reef\|squid\|centos9-only\|crimson-only\|jaeger\)'
+            echo "${{GIT_BRANCH}}" | grep -v '\(reef\|squid\|centos9-only\|crimson-only\|jaeger\)'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -94,13 +94,13 @@
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=jammy centos9 windows
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
                     FLAVOR=crimson
@@ -109,7 +109,7 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*centos9-only.*
-          label: '${GIT_BRANCH}'
+          label: '${{GIT_BRANCH}}'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -119,7 +119,7 @@
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
                     ARCHS=x86_64
@@ -129,7 +129,7 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*crimson-only.*
-          label: '${GIT_BRANCH}'
+          label: '${{GIT_BRANCH}}'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -139,7 +139,7 @@
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
                     FLAVOR=crimson
@@ -150,7 +150,7 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*jaeger.*
-          label: '${GIT_BRANCH}'
+          label: '${{GIT_BRANCH}}'
           on-evaluation-failure: dont-run
           steps:
             - shell:
@@ -160,7 +160,7 @@
             - trigger-builds:
                 - project: 'ceph-dev-new'
                   predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
+                    BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos8 focal
                     FLAVOR=jaeger
@@ -169,7 +169,7 @@
       - conditional-step:
           condition-kind: regex-match
           regex: .*sccache.*
-          label: '${GIT_BRANCH}'
+          label: '${{GIT_BRANCH}}'
           on-evaluation-failure: dont-run
           steps:
             - shell: echo skipping

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -37,7 +37,7 @@
           on-evaluation-failure: dont-run
           steps:
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                 - ../../../scripts/build_utils.sh
                 - ../../build/notify
             - trigger-builds:
@@ -63,7 +63,7 @@
           on-evaluation-failure: dont-run
           steps:
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                 - ../../../scripts/build_utils.sh
                 - ../../build/notify
             - trigger-builds:
@@ -88,7 +88,7 @@
           on-evaluation-failure: dont-run
           steps:
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                 - ../../../scripts/build_utils.sh
                 - ../../build/notify
             - trigger-builds:
@@ -113,7 +113,7 @@
           on-evaluation-failure: dont-run
           steps:
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                 - ../../../scripts/build_utils.sh
                 - ../../build/notify
             - trigger-builds:
@@ -133,7 +133,7 @@
           on-evaluation-failure: dont-run
           steps:
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                 - ../../../scripts/build_utils.sh
                 - ../../build/notify
             - trigger-builds:
@@ -154,7 +154,7 @@
           on-evaluation-failure: dont-run
           steps:
             - shell:
-                !include-raw:
+                !include-raw-verbatim:
                 - ../../../scripts/build_utils.sh
                 - ../../build/notify
             - trigger-builds:

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -94,13 +94,13 @@
           filter: dist/sha1
           which-build: multijob-build
       - inject:
-          properties-file: ${WORKSPACE}/dist/sha1
+          properties-file: ${{WORKSPACE}}/dist/sha1
       - copyartifact:
           project: ceph-dev-new-setup
           filter: dist/branch
           which-build: multijob-build
       - inject:
-          properties-file: ${WORKSPACE}/dist/branch
+          properties-file: ${{WORKSPACE}}/dist/branch
       - multijob:
           name: 'ceph dev build phase'
           condition: SUCCESSFUL
@@ -114,4 +114,4 @@
           global: true
           mask-password-params: true
       - build-name:
-          name: "#${BUILD_NUMBER} ${BRANCH}, ${SHA1}, ${DISTROS}, ${FLAVOR}"
+          name: "#${{BUILD_NUMBER}} ${{BRANCH}}, ${{SHA1}}, ${{DISTROS}}, ${{FLAVOR}}"

--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -9,7 +9,7 @@
         - git:
             url: https://github.com/ceph/ceph-build
             branches:
-              - ${CEPH_BUILD_BRANCH}
+              - ${{CEPH_BUILD_BRANCH}}
             shallow-clone: true
             submodule:
               disable: true

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -31,7 +31,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 
@@ -49,7 +49,7 @@
                   - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure
 

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -85,13 +85,13 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           filter: dist/sha1
           which-build: multijob-build
       - inject:
-          properties-file: ${WORKSPACE}/dist/sha1
+          properties-file: ${{WORKSPACE}}/dist/sha1
       - copyartifact:
           project: ceph-dev-setup
           filter: dist/branch
           which-build: multijob-build
       - inject:
-          properties-file: ${WORKSPACE}/dist/branch
+          properties-file: ${{WORKSPACE}}/dist/branch
       - multijob:
           name: 'ceph dev build phase'
           condition: SUCCESSFUL
@@ -105,4 +105,4 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           global: true
           mask-password-params: true
       - build-name:
-          name: "#${BUILD_NUMBER} ${BRANCH}, ${SHA1}, ${DISTROS}, ${FLAVOR}"
+          name: "#${{BUILD_NUMBER}} ${{BRANCH}}, ${{SHA1}}, ${{DISTROS}}, ${{FLAVOR}}"

--- a/ceph-devstack/config/definitions/ceph-devstack.yml
+++ b/ceph-devstack/config/definitions/ceph-devstack.yml
@@ -8,7 +8,7 @@
         - git:
             url: https://github.com/zmc/ceph-devstack
             branches:
-              - origin/${CEPH_DEVSTACK_BRANCH}
+              - origin/${{CEPH_DEVSTACK_BRANCH}}
     parameters:
       - string:
           name: CEPH_DEVSTACK_BRANCH

--- a/ceph-docs/config/definitions/ceph-docs.yml
+++ b/ceph-docs/config/definitions/ceph-docs.yml
@@ -33,4 +33,4 @@
 
     builders:
       - shell:
-          !include-raw: ../../build/build
+          !include-raw-verbatim: ../../build/build

--- a/ceph-grafana-trigger/config/definitions/ceph-grafana-trigger.yml
+++ b/ceph-grafana-trigger/config/definitions/ceph-grafana-trigger.yml
@@ -55,4 +55,4 @@
               username: CONTAINER_REPO_USERNAME
               password: CONTAINER_REPO_PASSWORD
       - build-name:
-          name: "#${BUILD_NUMBER} ${BRANCH}"
+          name: "#${{BUILD_NUMBER}} ${{BRANCH}}"

--- a/ceph-grafana-trigger/config/definitions/ceph-grafana-trigger.yml
+++ b/ceph-grafana-trigger/config/definitions/ceph-grafana-trigger.yml
@@ -43,7 +43,7 @@
               current-parameters: true
               block: true
         - shell:
-            !include-raw: ../../build/build
+            !include-raw-verbatim: ../../build/build
 
     wrappers:
       - inject-passwords:

--- a/ceph-grafana/config/definitions/ceph-grafana.yml
+++ b/ceph-grafana/config/definitions/ceph-grafana.yml
@@ -34,7 +34,7 @@
 
     builders:
         - shell:
-            !include-raw:
+            !include-raw-verbatim:
                 ../../build/build
 
     wrappers:

--- a/ceph-grafana/config/definitions/ceph-grafana.yml
+++ b/ceph-grafana/config/definitions/ceph-grafana.yml
@@ -47,4 +47,4 @@
               username: CONTAINER_REPO_USERNAME
               password: CONTAINER_REPO_PASSWORD
       - build-name:
-          name: "#${BUILD_NUMBER} ${BRANCH}, ${ARCH}"
+          name: "#${{BUILD_NUMBER}} ${{BRANCH}}, ${{ARCH}}"

--- a/ceph-iscsi-cli-flake8/config/definitions/ceph-iscsi-config-flake8.yml
+++ b/ceph-iscsi-cli-flake8/config/definitions/ceph-iscsi-config-flake8.yml
@@ -4,7 +4,7 @@
       - git:
           url: https://github.com/ceph/ceph-iscsi-cli.git
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/ceph-iscsi-cli-flake8/config/definitions/ceph-iscsi-config-flake8.yml
+++ b/ceph-iscsi-cli-flake8/config/definitions/ceph-iscsi-config-flake8.yml
@@ -56,6 +56,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/ceph-iscsi-cli-trigger/config/definitions/ceph-iscsi-cli-trigger.yml
+++ b/ceph-iscsi-cli-trigger/config/definitions/ceph-iscsi-cli-trigger.yml
@@ -33,5 +33,5 @@
       - trigger-builds:
         - project: 'ceph-iscsi-cli'
           predefined-parameters: |
-            BRANCH=${GIT_BRANCH}
+            BRANCH=${{GIT_BRANCH}}
             FORCE=True

--- a/ceph-iscsi-cli/config/definitions/ceph-iscsi-cli.yml
+++ b/ceph-iscsi-cli/config/definitions/ceph-iscsi-cli.yml
@@ -86,14 +86,14 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # debian build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_deb
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_deb
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup

--- a/ceph-iscsi-config-flake8/config/definitions/ceph-iscsi-config-flake8.yml
+++ b/ceph-iscsi-config-flake8/config/definitions/ceph-iscsi-config-flake8.yml
@@ -56,6 +56,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/ceph-iscsi-config-flake8/config/definitions/ceph-iscsi-config-flake8.yml
+++ b/ceph-iscsi-config-flake8/config/definitions/ceph-iscsi-config-flake8.yml
@@ -4,7 +4,7 @@
       - git:
           url: https://github.com/ceph/ceph-iscsi-config.git
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/ceph-iscsi-config-trigger/config/definitions/ceph-iscsi-config-trigger.yml
+++ b/ceph-iscsi-config-trigger/config/definitions/ceph-iscsi-config-trigger.yml
@@ -33,5 +33,5 @@
       - trigger-builds:
         - project: 'ceph-iscsi-config'
           predefined-parameters: |
-            BRANCH=${GIT_BRANCH}
+            BRANCH=${{GIT_BRANCH}}
             FORCE=True

--- a/ceph-iscsi-config/config/definitions/ceph-iscsi-config.yml
+++ b/ceph-iscsi-config/config/definitions/ceph-iscsi-config.yml
@@ -86,14 +86,14 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # debian build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_deb
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_deb
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup

--- a/ceph-iscsi-stable/config/definitions/ceph-iscsi-stable.yml
+++ b/ceph-iscsi-stable/config/definitions/ceph-iscsi-stable.yml
@@ -111,7 +111,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup
@@ -128,7 +128,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
                 - inject:
                     properties-file: ${WORKSPACE}/build_info
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure
 

--- a/ceph-iscsi-stable/config/definitions/ceph-iscsi-stable.yml
+++ b/ceph-iscsi-stable/config/definitions/ceph-iscsi-stable.yml
@@ -126,7 +126,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
                   - ABORTED
               build-steps:
                 - inject:
-                    properties-file: ${WORKSPACE}/build_info
+                    properties-file: ${{WORKSPACE}}/build_info
                 - shell:
                     !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh

--- a/ceph-iscsi-tools-trigger/config/definitions/ceph-iscsi-tools-trigger.yml
+++ b/ceph-iscsi-tools-trigger/config/definitions/ceph-iscsi-tools-trigger.yml
@@ -33,5 +33,5 @@
       - trigger-builds:
         - project: 'ceph-iscsi-tools'
           predefined-parameters: |
-            BRANCH=${GIT_BRANCH}
+            BRANCH=${{GIT_BRANCH}}
             FORCE=True

--- a/ceph-iscsi-tools/config/definitions/ceph-iscsi-tools.yml
+++ b/ceph-iscsi-tools/config/definitions/ceph-iscsi-tools.yml
@@ -86,14 +86,14 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # debian build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_deb
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_deb
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup

--- a/ceph-iscsi-tox/config/definitions/ceph-iscsi-tox.yml
+++ b/ceph-iscsi-tox/config/definitions/ceph-iscsi-tox.yml
@@ -56,6 +56,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/ceph-iscsi-tox/config/definitions/ceph-iscsi-tox.yml
+++ b/ceph-iscsi-tox/config/definitions/ceph-iscsi-tox.yml
@@ -4,7 +4,7 @@
       - git:
           url: https://github.com/ceph/ceph-iscsi.git
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/ceph-iscsi-trigger/config/definitions/ceph-iscsi-trigger.yml
+++ b/ceph-iscsi-trigger/config/definitions/ceph-iscsi-trigger.yml
@@ -33,5 +33,5 @@
       - trigger-builds:
         - project: 'ceph-iscsi'
           predefined-parameters: |
-            BRANCH=${GIT_BRANCH}
+            BRANCH=${{GIT_BRANCH}}
             FORCE=True

--- a/ceph-iscsi/config/definitions/ceph-iscsi.yml
+++ b/ceph-iscsi/config/definitions/ceph-iscsi.yml
@@ -85,7 +85,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup

--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -19,8 +19,8 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - origin/pr/${ghprbPullId}/merge
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - origin/pr/${{ghprbPullId}}/merge
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           timeout: 20
           basedir: "ceph-pr"
           shallow-clone: true

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -54,8 +54,8 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - origin/pr/${ghprbPullId}/merge
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - origin/pr/${{ghprbPullId}}/merge
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -64,7 +64,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
             - ../../../scripts/dashboard/install-backend-api-test-deps.sh

--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -71,7 +71,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 

--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -4,8 +4,8 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - ${{sha1}}
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -47,7 +47,7 @@
 
     builders:
       - shell:
-          !include-raw: ../../build/build
+          !include-raw-verbatim: ../../build/build
 
     wrappers:
       - credentials-binding:

--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -37,8 +37,8 @@
           url: https://github.com/ceph/ceph
           browser: auto
           branches:
-            - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - ${{sha1}}
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           skip-tag: true
           shallow-clone: true
           honor-refspec: true

--- a/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
@@ -41,8 +41,8 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - ${sha1}
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - ${{sha1}}
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
@@ -50,5 +50,5 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/build

--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -3,7 +3,7 @@
     block-upstream: false
     builders:
     - shell:
-        !include-raw:
+        !include-raw-verbatim:
           - ../../../scripts/build_utils.sh
           - ../../build/build
     concurrent: true
@@ -91,7 +91,7 @@
                 - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../build/kill-tests
       - xunit:
           thresholds:

--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -42,8 +42,8 @@
         url: https://github.com/ceph/ceph.git
         name: origin
         branches:
-          - origin/pr/${ghprbPullId}/merge
-        refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+          - origin/pr/${{ghprbPullId}}/merge
+        refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
         skip-tag: true
         shallow-clone: true
         honor-refspec: true

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -61,7 +61,7 @@
 
     builders:
     - shell:
-        !include-raw:
+        !include-raw-verbatim:
           - ../../../scripts/build_utils.sh
           - ../../build/build
 
@@ -89,7 +89,7 @@
                 - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../build/kill-tests
       - xunit:
           thresholds:

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -50,8 +50,8 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - origin/pr/${ghprbPullId}/merge
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - origin/pr/${{ghprbPullId}}/merge
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           browser: auto
           timeout: 20
           skip-tag: true

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -49,7 +49,7 @@
       - git:
           url: https://github.com/ceph/ceph-qa-suite.git
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -58,6 +58,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
+++ b/ceph-release-rpm/config/definitions/ceph-release-rpm.yml
@@ -42,7 +42,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 

--- a/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml
+++ b/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml
@@ -58,8 +58,8 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - origin/pr/${ghprbPullId}/merge
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - origin/pr/${{ghprbPullId}}/merge
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -96,4 +96,4 @@
                 - FAILURE
                 - ABORTED
               build-steps:
-                - shell: "${WORKSPACE}/ceph-build/ceph-rook-e2e/build/cleanup"
+                - shell: "${{WORKSPACE}}/ceph-build/ceph-rook-e2e/build/cleanup"

--- a/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml
+++ b/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml
@@ -74,7 +74,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
              - ../../../scripts/rook-orch/install-rook-e2e-deps.sh
       - shell: |
           export COMMIT_INFO_MESSAGE="$ghprbPullTitle"

--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -36,7 +36,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/create_tag
             - ../../build/build
@@ -54,7 +54,7 @@
                   - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure
 

--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -62,7 +62,7 @@ SECURITY: Builds from BRANCH-release branch in ceph-private.git (private repo)."
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 

--- a/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
+++ b/ceph-volume-scenario/config/definitions/ceph-volume-scenario.yml
@@ -55,7 +55,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 
@@ -68,7 +68,7 @@
                   - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/teardown
 

--- a/ceph-volume-unit-tests/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-unit-tests/config/definitions/ceph-volume-pr.yml
@@ -68,7 +68,7 @@
             GITHUB_STATUS_FAILURE="failed"
             GITHUB_STATUS_ERROR="completed with errors"
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 
@@ -86,6 +86,6 @@
                   - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/teardown

--- a/ceph-volume-unit-tests/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-unit-tests/config/definitions/ceph-volume-pr.yml
@@ -52,7 +52,7 @@
           url: https://github.com/ceph/ceph
           browser: auto
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           skip-tag: true
           timeout: 20

--- a/ceph-website-prs/config/definitions/ceph-website-prs.yml
+++ b/ceph-website-prs/config/definitions/ceph-website-prs.yml
@@ -51,6 +51,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/ceph-website/install-deps.sh
             - ../../build/build

--- a/ceph-website-prs/config/definitions/ceph-website-prs.yml
+++ b/ceph-website-prs/config/definitions/ceph-website-prs.yml
@@ -36,14 +36,14 @@
           success-status: "Site compiled successfully!"
           failure-status: "Site compilation failed"
 #         This is kinda noisy if there's lots of force pushes
-#         success-comment: "Site built successfully!  https://${GIT_BRANCH}.ceph.io"
+#         success-comment: "Site built successfully!  https://${{GIT_BRANCH}}.ceph.io"
 
     scm:
       - git:
           url: https://github.com/ceph/ceph.io
           branches:
-            - origin/pr/${ghprbPullId}/merge
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - origin/pr/${{ghprbPullId}}/merge
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           browser: auto
           skip-tag: true
           timeout: 20

--- a/ceph-website/config/definitions/ceph-website.yml
+++ b/ceph-website/config/definitions/ceph-website.yml
@@ -31,6 +31,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/ceph-website/install-deps.sh
             - ../../build/build

--- a/ceph-windows-image-build/config/definitions/ceph-windows-image-build.yml
+++ b/ceph-windows-image-build/config/definitions/ceph-windows-image-build.yml
@@ -32,7 +32,7 @@
           basedir: ceph-build
 
     builders:
-      - shell: "${WORKSPACE}/ceph-build/ceph-windows-image-build/build/build"
+      - shell: "${{WORKSPACE}}/ceph-build/ceph-windows-image-build/build/build"
 
     wrappers:
       - credentials-binding:
@@ -53,4 +53,4 @@
                 - FAILURE
                 - ABORTED
               build-steps:
-                - shell: "${WORKSPACE}/ceph-build/ceph-windows-image-build/build/cleanup"
+                - shell: "${{WORKSPACE}}/ceph-build/ceph-windows-image-build/build/cleanup"

--- a/ceph-windows-installer-build/config/definitions/ceph-windows-installer-build.yml
+++ b/ceph-windows-installer-build/config/definitions/ceph-windows-installer-build.yml
@@ -59,7 +59,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../../scripts/ceph-windows/setup_libvirt
@@ -92,7 +92,7 @@
                 - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../../scripts/ceph-windows/cleanup
 
@@ -107,6 +107,6 @@
                     properties-file: ${WORKSPACE}/build_info
 
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure

--- a/ceph-windows-installer-build/config/definitions/ceph-windows-installer-build.yml
+++ b/ceph-windows-installer-build/config/definitions/ceph-windows-installer-build.yml
@@ -104,7 +104,7 @@
                   - ABORTED
               build-steps:
                 - inject:
-                    properties-file: ${WORKSPACE}/build_info
+                    properties-file: ${{WORKSPACE}}/build_info
 
                 - shell:
                     !include-raw-verbatim:

--- a/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
+++ b/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
@@ -65,7 +65,7 @@
 
     builders:
     - shell:
-        !include-raw:
+        !include-raw-verbatim:
           - ../../../scripts/build_utils.sh
           - ../../build/check_docs_pr_only
           - ../../../scripts/ceph-windows/setup_libvirt
@@ -93,7 +93,7 @@
                 - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../../scripts/ceph-windows/cleanup
 

--- a/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
+++ b/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
@@ -53,8 +53,8 @@
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - origin/pr/${ghprbPullId}/merge
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
+            - origin/pr/${{ghprbPullId}}/merge
+          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
           browser: auto
           timeout: 20
           do-not-fetch-tags: true

--- a/ceph-windows-test/config/definitions/ceph-windows-test.yml
+++ b/ceph-windows-test/config/definitions/ceph-windows-test.yml
@@ -53,7 +53,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../../scripts/ceph-windows/setup_libvirt
             - ../../../scripts/ceph-windows/setup_libvirt_ubuntu_vm
@@ -86,6 +86,6 @@
                 - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../../scripts/ceph-windows/cleanup

--- a/ceph/config/definitions/ceph.yml
+++ b/ceph/config/definitions/ceph.yml
@@ -109,7 +109,7 @@ SECURITY: Builds from BRANCH-release branch in ceph-private.git (private repo)."
           filter: ceph-build/ansible/ceph/dist/sha1
           which-build: multijob-build
       - inject:
-          properties-file: ${WORKSPACE}/ceph-build/ansible/ceph/dist/sha1
+          properties-file: ${{WORKSPACE}}/ceph-build/ansible/ceph/dist/sha1
       - multijob:
           name: 'ceph build phase'
           condition: SUCCESSFUL
@@ -130,4 +130,4 @@ SECURITY: Builds from BRANCH-release branch in ceph-private.git (private repo)."
           global: true
           mask-password-params: true
       - build-name:
-          name: "#${BUILD_NUMBER} ${BRANCH}, ${SHA1}"
+          name: "#${{BUILD_NUMBER}} ${{BRANCH}}, ${{SHA1}}"

--- a/cephmetrics-pull-requests/config/definitions/cephmetrics-pull-requests.yml
+++ b/cephmetrics-pull-requests/config/definitions/cephmetrics-pull-requests.yml
@@ -50,7 +50,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../setup/setup
             - ../../build/build

--- a/cephmetrics-pull-requests/config/definitions/cephmetrics-pull-requests.yml
+++ b/cephmetrics-pull-requests/config/definitions/cephmetrics-pull-requests.yml
@@ -41,7 +41,7 @@
       - git:
           url: https://github.com/ceph/cephmetrics.git
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/cephmetrics-release/config/definitions/cephmetrics-release.yml
+++ b/cephmetrics-release/config/definitions/cephmetrics-release.yml
@@ -86,7 +86,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           sudo rm -rf release
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_rpm

--- a/cephmetrics/config/definitions/cephmetrics.yml
+++ b/cephmetrics/config/definitions/cephmetrics.yml
@@ -87,7 +87,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           sudo rm -rf release
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_rpm

--- a/chacra-pull-requests/config/definitions/chacra-pull-requests.yml
+++ b/chacra-pull-requests/config/definitions/chacra-pull-requests.yml
@@ -4,7 +4,7 @@
       - git:
           url: https://github.com/ceph/chacra
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/chacra-pull-requests/config/definitions/chacra-pull-requests.yml
+++ b/chacra-pull-requests/config/definitions/chacra-pull-requests.yml
@@ -73,6 +73,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/configshell-fb/config/definitions/configshell-fb.yml
+++ b/configshell-fb/config/definitions/configshell-fb.yml
@@ -84,7 +84,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_rpm

--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -8,8 +8,15 @@
 
 set -euxo pipefail
 
-# the following two methods exist in scripts/build_utils.sh
-pkgs=( "dataclasses" "jenkins-job-builder>=3.5.0,<6.0.0" )
+# the jjb version is an unreleased patch from dmick to add support for 'ancestry' build choosers
+# for ceph-dev-new-trigger, to allow it to be configured to only look at branches up to N days
+# old.  This is just arguably better, but also useful when jenkins (or that plugin) decides it
+# needs to build every branch.
+#
+# when jenkins-job-builder 6.5 or later is released, this requirement should change to
+# jenkins-job-builder>=6.5
+
+pkgs=( "dataclasses" "git+https://opendev.org/jjb/jenkins-job-builder@60f0316389" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]" latest

--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -45,7 +45,7 @@ If this is checked, JJB will wipe out its cache and force each job to align with
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 

--- a/kernel-trigger/config/definitions/kernel-trigger.yml
+++ b/kernel-trigger/config/definitions/kernel-trigger.yml
@@ -74,5 +74,5 @@
       - trigger-builds:
         - project: 'kernel'
           predefined-parameters: |
-            BRANCH=${GIT_BRANCH}
+            BRANCH=${{GIT_BRANCH}}
             FORCE=True

--- a/kernel/config/definitions/kernel.yml
+++ b/kernel/config/definitions/kernel.yml
@@ -123,7 +123,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # debian build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_deb
             - ../../../scripts/build_utils.sh
             - ../../build/setup
@@ -132,7 +132,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
             - ../../build/build_deb
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup
@@ -149,7 +149,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
                   - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure
 

--- a/lab-cop/config/definitions/lab-cop.yml
+++ b/lab-cop/config/definitions/lab-cop.yml
@@ -12,6 +12,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/build
 

--- a/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
+++ b/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
@@ -50,7 +50,7 @@
       - git:
           url: https://github.com/alfredodeza/merfi.git
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
+++ b/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
@@ -59,6 +59,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/mita-deploy/config/definitions/mita-deploy.yml
+++ b/mita-deploy/config/definitions/mita-deploy.yml
@@ -39,7 +39,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 

--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -177,7 +177,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
                   - ABORTED
               build-steps:
                 - inject:
-                    properties-file: ${WORKSPACE}/build_info
+                    properties-file: ${{WORKSPACE}}/build_info
                 - shell:
                     !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh

--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -155,14 +155,14 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           sudo rm -rf release
       # debian build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_deb
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_deb
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup
@@ -179,7 +179,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
                 - inject:
                     properties-file: ${WORKSPACE}/build_info
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure
 

--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -123,14 +123,14 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # debian build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_deb
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_deb
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/validate_rpm
             - ../../../scripts/build_utils.sh
             - ../../build/setup
@@ -149,7 +149,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
                     properties-file: ${WORKSPACE}/build_info
 
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure
                 - shell: if [ -f /etc/yum.repos.d/shaman.repo ]; then sudo rm -f /etc/yum.repos.d/shaman.repo; fi

--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -146,7 +146,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
                   - ABORTED
               build-steps:
                 - inject:
-                    properties-file: ${WORKSPACE}/build_info
+                    properties-file: ${{WORKSPACE}}/build_info
 
                 - shell:
                     !include-raw-verbatim:

--- a/paddles-pull-requests/config/definitions/paddles-pull-requests.yml
+++ b/paddles-pull-requests/config/definitions/paddles-pull-requests.yml
@@ -4,7 +4,7 @@
       - git:
           url: https://github.com/ceph/paddles
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/paddles-pull-requests/config/definitions/paddles-pull-requests.yml
+++ b/paddles-pull-requests/config/definitions/paddles-pull-requests.yml
@@ -59,6 +59,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/quay-pruner/config/definitions/quay-pruner.yml
+++ b/quay-pruner/config/definitions/quay-pruner.yml
@@ -35,7 +35,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/build
 
     wrappers:

--- a/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
+++ b/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
@@ -70,6 +70,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
+++ b/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
@@ -7,7 +7,7 @@
       - git:
           url: https://github.com/ceph/radosgw-agent.git
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/radosgw-agent/config/definitions/radosgw-agent.yml
+++ b/radosgw-agent/config/definitions/radosgw-agent.yml
@@ -64,7 +64,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 

--- a/rtslib-fb-trigger/config/definitions/rtslib-fb-trigger.yml
+++ b/rtslib-fb-trigger/config/definitions/rtslib-fb-trigger.yml
@@ -34,5 +34,5 @@
       - trigger-builds:
         - project: 'rtslib-fb'
           predefined-parameters: |
-            BRANCH=${GIT_BRANCH}
+            BRANCH=${{GIT_BRANCH}}
             FORCE=True

--- a/rtslib-fb/config/definitions/rtslib-fb.yml
+++ b/rtslib-fb/config/definitions/rtslib-fb.yml
@@ -84,7 +84,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_rpm

--- a/samba-trigger/config/definitions/samba-trigger.yml
+++ b/samba-trigger/config/definitions/samba-trigger.yml
@@ -34,5 +34,5 @@
       - trigger-builds:
         - project: 'samba'
           predefined-parameters: |
-            BRANCH=${GIT_BRANCH}
+            BRANCH=${{GIT_BRANCH}}
             FORCE=True

--- a/samba/config/definitions/samba.yml
+++ b/samba/config/definitions/samba.yml
@@ -95,13 +95,13 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # debian build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_deb
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_rpm

--- a/sepia-fog-images/config/definitions/sepia-fog-images.yml
+++ b/sepia-fog-images/config/definitions/sepia-fog-images.yml
@@ -47,7 +47,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../build/build
 
     publishers:
@@ -59,7 +59,7 @@
                   - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../build/failure
 
     wrappers:

--- a/shaman-pull-requests/config/definitions/shaman-pull-requests.yml
+++ b/shaman-pull-requests/config/definitions/shaman-pull-requests.yml
@@ -4,7 +4,7 @@
       - git:
           url: https://github.com/ceph/shaman
           branches:
-            - ${sha1}
+            - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
           browser: auto
           timeout: 20

--- a/shaman-pull-requests/config/definitions/shaman-pull-requests.yml
+++ b/shaman-pull-requests/config/definitions/shaman-pull-requests.yml
@@ -73,6 +73,6 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build

--- a/sync-images/config/definitions/sync-images.yml
+++ b/sync-images/config/definitions/sync-images.yml
@@ -26,7 +26,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
 

--- a/tcmu-runner-trigger/config/definitions/tcmu-runner-trigger.yml
+++ b/tcmu-runner-trigger/config/definitions/tcmu-runner-trigger.yml
@@ -34,5 +34,5 @@
       - trigger-builds:
         - project: 'tcmu-runner'
           predefined-parameters: |
-            BRANCH=${GIT_BRANCH}
+            BRANCH=${{GIT_BRANCH}}
             FORCE=True

--- a/tcmu-runner/config/definitions/tcmu-runner.yml
+++ b/tcmu-runner/config/definitions/tcmu-runner.yml
@@ -96,7 +96,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           rm -rf release
       # rpm build scripts
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../build/build_rpm

--- a/wnbd-build/config/definitions/wnbd-build.yml
+++ b/wnbd-build/config/definitions/wnbd-build.yml
@@ -84,7 +84,7 @@
                   - ABORTED
               build-steps:
                 - inject:
-                    properties-file: ${WORKSPACE}/build_info
+                    properties-file: ${{WORKSPACE}}/build_info
 
                 - shell:
                     !include-raw-verbatim:

--- a/wnbd-build/config/definitions/wnbd-build.yml
+++ b/wnbd-build/config/definitions/wnbd-build.yml
@@ -39,7 +39,7 @@
 
     builders:
       - shell:
-          !include-raw:
+          !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/setup
             - ../../../scripts/ceph-windows/setup_libvirt
@@ -72,7 +72,7 @@
                 - ABORTED
               build-steps:
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../../scripts/ceph-windows/cleanup
 
@@ -87,6 +87,6 @@
                     properties-file: ${WORKSPACE}/build_info
 
                 - shell:
-                    !include-raw:
+                    !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../build/failure


### PR DESCRIPTION
jjb v6 has several non-backward-compatible changes:

- {macro} expansion is done unconditionally now, so all usages of ${var} change to ${{var}}
- !include-raw splits into several options; the one we always want is !include-raw-verbatim (no macro expansion)

This changeset

- changes all jobs to conform to jjb6 syntax
- uses a new prerelease version of jenkins-job-builder (integrated into main, but not yet released) from the git repo
- uses the functionality in that prerelease version to set 'maximum-age' of a ref to build for ceph-dev-new-trigger to 7 days

Note that some of the jobs are template jobs, and already had ${{}} in places, because they already needed to distinguish between macro usage and variable substitution.

Users who wish to run jenkins-job-builder locally will need to update to the prerelease version.  This can be done with "pip install git+https://opendev.org/jjb/jenkins-job-builder@60f031638"