### PR TITLE
ceph-dev-new-trigger: use new feature, 7-day-old or newer branches

### DIFF
--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -25,6 +25,8 @@
           skip-tag: true
           timeout: 20
           wipe-workspace: true
+          choosing-strategy: ancestry
+          maximum-age: 7
 
     builders:
       # build reef on:
@@ -175,6 +177,8 @@
             - shell: echo skipping
 
     wrappers:
+      - build-name:
+          name: "#${{BUILD_NUMBER}} ${{GIT_BRANCH}}"
       - inject-passwords:
           global: true
           mask-password-params: true


### PR DESCRIPTION
Actually modify the trigger job to use choosing-strategy: ancestry and
maximum-age: 7, so that only branches newer than 7 days old get built.

Also set build-name to the branch being triggered, for clarity.