### PR TITLE
Add missing release name, unblocking Windows build

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -13,6 +13,9 @@ function create_venv_dir() {
 function release_from_version() {
     local ver=$1
     case $ver in
+    20.*)
+        rel="tentacle"
+        ;;
     19.*)
         rel="squid"
         ;;


### PR DESCRIPTION
The release_from_version() helper currently fails as there's no entry for 20.0. We'll fix this, unblocking the Windows CI.