### PR TITLE
ceph-build: remove container build step

### DIFF
--- a/ceph-build/config/definitions/ceph-build.yml
+++ b/ceph-build/config/definitions/ceph-build.yml
@@ -98,7 +98,6 @@
                   - ../../../scripts/build_utils.sh
                   - ../../build/setup_rpm
                   - ../../build/build_rpm
-                  - ../../../scripts/build_container
                   - ../../../scripts/status_completed
     publishers:
       - postbuildscript:


### PR DESCRIPTION
This was removed from build_rpm, but then when a reorg happened to separate the function into a separate script, the fact that ceph-build doesn't do container builds anymore was missed.

Release container builds now happen after the manual signing step using job ceph-release-containers