### PR TITLE
ceph-dev*: intermediate transition to WITH_CRIMSON

### DIFF
--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -69,7 +69,7 @@
               export WITH_SEASTAR=true
               # TODO use clang-10 on ubuntu/focal
               timeout 7200 src/script/run-make.sh \
-                --cmake-args "-DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_C_COMPILER=$c_compiler -DCMAKE_BUILD_TYPE=Release -DWITH_SEASTAR=ON -DWITH_TESTS=OFF" \
+                --cmake-args "-DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_C_COMPILER=$c_compiler -DCMAKE_BUILD_TYPE=Release -DWITH_SEASTAR=ON -DWITH_CRIMSON=ON -DWITH_TESTS=OFF" \
                 vstart-base crimson-osd
               src/script/run-cbt.sh --build-dir $PWD/build --source-dir $PWD --cbt ${{WORKSPACE}}/cbt -a $archive_dir src/test/crimson/cbt/radosbench_4K_read.yaml
           else

--- a/ceph-pull-requests-arm64/build/build
+++ b/ceph-pull-requests-arm64/build/build
@@ -12,6 +12,7 @@ n_test_jobs=${n_build_jobs}
 export CHECK_MAKEOPTS="-j${n_test_jobs}"
 export BUILD_MAKEOPTS="-j${n_build_jobs}"
 export WITH_SEASTAR=true
+export WITH_CRIMSON=true
 export WITH_RBD_RWL=true
 timeout 4h ./run-make-check.sh
 sleep 5

--- a/ceph-pull-requests/build/build
+++ b/ceph-pull-requests/build/build
@@ -9,6 +9,7 @@ fi
 
 export NPROC=$(nproc)
 export WITH_SEASTAR=true
+export WITH_CRIMSON=true
 export WITH_RBD_RWL=true
 timeout 3h ./run-make-check.sh
 sleep 5

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -874,6 +874,7 @@ ceph_build_args_from_flavor() {
         ;;
     crimson)
         CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
+        CEPH_EXTRA_RPMBUILD_ARGS="${CEPH_EXTRA_RPMBUILD_ARGS} --with crimson"
         CEPH_EXTRA_CMAKE_ARGS+=" -DCMAKE_BUILD_TYPE=Debug"
         DEB_BUILD_PROFILES="pkg.ceph.crimson"
         ;;
@@ -1490,6 +1491,7 @@ setup_rpm_build_deps() {
     case "${FLAVOR}" in
     crimson)
       sed -i -e 's/%bcond_with seastar/%bcond_without seastar/g' $DIR/ceph.spec
+      sed -i -e 's/%bcond_with crimson/%bcond_without crimson/g' $DIR/ceph.spec
         ;;
     jaeger)
       sed -i -e 's/%bcond_with jaeger/%bcond_without jaeger/g' $DIR/ceph.spec


### PR DESCRIPTION
See: https://github.com/ceph/ceph/pull/61672
This PR changes any WITH_SEASTAR / --with-seastar to WITH_CRIMSON / --with crimson respectively. We should let our builders add the new flags and once the PR is merged we could clean up the unused WITH_SEASTAR.