### PR TITLE
Seperate Crimson flavors to crimson-debug/release

### DIFF
--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -98,7 +98,7 @@
                     BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
-                    FLAVOR=crimson
+                    FLAVOR=crimson-debug
                     ARCHS=x86_64
       # build main on:
       # default: jammy centos9 windows
@@ -124,7 +124,7 @@
                     BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
-                    FLAVOR=crimson
+                    FLAVOR=crimson-debug
                     ARCHS=x86_64
 
     wrappers:

--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -102,7 +102,8 @@
                     ARCHS=x86_64
       # build main on:
       # default: jammy centos9 windows
-      # crimson: centos9
+      # crimson-debug: centos9
+      # crimson-release: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*main.*
@@ -125,6 +126,13 @@
                     FORCE=True
                     DISTROS=centos9
                     FLAVOR=crimson-debug
+                    ARCHS=x86_64
+                - project: 'ceph-dev'
+                  predefined-parameters: |
+                    BRANCH=${{GIT_BRANCH}}
+                    FORCE=True
+                    DISTROS=centos9
+                    FLAVOR=crimson-release
                     ARCHS=x86_64
 
     wrappers:

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -91,7 +91,7 @@
                     BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
-                    FLAVOR=crimson
+                    FLAVOR=crimson-debug
                     ARCHS=x86_64
       # If no release name is found in branch, build on all possible distro/flavor combos (except xenial, bionic, focal).
       # regex matching and 'on-evaluation-failure: run' doesn't work here so triple negative it is.
@@ -117,7 +117,7 @@
                     BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
-                    FLAVOR=crimson
+                    FLAVOR=crimson-debug
                     ARCHS=x86_64
       # build only centos9, no crimson, no jaeger
       - conditional-step:
@@ -139,7 +139,8 @@
                     ARCHS=x86_64
       # Build only the `crimson` flavour, don't waste resources on the default one.
       # Useful for the crimson's bug-hunt at Sepia
-      # crimson: centos9
+      # crimson-debug: centos9
+      # crimson-release: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*crimson-only.*
@@ -156,7 +157,15 @@
                     BRANCH=${{GIT_BRANCH}}
                     FORCE=True
                     DISTROS=centos9
-                    FLAVOR=crimson
+                    FLAVOR=crimson-debug
+                    ARCHS=x86_64
+            - trigger-builds:
+                - project: 'ceph-dev-new'
+                  predefined-parameters: |
+                    BRANCH=${{GIT_BRANCH}}
+                    FORCE=True
+                    DISTROS=centos9
+                    FLAVOR=crimson-release
                     ARCHS=x86_64
       # Build jaegertracing branch on needed env,  don't waste resources on the default one.
       # Useful for testing specific builds failure

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -51,10 +51,11 @@
           name: FLAVOR
           choices:
             - default
-            - crimson
+            - crimson-debug
+            - crimson-release
             - jaeger
           default: "default"
-          description: "Type of Ceph build, choices are: crimson, jaeger, default. Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: crimson-debug, crimson-release, jaeger, default. Defaults to: 'default'"
 
       - string:
           name: CI_CONTAINER

--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -59,10 +59,11 @@
           name: FLAVOR
           choices:
             - default
-            - crimson
+            - crimson-debug
+            - crimson-release
             - jaeger
           default: "default"
-          description: "Type of Ceph build, choices are: crimson, jaeger, default. Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: crimson-debug, crimson-release, jaeger, default. Defaults to: 'default'"
 
       - bool:
           name: CI_CONTAINER

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -53,9 +53,10 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           name: FLAVOR
           choices:
             - default
-            - crimson
+            - crimson-debug
+            - crimson-release
           default: "default"
-          description: "Type of Ceph build, choices are: crimson, default. Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: crimson-debug, crimson-release, default. Defaults to: 'default'"
 
       - bool:
           name: CI_CONTAINER

--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -65,8 +65,8 @@
                   break
               fi
           done
-          if test {osd-flavor} = "crimson" ; then
-              export WITH_SEASTAR=true
+          if test {osd-flavor} = "crimson-release" ; then
+              export WITH_CRIMSON=true
               # TODO use clang-10 on ubuntu/focal
               timeout 7200 src/script/run-make.sh \
                 --cmake-args "-DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_C_COMPILER=$c_compiler -DCMAKE_BUILD_TYPE=Release -DWITH_CRIMSON=ON -DWITH_TESTS=OFF" \
@@ -246,7 +246,8 @@
 - project:
     name: ceph-perf
     osd-flavor:
-      - crimson
+      - crimson-debug
+      - crimson-release
       - classic
     jobs:
       - ceph-perf-{osd-flavor}

