### PR TITLE
sepia-fog-images: add image test to 'poll for deploy' loop

### DIFF
--- a/sepia-fog-images/build/build
+++ b/sepia-fog-images/build/build
@@ -221,7 +221,7 @@ if [ "$PAUSEQUEUE" == "true" ]; then
   fogdeployid=$(curl -f -s -k -H "fog-api-token: ${FOG_API_TOKEN}" -H "fog-user-token: ${FOG_USER_TOKEN}" http://fog.front.sepia.ceph.com/fog/tasktype -d '{"name": "Deploy"}' -X GET | jq -r '.tasktypes[0].id')
 
   # Check for scheduled deploy tasks
-  deploytasks=$(curl -f -s -k -H "fog-api-token: ${FOG_API_TOKEN}" -H "fog-user-token: ${FOG_USER_TOKEN}" http://fog.front.sepia.ceph.com/fog/task/active -d '{"typeID": "'${fogdeployid}'"}' -X GET | jq -r '.count')
+  deploytasks=$(curl -f -s -k -H "fog-api-token: ${FOG_API_TOKEN}" -H "fog-user-token: ${FOG_USER_TOKEN}" http://fog.front.sepia.ceph.com/fog/task/active -d '{"typeID": "'${fogdeployid}'", "imageID": "'${fogimageid}'"}' -X GET | jq -r '.count')
 
   # If there are scheduled or active deploy tasks, pause the queue and let them finish.
   # Capturing a new OS image can interrupt active OS deployments.


### PR DESCRIPTION
When checking for scheduled deploy tasks, check not only for existing deploy tasks but for deploy tasks *for the image we're proposing to capture*.  There are often deploy tasks on a busy fog server, but we only need to avoid affecting tasks for the image we're updating