### PR TITLE
scripts/build_utils: remove Debug build from Crimson

### DIFF
--- a/ceph-source-dist/build/Jenkinsfile
+++ b/ceph-source-dist/build/Jenkinsfile
@@ -14,8 +14,7 @@ pipeline {
               env.DEB_BUILD_PROFILES=""
               break
             case "crimson":
-              env.CEPH_EXTRA_RPMBUILD_ARGS="--with seastar"
-              env.CEPH_EXTRA_CMAKE_ARGS+=" -DCMAKE_BUILD_TYPE=Debug"
+              env.CEPH_EXTRA_RPMBUILD_ARGS="--with crimson"
               env.DEB_BUILD_PROFILES="pkg.ceph.crimson"
               break
             case "jaeger":

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -869,7 +869,6 @@ ceph_build_args_from_flavor() {
         ;;
     crimson)
         CEPH_EXTRA_RPMBUILD_ARGS="--with crimson"
-        CEPH_EXTRA_CMAKE_ARGS+=" -DCMAKE_BUILD_TYPE=Debug"
         DEB_BUILD_PROFILES="pkg.ceph.crimson"
         ;;
     jaeger)


### PR DESCRIPTION
See: https://github.com/ceph/ceph-build/pull/2167/files Builds should be set to Debug only when ending in "-debug".

https://github.com/ceph/ceph-build/pull/1805 set Crimson to always use Debug. That made sense in earlier development phases.
However, today we should align with Classical builds and use Debug only when needed.