### PR TITLE
Remove Github Pull Request Builder from required PR Check jobs

### DIFF
--- a/ceph-pr-api/build/build
+++ b/ceph-pr-api/build/build
@@ -1,13 +1,8 @@
 #!/bin/bash -e
 
-docs_pr_only
-container_pr_only
-if [[ "$DOCS_ONLY" = true || "$CONTAINER_ONLY" = true ]]; then
-    echo "Only the doc/ or container/ dir changed.  No need to run make check or API tests."
-    mkdir -p $WORKSPACE/build/out
-    echo "File created to avoid Jenkins' Artifact Archiving plugin from hanging" > $WORKSPACE/build/out/mgr.foo.log
-    exit 0
-fi
+echo "This job was triggered by $TRIGGER_METHOD via $TRIGGERED_BY"
+
+report_github_check_status pending "ceph API tests" "ceph API tests running" $GH_PULL_REQUEST_SHA $BUILD_URL
 
 n_build_jobs=$(get_nr_build_jobs)
 n_test_jobs=$(($(nproc) / 4))
@@ -16,5 +11,8 @@ export BUILD_MAKEOPTS="-j${n_build_jobs}"
 export FOR_MAKE_CHECK=1
 timeout 2h ./src/script/run-make.sh \
         --cmake-args '-DWITH_TESTS=OFF -DENABLE_GIT_VERSION=OFF'
+
+report_github_check_status success "ceph API tests" "ceph API tests passed" $GH_PULL_REQUEST_SHA $BUILD_URL
+
 sleep 5
 ps -ef | grep ceph || true

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -25,38 +25,24 @@
 
     parameters:
       - string:
