### PR TITLE
ansible: Add tag to python interpreter var setting tasks

### DIFF
--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -796,6 +796,7 @@
             (ansible_os_family == "Debian" and ansible_distribution_major_version|int <= 16)
       tags:
         - register
+        - interpreter
 
     - set_fact:
         pip_version: pip3
@@ -805,6 +806,7 @@
             ansible_os_family == "Suse"
       tags:
         - register
+        - interpreter
 
     - name: Install six, latest one
       pip:


### PR DESCRIPTION
I'm working on a combination of terraform and ansible to quickly spin up instances in IBM Cloud so they can join Jenkins as builders.

Part of this process involves creating a virtualenv and running ansible from it.  python-jenkins needs to be installed in the virtualenv and setting the python interpreters inside the playbook breaks that.

This PR will let me `--skip-tags interpreter`