### PR TITLE
Revert "Remove quincy builds/mentions from most builds/build configs."

### DIFF
--- a/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
+++ b/ceph-api-nightly/config/definitions/ceph-api-nightly.yml
@@ -5,6 +5,7 @@
       - tentacle
       - squid
       - reef
+      - quincy
     test_suite:
       - backend:
           test_suite_script: run-backend-api-tests.sh

--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -59,14 +59,17 @@
       - conditional-step:
           condition-kind: or
           condition-operands:
+            - condition-kind: regex-match
+              regex: (jewel|kraken|luminous)
+              label: '${BRANCH}'
             - condition-kind: and
               condition-operands:
                 - condition-kind: regex-match
-                  regex: (reef|squid|tentacle)
-                  label: '${{BRANCH}}'
+                  regex: (mimic|nautilus|octopus|pacific|quincy|reef|squid)
+                  label: '${BRANCH}'
                 - condition-kind: regex-match
-                  regex: (focal|jammy|centos9|buster|bullseye|bookworm)
-                  label: '${{DIST}}'
+                  regex: (xenial|bionic|focal|jammy|centos7|centos8|centos9|buster|bullseye|bookworm)
+                  label: '${DIST}'
           on-evaluation-failure: dont-run
           steps:
             - shell: |

--- a/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
+++ b/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
@@ -5,6 +5,7 @@
       - tentacle
       - squid
       - reef
+      - quincy
     jobs:
       - '{name}-{ceph_branch}'
 

--- a/ceph-dev-build/build/build_osc
+++ b/ceph-dev-build/build/build_osc
@@ -11,6 +11,24 @@ squid)
 reef)
     OBSREPO="openSUSE_Leap_15.3"
     ;;
+quincy)
+    OBSREPO="openSUSE_Leap_15.3"
+    ;;
+pacific)
+    OBSREPO="openSUSE_Leap_15.3"
+    ;;
+octopus)
+    OBSREPO="openSUSE_Leap_15.2"
+    ;;
+nautilus)
+    OBSREPO="openSUSE_Leap_15.1"
+    ;;
+mimic)
+    OBSREPO="openSUSE_Leap_15.0"
+    ;;
+luminous)
+    OBSREPO="openSUSE_Leap_42.3"
+    ;;
 *)
     echo Not supported release '$RELEASE_BRANCH' by openSUSE
     exit 1

--- a/ceph-dev-build/build/setup_osc
+++ b/ceph-dev-build/build/setup_osc
@@ -50,6 +50,30 @@ reef)
     DISTRO=opensuse
     RELEASE="15.3"
     ;;
+quincy)
+    DISTRO=opensuse
+    RELEASE="15.3"
+    ;;
+pacific)
+    DISTRO=opensuse
+    RELEASE="15.3"
+    ;;
+octopus)
+    DISTRO=opensuse
+    RELEASE="15.2"
+    ;;
+nautilus)
+    DISTRO=opensuse
+    RELEASE="15.1"
+    ;;
+mimic)
+    DISTRO=opensuse
+    RELEASE="15.0"
+    ;;
+luminous)
+    DISTRO=opensuse
+    RELEASE="42.3"
+    ;;
 *)
     echo Not supported release '$RELEASE_BRANCH' by openSUSE
     exit 1

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -33,11 +33,30 @@
             - origin/tentacle
             - origin/squid
             - origin/reef
+            - origin/quincy
           skip-tag: true
           timeout: 20
           wipe-workspace: true
 
     builders:
+      # build quincy on:
+      # default: focal centos9 leap15
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*quincy.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=focal centos9 leap15
       # build reef on:
       # default: jammy focal centos9 windows
       - conditional-step:

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -29,6 +29,114 @@
           maximum-age: 7
 
     builders:
