### PR TITLE
Skip workflows for documentation and container-only changes

### DIFF
--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -36,7 +36,9 @@
           github-hooks: true
           permit-all: false
           auto-close-on-fail: false
-
+          excluded-regions:
+            - ^doc/*
+            - ^container/.*
     scm:
       - git:
           url: https://github.com/ceph/ceph-build.git

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -50,6 +50,9 @@
           started-status: "running API tests"
           success-status: "ceph API tests succeeded"
           failure-status: "ceph API tests failed"
+          excluded-regions:
+            - ^doc/*
+            - ^container/.*
 
     scm:
       - git:

--- a/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
@@ -36,6 +36,9 @@
           started-status: "checking if PR has modified submodules"
           success-status: "submodules for project are unmodified"
           failure-status: "Approval needed: modified submodules found"
+          excluded-regions:
+            - ^doc/*
+            - ^container/.*
 
     scm:
       - git:


### PR DESCRIPTION
Use GitHub's path-based filtering to exclude CI workflows when PRs only modify documentation (^doc/*) or container files (`^container/.*`).

Previously, we relied on `docs_pr_only()` and `container_pr_only()` bash functions to detect these changes and skip make-check workflows. This approach had significant drawbacks:

- Required cloning the repository and running build scripts even for skipped tests
- Failed entirely when Jenkins nodes couldn't clone due to infrastructure issues, blocking even trivial documentation changes

This change applies exclude patterns directly to workflow triggers for:
- ceph-build-pull-requests
- ceph-windows-pull-requests
- ceph-pr-api
- ceph-pr-submodules

Benefits:
- Reduces Jenkins node load by avoiding unnecessary repository clones
- Prevents infrastructure issues from blocking documentation contributors
- Maintains a part of of the skip logic with better reliability