-          name: sha1
-          description: "commit id or a refname, like 'origin/pr/72/head'"
-
-    triggers:
-      - github-pull-request:
-          cancel-builds-on-update: true
-          allow-whitelist-orgs-as-admins: true
-          org-list:
-            - ceph
-          white-list-target-branches:
-            - main
-            - tentacle
-            - squid
-            - reef
-            - "feature-.*"
-          trigger-phrase: 'jenkins test api'
-          skip-build-phrase: '^jenkins do not test.*'
-          only-trigger-phrase: false
-          github-hooks: true
-          permit-all: true
-          auto-close-on-fail: false
-          status-context: "ceph API tests"
-          started-status: "running API tests"
-          success-status: "ceph API tests succeeded"
-          failure-status: "ceph API tests failed"
+          name: GH_PULL_REQUEST_ID
+          description: "The GitHub PR number, like '72' in 'ceph/pull/72'"
+      - string:
+          name: GH_PULL_REQUEST_SHA
+          description: "The GitHub PR SHA1, like 'c816207c3130c67e5bcc56766a530e881e2c0181'"
+      - string:
+          name: TRIGGERED_BY
+          description: "The GitHub Action Workflow that called this job"
+      - string:
+          name: TRIGGER_METHOD
+          description: "The method by which this job was triggered (e.g., comment or push)"
 
     scm:
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - origin/pr/${{ghprbPullId}}/merge
-          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+            - origin/pr/${{GH_PULL_REQUEST_ID}}/merge
+          refspec: +refs/pull/${{GH_PULL_REQUEST_ID}}/*:refs/remotes/origin/pr/${{GH_PULL_REQUEST_ID}}/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -79,6 +65,14 @@
           builders:
             - role: SLAVE
               build-on:
+                - FAILURE
+                - ABORTED
+              build-steps:
+                - shell: |
+                    . ../../../scripts/report_github_check_status.sh
+                    report_github_check_status failure "ceph API tests" "ceph API tests failed" ${{GH_PULL_REQUEST_SHA}} ${{BUILD_URL}}
+            - role: SLAVE
+              build-on:
                   - ABORTED
               build-steps:
                 - shell: "sudo dpkg --configure -a"
@@ -95,3 +89,6 @@
               credential-id: github-readonly-token
               username: GITHUB_USER
               password: GITHUB_PASS
+          - text:
+              credential-id: github-ceph-jenkins-pr-checks
+              variable: GITHUB_TOKEN

--- a/ceph-pull-requests-arm64/build/build
+++ b/ceph-pull-requests-arm64/build/build
@@ -1,11 +1,8 @@
 #!/bin/bash -ex
 
-docs_pr_only
-container_pr_only
-if [[ "$DOCS_ONLY" = true || "$CONTAINER_ONLY" = true ]]; then
-    echo "Only the doc/ or container/ dir changed.  No need to run make check."
-    exit 0
-fi
+echo "This job was triggered by $TRIGGER_METHOD via $TRIGGERED_BY"
+
+report_github_check_status pending "make check (arm64)" "make check (arm64) running" $GH_PULL_REQUEST_SHA $BUILD_URL
 
 n_build_jobs=$(get_nr_build_jobs)
 n_test_jobs=${n_build_jobs}
@@ -14,5 +11,8 @@ export BUILD_MAKEOPTS="-j${n_build_jobs}"
 export WITH_CRIMSON=true
 export WITH_RBD_RWL=true
 timeout 4h ./run-make-check.sh
+
+report_github_check_status success "make check (arm64)" "make check (arm64) passed" $GH_PULL_REQUEST_SHA $BUILD_URL
+
 sleep 5
 ps -ef | grep -v jnlp | grep ceph || true

--- a/ceph-pull-requests-arm64/build/kill-tests
+++ b/ceph-pull-requests-arm64/build/kill-tests
@@ -1,5 +1,7 @@
 #!/bin/bash -ex
 
+report_github_check_status failure "make check (arm64)" "make check (arm64) failed" $GH_PULL_REQUEST_SHA $BUILD_URL
+
 # kill all descendant processes of ctest
 
 # ceph-pull-requests-arm64/build/build is killed by jenkins when the ceph-pull-requests-arm64 job is aborted or

--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -5,16 +5,27 @@
     - shell:
         !include-raw-verbatim:
           - ../../../scripts/build_utils.sh
+          - ../../../scripts/report_github_check_status.sh
           - ../../build/build
     concurrent: true
     disabled: false
     name: ceph-pull-requests-arm64
     node: 'arm64 && !centos7 && !centos8 && !centos9'
+
     parameters:
-    - string:
-        name: ghprbPullId
-        description: "the GitHub pull id, like '72' in 'ceph/pull/72'"
-        default: origin/main
+      - string:
+          name: GH_PULL_REQUEST_ID
+          description: "The GitHub PR number, like '72' in 'ceph/pull/72'"
+      - string:
+          name: GH_PULL_REQUEST_SHA
+          description: "The GitHub PR SHA1, like 'c816207c3130c67e5bcc56766a530e881e2c0181'"
+      - string:
+          name: TRIGGERED_BY
+          description: "The GitHub Action Workflow that called this job"
+      - string:
+          name: TRIGGER_METHOD
+          description: "The method by which this job was triggered (e.g., comment or push)"
+
     project-type: freestyle
     properties:
     - build-discarder:
@@ -42,31 +53,13 @@
         url: https://github.com/ceph/ceph.git
         name: origin
         branches:
-          - origin/pr/${{ghprbPullId}}/merge
-        refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+          - origin/pr/${{GH_PULL_REQUEST_ID}}/merge
+        refspec: +refs/pull/${{GH_PULL_REQUEST_ID}}/*:refs/remotes/origin/pr/${{GH_PULL_REQUEST_ID}}/*
         skip-tag: true
         shallow-clone: true
         honor-refspec: true
         timeout: 20
         wipe-workspace: true
-    triggers:
-    - github-pull-request:
-        cancel-builds-on-update: true
-        allow-whitelist-orgs-as-admins: true
-        org-list:
-        - ceph
-        trigger-phrase: 'jenkins test make check arm64'
-        skip-build-phrase: '^jenkins do not test.*'
-        only-trigger-phrase: false
-        github-hooks: true
-        permit-all: true
-        auto-close-on-fail: false
-        status-context: "make check (arm64)"
-        started-status: "running make check"
-        success-status: "make check succeeded"
-        failure-status: "make check failed"
-        white-list-target-branches:
-        - main
     publishers:
       - cobertura:
           report-file: "src/pybind/mgr/dashboard/frontend/coverage/cobertura-coverage.xml"
@@ -110,3 +103,6 @@
               credential-id: github-readonly-token
               username: GITHUB_USER
               password: GITHUB_PASS
+          - text:
+              credential-id: github-ceph-jenkins-pr-checks
+              variable: GITHUB_TOKEN

--- a/ceph-pull-requests/build/build
+++ b/ceph-pull-requests/build/build
@@ -1,15 +1,15 @@
 #!/bin/bash -ex
 
-docs_pr_only
-container_pr_only
-if [[ "$DOCS_ONLY" = true || "$CONTAINER_ONLY" = true ]]; then
-    echo "Only the doc/ or container/ dir changed.  No need to run make check."
-    exit 0
-fi
+echo "This job was triggered by $TRIGGER_METHOD via $TRIGGERED_BY"
+
+report_github_check_status pending "make check" "make check running" $GH_PULL_REQUEST_SHA $BUILD_URL
 
 export NPROC=$(nproc)
 export WITH_CRIMSON=true
 export WITH_RBD_RWL=true
 timeout 3h ./run-make-check.sh
+
+report_github_check_status success "make check" "make check passed" $GH_PULL_REQUEST_SHA $BUILD_URL
+
 sleep 5
 ps -ef | grep -v jnlp | grep ceph || true

--- a/ceph-pull-requests/build/kill-tests
+++ b/ceph-pull-requests/build/kill-tests
@@ -1,5 +1,7 @@
 #!/bin/bash -ex
 
+report_github_check_status failure "make check" "make check failed" $GH_PULL_REQUEST_SHA $BUILD_URL
+
 # kill all descendant processes of ctest
 
 # ceph-pull-requests/build/build is killed by jenkins when the ceph-pull-requests job is aborted or

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -26,32 +26,24 @@
 
     parameters:
       - string:
-          name: ghprbPullId
-          description: "the GitHub pull id, like '72' in 'ceph/pull/72'"
-
-    triggers:
-      - github-pull-request:
-          cancel-builds-on-update: true
-          allow-whitelist-orgs-as-admins: true
-          org-list:
-            - ceph
-          trigger-phrase: 'jenkins test make check'
-          skip-build-phrase: '^jenkins do not test.*'
-          only-trigger-phrase: false
-          github-hooks: true
-          permit-all: true
-          auto-close-on-fail: false
-          status-context: "make check"
-          started-status: "running make check"
-          success-status: "make check succeeded"
-          failure-status: "make check failed"
+          name: GH_PULL_REQUEST_ID
+          description: "The GitHub PR number, like '72' in 'ceph/pull/72'"
+      - string:
+          name: GH_PULL_REQUEST_SHA
+          description: "The GitHub PR SHA1, like 'c816207c3130c67e5bcc56766a530e881e2c0181'"
+      - string:
+          name: TRIGGERED_BY
+          description: "The GitHub Action Workflow that called this job"
+      - string:
+          name: TRIGGER_METHOD
+          description: "The method by which this job was triggered (e.g., comment or push)"
 
     scm:
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - origin/pr/${{ghprbPullId}}/merge
-          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+            - origin/pr/${{GH_PULL_REQUEST_ID}}/merge
+          refspec: +refs/pull/${{GH_PULL_REQUEST_ID}}/*:refs/remotes/origin/pr/${{GH_PULL_REQUEST_ID}}/*
           browser: auto
           timeout: 20
           skip-tag: true
@@ -63,6 +55,7 @@
     - shell:
         !include-raw-verbatim:
           - ../../../scripts/build_utils.sh
+          - ../../../scripts/report_github_check_status.sh
           - ../../build/build
 
     publishers:
@@ -109,3 +102,6 @@
               credential-id: github-readonly-token
               username: GITHUB_USER
               password: GITHUB_PASS
+          - text:
+              credential-id: github-ceph-jenkins-pr-checks
+              variable: GITHUB_TOKEN

--- a/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
+++ b/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
@@ -25,37 +25,24 @@
 
     parameters:
       - string:
-          name: ghprbPullId
-          description: "The GitHub pull request id, like '72' in 'ceph/pull/72'"
-
-    triggers:
-      - github-pull-request:
-          cancel-builds-on-update: true
-          allow-whitelist-orgs-as-admins: true
-          org-list:
-            - ceph
-          white-list-target-branches:
-            - main
-            - tentacle
-            - squid
-            - reef
-          trigger-phrase: 'jenkins test windows'
-          skip-build-phrase: '^jenkins do not test.*'
-          only-trigger-phrase: false
-          github-hooks: true
-          permit-all: true
-          auto-close-on-fail: false
-          status-context: "ceph windows tests"
-          started-status: "running ceph windows tests"
-          success-status: "ceph windows tests succeeded"
-          failure-status: "ceph windows tests failed"
+          name: GH_PULL_REQUEST_ID
+          description: "The GitHub PR number, like '72' in 'ceph/pull/72'"
+      - string:
+          name: GH_PULL_REQUEST_SHA
+          description: "The GitHub PR SHA1, like 'c816207c3130c67e5bcc56766a530e881e2c0181'"
+      - string:
+          name: TRIGGERED_BY
+          description: "The GitHub Action Workflow that called this job"
+      - string:
+          name: TRIGGER_METHOD
+          description: "The method by which this job was triggered (e.g., comment or push)"
 
     scm:
       - git:
           url: https://github.com/ceph/ceph.git
           branches:
-            - origin/pr/${{ghprbPullId}}/merge
-          refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+            - origin/pr/${{GH_PULL_REQUEST_ID}}/merge
+          refspec: +refs/pull/${{GH_PULL_REQUEST_ID}}/*:refs/remotes/origin/pr/${{GH_PULL_REQUEST_ID}}/*
           browser: auto
           timeout: 20
           do-not-fetch-tags: true
@@ -65,10 +52,13 @@
           basedir: ceph
 
     builders:
+    - shell: |
+        . ../../../scripts/report_github_check_status.sh
+        report_github_check_status pending "ceph windows tests" "ceph windows tests failed" ${{GH_PULL_REQUEST_SHA}} ${{BUILD_URL}}
+
     - shell:
         !include-raw-verbatim:
           - ../../../scripts/build_utils.sh
-          - ../../build/check_docs_pr_only
           - ../../../scripts/ceph-windows/setup_libvirt
           - ../../../scripts/ceph-windows/setup_libvirt_ubuntu_vm
           - ../../../scripts/ceph-windows/win32_build
@@ -77,6 +67,10 @@
           - ../../../scripts/ceph-windows/setup_libvirt_windows_vm
           - ../../../scripts/ceph-windows/setup_ceph_vstart
           - ../../../scripts/ceph-windows/run_tests
+
+    - shell: |
+        . ../../../scripts/report_github_check_status.sh
+        report_github_check_status success "ceph windows tests" "ceph windows tests passed" ${{GH_PULL_REQUEST_SHA}} ${{BUILD_URL}}
 
     publishers:
       - archive:
@@ -97,6 +91,14 @@
                     !include-raw-verbatim:
                       - ../../../scripts/build_utils.sh
                       - ../../../scripts/ceph-windows/cleanup
+            - role: SLAVE
+              build-on:
+                - FAILURE
+                - ABORTED
+              build-steps:
+                - shell: |
+                    . ../../../scripts/report_github_check_status.sh
+                    report_github_check_status failure "ceph windows tests" "ceph windows tests failed" ${{GH_PULL_REQUEST_SHA}} ${{BUILD_URL}}
 
     wrappers:
       - ansicolor
@@ -108,3 +110,6 @@
               credential-id: github-readonly-token
               username: GITHUB_USER
               password: GITHUB_PASS
+          - text:
+              credential-id: github-ceph-jenkins-pr-checks
+              variable: GITHUB_TOKEN

--- a/scripts/report_github_check_status.sh
+++ b/scripts/report_github_check_status.sh
@@ -1,0 +1,45 @@
+report_github_check_status () {
+    
+    state="$1"             # success, failure, or pending
+    context="$2"           # e.g. "jenkins/build"
+    description="$3"       # e.g. "Build passed"
+    sha="$4"               # Commit SHA
+    target_url="$5"        # Optional link to Jenkins build
+    owner="${6:-ceph}"     # Default to "ceph"
+    repo="${7:-ceph}"      # Default to "ceph"
+    
+    if [[ -z "$GITHUB_TOKEN" ]]; then
+      echo "GITHUB_TOKEN environment variable not set"
+      exit 1
+    fi
+    
+    if [[ -z "$state" || -z "$context" || -z "$description" || -z "$sha" ]]; then
+      echo "Usage: $0 <state> <context> <description> <sha> <target_url> [owner] [repo]"
+      exit 1
+    fi
+    
+    payload=$(jq -nc \
+      --arg state "$state" \
+      --arg context "$context" \
+      --arg description "$description" \
+      --arg target_url "$target_url" \
+      '{
+        state: $state,
+        context: $context,
+        description: $description,
+        target_url: ($target_url // null)
+      }')
+    
+    curl --retry 5 --retry-delay 2 --retry-all-errors --fail -s -X POST \
+      -H "Authorization: token $GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github.v3+json" \
+      -H "Content-Type: application/json" \
+      -d "$payload" \
+      "https://api.github.com/repos/$owner/$repo/statuses/$sha"
+    
+}
+
+# If the script is executed (as opposed to sourced), run the function now
+if [ "$(basename -- "${0#-}")" = "$(basename -- "${BASH_SOURCE}")" ]; then
+  report_github_check_status "$@"
+fi


### PR DESCRIPTION
This is the start of extricating Github Pull Request Builder.  GHPRB has some functionality that we've relied on forever: sending Github Status Checks back to Github PRs.  This can easily be accomplished using the API now.

The ceph-pull-requests, ceph-pull-requests-arm64, ceph-windows-pull-requests, and ceph-pr-api jobs will now be triggered by new Github Workflows (collection of Github Actions): https://github.com/ceph/ceph/pull/63168.

The other added benefit of this change is we no longer have to check for docs-only or container-only PRs on the Jenkins side of things.  Github will take care of checking and send fake status checks back to applicable PRs.