### PR TITLE
scripts: docs_pr_only() considers PendingReleaseNotes

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1728,6 +1728,7 @@ docs_pr_only() {
     'README.*'
     'SubmittingPatches'
     '.readthedocs.yml'
+    'PendingReleaseNotes'
   )
   if pr_only_for patterns; then DOCS_ONLY=true; fi
 }


### PR DESCRIPTION
avoid building from source and running the various 'make check's when the pr only touches PendingReleaseNotes