+      # Build luminous on:
+      # default: centos7 bionic xenial trusty
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*luminous.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=centos7 bionic xenial trusty
+      # build mimic on:
+      # default: bionic xenial centos7
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*mimic.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=bionic xenial centos7
+      # build nautilus on:
+      # default: bionic xenial centos7 centos8
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*nautilus.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=bionic xenial centos7 centos8
+      # build octopus on:
+      # default: focal bionic centos7 centos8 leap15
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*octopus.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=focal bionic centos7 centos8 leap15
+      # build pacific on:
+      # default: focal bionic centos8
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*pacific.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=focal bionic centos8 windows
+      # build quincy on:
+      # default: focal jammy centos9 leap15
+      - conditional-step:
+          condition-kind: regex-match
+          regex: .*quincy.*
+          label: '${GIT_BRANCH}'
+          on-evaluation-failure: dont-run
+          steps:
+            - shell:
+                !include-raw:
+                - ../../../scripts/build_utils.sh
+                - ../../build/notify
+            - trigger-builds:
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${GIT_BRANCH}
+                    FORCE=True
+                    DISTROS=focal jammy centos9 leap15
       # build reef on:
       # default: jammy focal centos9 windows
       - conditional-step:
@@ -98,7 +206,7 @@
       - conditional-step:
           condition-kind: shell
           condition-command: |
-            echo "${{GIT_BRANCH}}" | grep -v '\(reef\|squid\|tentacle\|centos9-only\|crimson-only\|jaeger\)'
+            echo "${GIT_BRANCH}" | grep -v '\(luminous\|mimic\|nautilus\|octopus\|pacific\|quincy\|reef\|squid\|centos9-only\|crimson-only\|jaeger\)'
           on-evaluation-failure: dont-run
           steps:
             - shell:

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -39,6 +39,10 @@
             - tentacle
             - squid
             - reef
+            - quincy
+            - pacific
+            - octopus
+            - nautilus
             - "feature-.*"
           trigger-phrase: 'jenkins test api'
           skip-build-phrase: '^jenkins do not test.*'

--- a/ceph-volume-nightly/build/build
+++ b/ceph-volume-nightly/build/build
@@ -16,7 +16,11 @@ update_vagrant_boxes
 
 cd src/ceph-volume/ceph_volume/tests/functional/$SUBCOMMAND
 
-if [[ "$CEPH_BRANCH" == "reef" ]]; then
+if [[ "$CEPH_BRANCH" == "pacific" ]]; then
+    CEPH_ANSIBLE_BRANCH="stable-6.0"
+elif [[ "$CEPH_BRANCH" == "quincy" ]]; then
+    CEPH_ANSIBLE_BRANCH="stable-7.0"
+elif [[ "$CEPH_BRANCH" == "reef" ]]; then
     CEPH_ANSIBLE_BRANCH="stable-8.0"
 else
     CEPH_ANSIBLE_BRANCH="main"

--- a/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
+++ b/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
@@ -39,6 +39,7 @@
             - tentacle
             - squid
             - reef
+            - quincy
           trigger-phrase: 'jenkins test windows'
           skip-build-phrase: '^jenkins do not test.*'
           only-trigger-phrase: false

--- a/scripts/sign-rpms
+++ b/scripts/sign-rpms
@@ -30,7 +30,7 @@ project=$1; shift
 
 if [ $# -eq 0 ]; then
   # Default releases if no arguments passed
-  releases=( reef squid tentacle )
+  releases=( quincy reef squid )
 else
   releases=( "$@" )
 fi

--- a/scripts/sync-push
+++ b/scripts/sync-push
@@ -22,7 +22,7 @@ project=$1; shift
 prerelease_dir=/data/download.ceph.com/www/prerelease/${project}
 
 if [[ "$project" == "ceph" ]] ; then
-  releases=${*:-"reef squid tentacle"}
+  releases=${*:-"quincy reef squid"}
 else
   releases=$*
 fi


### PR DESCRIPTION
This reverts commit 66c3c98dfa54db0c1a8fdae14f82efc41ced88f3.

Fixes: https://github.com/ceph/ceph-build/pull/2316/