### PR TITLE
ceph-dev*: Remove Crimson unsupported builds

### DIFF
--- a/attic/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
+++ b/attic/ceph-dev-trigger/config/definitions/ceph-dev-trigger.yml
@@ -55,7 +55,6 @@
                     DISTROS=focal centos8 leap15
       # build reef on:
       # default: jammy focal centos8 centos9
-      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
@@ -72,15 +71,8 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=jammy focal centos8 centos9
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos8 centos9
-                    FLAVOR=crimson
       # build squid on:
       # default: jammy focal centos8 centos9
-      # crimson: centos8 centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*squid.*
@@ -97,12 +89,6 @@
                     BRANCH=${GIT_BRANCH}
                     FORCE=True
                     DISTROS=jammy focal centos8 centos9
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${GIT_BRANCH}
-                    FORCE=True
-                    DISTROS=centos9
-                    FLAVOR=crimson
       # build tentacle on:
       # default: jammy focal centos8 centos9
       # crimson: centos8 centos9

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -40,7 +40,6 @@
     builders:
       # build reef on:
       # default: jammy focal centos9 windows
-      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
@@ -57,16 +56,8 @@
                     BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=jammy focal centos9 windows
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${{GIT_BRANCH}}
-                    FORCE=True
-                    DISTROS=centos9
-                    FLAVOR=crimson
-                    ARCHS=x86_64
       # build squid on:
       # default: jammy centos9 windows
-      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*squid.*
@@ -83,13 +74,6 @@
                     BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=jammy centos9 windows
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${{GIT_BRANCH}}
-                    FORCE=True
-                    DISTROS=centos9
-                    FLAVOR=crimson
-                    ARCHS=x86_64
       # build tentacle on:
       # default: jammy centos9 windows
       # crimson: centos9

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -31,7 +31,6 @@
     builders:
       # build reef on:
       # default: jammy focal centos9 windows
-      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*reef.*
@@ -49,15 +48,9 @@
                     FORCE=True
                     DISTROS=jammy focal centos9 windows
                 - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${{GIT_BRANCH}}
-                    FORCE=True
-                    DISTROS=centos9
-                    FLAVOR=crimson
-                    ARCHS=x86_64
+
       # build squid on:
       # default: jammy centos9 windows
-      # crimson: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*squid.*
@@ -74,13 +67,6 @@
                     BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=jammy centos9 windows
-                - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${{GIT_BRANCH}}
-                    FORCE=True
-                    DISTROS=centos9
-                    FLAVOR=crimson
-                    ARCHS=x86_64
       # build tentacle on:
       # default: jammy centos9 windows
       # crimson: centos9


### PR DESCRIPTION
Crimson should be built only for main and T.
Remove R and S builds.