### PR TITLE
ansible: Fixes to podman subuid/subgid checks

### DIFF
--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -501,9 +501,9 @@
       changed_when: false
 
     - name: Find highest used subuid
-      command: "awk -F: '{print $2+$3}' /etc/subuid | sort -n | tail -1"
+      shell: "awk -F: '{print $2+$3}' /etc/subuid | sort -n | tail -1"
       register: highest_subuid
-      when: subuid_check.rc != 0 or subgid_check.rc != 0
+      when: subuid_check.rc == 0 or subgid_check.rc == 0
       changed_when: false
 
     - name: Set next available UID range


### PR DESCRIPTION
I think this was working during my testing because sub{u,g}id_check.rc /wasn't/ 0.  I had manually modified the system so it wasn't in the same state as a fresh cloud instance.

I manually ran this playbook on an instance and confirmed it gets past the podman setup now.