### PR TITLE
ceph*setup: Do not run on arm64 builders

### DIFF
--- a/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
+++ b/ceph-dev-new-setup/config/definitions/ceph-dev-new-setup.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-dev-new-setup
     description: "This job step checks out the branch and builds the tarballs, diffs, and dsc that are passed to the ceph-dev-build step.\r\n\r\nNotes:\r\nJob needs to run on a releatively recent debian system.  The Restrict where run feature is used to specifiy an appropriate label.\r\nThe clear workspace before checkout box for the git plugin is used."
-    node: huge
+    node: huge && !arm64
     display-name: 'ceph-dev-new-setup'
     block-downstream: false
     block-upstream: false

--- a/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
+++ b/ceph-dev-setup/config/definitions/ceph-dev-setup.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-dev-setup
     description: "This job step checks out the branch and builds the tarballs, diffs, and dsc that are passed to the ceph-dev-build step.\r\n\r\nNotes:\r\nJob needs to run on a releatively recent debian system.  The Restrict where run feature is used to specifiy an appropriate label.\r\nThe clear workspace before checkout box for the git plugin is used."
-    node: huge && bionic
+    node: huge && bionic && !arm64
     display-name: 'ceph-dev-setup'
     block-downstream: false
     block-upstream: false

--- a/ceph-setup/config/definitions/ceph-setup.yml
+++ b/ceph-setup/config/definitions/ceph-setup.yml
@@ -1,7 +1,7 @@
 - job:
     name: ceph-setup
     description: "This job:\r\n- Creates the version commit\r\n- Checks out the branch and builds the tarballs, diffs, and dsc that are passed to the ceph-build step.\r\n\r\nNotes:\r\nJob needs to run on a releatively recent debian system.  The Restrict where run feature is used to specifiy an appropriate label.\r\nThe clear workspace before checkout box for the git plugin is used."
-    node: huge && bionic
+    node: huge && bionic && !arm64
     display-name: 'ceph-setup'
     block-downstream: false
     block-upstream: false


### PR DESCRIPTION
We're already low on ARM builders.  This is a waste of resources.