### PR TITLE
vagrant-libvirt: install the latest version

### DIFF
--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -730,7 +730,7 @@
 
         # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1127#issuecomment-713651332
         - name: Install the vagrant-libvirt plugin (EL8)
-          command: vagrant plugin install vagrant-libvirt --plugin-version 0.3.0
+          command: vagrant plugin install vagrant-libvirt
           become_user: "{{ jenkins_user }}"
           environment:
             CONFIGURE_ARGS: 'with-ldflags=-L/opt/vagrant/embedded/lib with-libvirt-include=/usr/include/libvirt with-libvirt-lib=/usr/lib'


### PR DESCRIPTION
The pinned version is already too old and is failing in CI due to:
```
Error message given during initialization: Unable to resolve dependency: user requested 'vagrant-libvirt (= 0.12.2)'
```

Let's try the latest and see if the reason for pinning the old one still exists.