### PR TITLE
scripts: add build-with-container.py and friends to container_only_pr

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1741,6 +1741,9 @@ container_pr_only() {
   CONTAINER_ONLY=false
   local patterns=(
     'container/*'
+    'Dockerfile.build'
+    'src/script/buildcontainer-setup.sh'
+    'src/script/build-with-container.py'
   )
   if pr_only_for patterns; then CONTAINER_ONLY=true; fi
 }


### PR DESCRIPTION
Add the build-with-container.py script and the helper shell script and Dockerfile that support the builder image to the container_only_pr patterns in build_utils.sh.  This should save time and resources when contributing patches to only these files in the ceph/ceph repo.