--- a/ceph-source-dist/build/Jenkinsfile
+++ b/ceph-source-dist/build/Jenkinsfile
@@ -13,7 +13,12 @@ pipeline {
               env.CEPH_EXTRA_CMAKE_ARGS+=" -DWITH_SYSTEM_BOOST=OFF -DWITH_BOOST_VALGRIND=ON"
               env.DEB_BUILD_PROFILES=""
               break
-            case "crimson":
+            case "crimson-debug":
+              env.CEPH_EXTRA_RPMBUILD_ARGS="--with crimson"
+              env.DEB_BUILD_PROFILES="pkg.ceph.crimson"
+              env.CEPH_EXTRA_CMAKE_ARGS+=" -DCMAKE_BUILD_TYPE=Debug"
+              break
+            case "crimson-release":
               env.CEPH_EXTRA_RPMBUILD_ARGS="--with crimson"
               env.DEB_BUILD_PROFILES="pkg.ceph.crimson"
               break

--- a/ceph-source-dist/config/definitions/ceph-source-dist.yml
+++ b/ceph-source-dist/config/definitions/ceph-source-dist.yml
@@ -41,7 +41,8 @@
           name: FLAVOR
           choices:
             - default
-            - crimson
+            - crimson-debug
+            - crimson-release
             - jaeger
 
       - string:

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -20,7 +20,7 @@ page_limit = 100000
 NAME_RE = re.compile(
     r'(.*)-([0-9a-f]{7})-centos-.*([0-9]+)-(x86_64|aarch64)-devel'
 )
-SHA1_RE = re.compile(r'([0-9a-f]{40})(-crimson|-aarch64)*')
+SHA1_RE = re.compile(r'([0-9a-f]{40})(-crimson-debug|-crimson-release|-aarch64)*')
 
 
 def get_all_quay_tags(quaytoken):
@@ -291,7 +291,7 @@ def main():
                 continue
             # <sha1>-crimson tags don't have full or ref tags to go with.
             # Delete them iff the default <sha1> tag is to be deleted
-            if (match[2] == '-crimson') and (sha1 in tags_to_delete):
+            if match[2] in ('-crimson', '-crimson-debug', '-crimson-release') and sha1 in tags_to_delete:
                 if args.verbose:
                     print(
                         'Marking %s for deletion: orphaned sha1 tag' % name

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -867,7 +867,11 @@ ceph_build_args_from_flavor() {
         CEPH_EXTRA_CMAKE_ARGS+=" -DWITH_SYSTEM_BOOST=OFF -DWITH_BOOST_VALGRIND=ON"
         DEB_BUILD_PROFILES=""
         ;;
-    crimson)
+    crimson-debug)
+        CEPH_EXTRA_RPMBUILD_ARGS="--with crimson"
+        DEB_BUILD_PROFILES="pkg.ceph.crimson"
+        CEPH_EXTRA_CMAKE_ARGS+=" -DCMAKE_BUILD_TYPE=Debug"
+    crimson-release)
         CEPH_EXTRA_RPMBUILD_ARGS="--with crimson"
         DEB_BUILD_PROFILES="pkg.ceph.crimson"
         ;;
@@ -1019,7 +1023,7 @@ EOF
 
 extra_cmake_args() {
     # statically link against libstdc++ for building new releases on old distros
-    if [ "${FLAVOR}" = "crimson" ]; then
+    if [ "${FLAVOR}" = "crimson-debug" ] || [ "${FLAVOR}" = "crimson-release" ] ; then
         # seastar's exception hack assums dynamic linkage against libgcc. as
         # otherwise _Unwind_RaiseException will conflict with its counterpart
         # defined in libgcc_eh.a, when the linker comes into play. and more
@@ -1482,7 +1486,10 @@ setup_rpm_build_deps() {
 
     # enable more build depends required by build flavor(jaeger, crimson)
     case "${FLAVOR}" in
-    crimson)
+    crimson-debug)
+      sed -i -e 's/%bcond_with crimson/%bcond_without crimson/g' $DIR/ceph.spec
+        ;;
+    crimson-release)
       sed -i -e 's/%bcond_with crimson/%bcond_without crimson/g' $DIR/ceph.spec
         ;;
     jaeger)


### PR DESCRIPTION
The following change would allow us to:

* Keep testing "Debug" builds (crimson-debug) by default.
* When crimson-only is used, crimson-release would also be built.
* `crimson-release` builds would be used in the weekly nightlies and on
  selected PR gatings (when crimson-debug is not enough).

Note: Once crimson-release is stable enough we could switch crimson-debug
      to actaully be of: "RelWithDebInfo + !NDEBUG + asserts" instead of "Debug".
      For now, let's keep it as Debug since we know it's stable.

See: https://github.com/ceph/ceph/pull/63557