### PR TITLE
kernel: stop building for trusty, xenial and bionic

### DIFF
--- a/kernel/config/definitions/kernel.yml
+++ b/kernel/config/definitions/kernel.yml
@@ -16,8 +16,8 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: centos9, jammy, focal, bionic, xenial, and trusty"
-          default: "centos9 trusty xenial bionic focal jammy"
+          description: "A list of distros to build for. Available options are: centos9, jammy and focal"
+          default: "centos9 focal jammy"
 
       - string:
           name: ARCHS
@@ -60,9 +60,6 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           name: AVAILABLE_DIST
           values:
             - centos9
-            - trusty
-            - xenial
-            - bionic
             - focal
             - jammy
       - axis:


### PR DESCRIPTION
These are too old and kernel packages are no longer needed.