### PR TITLE
Enable linger for the Jenkins user

### DIFF
--- a/scripts/setup_container_runtime.sh
+++ b/scripts/setup_container_runtime.sh
@@ -25,6 +25,9 @@ function setup_container_runtime () {
   fi
 
   if command -v podman; then
+    if ! [ -d /run/user/$(id -u) -a -w /run/user/$(id -u) ]; then
+      sudo loginctl enable-linger $(id -nu)
+    fi
     PODMAN_MAJOR_VERSION=$(podman version -f json | jq -r '.Client.Version|split(".")[0]')
     if [ "$PODMAN_MAJOR_VERSION" -ge 4 ]; then
       PODMAN_DIR="$HOME/.local/share/containers"


### PR DESCRIPTION
This fixes errors like:
RunRoot is pointing to a path (/run/user/$ID/containers) which is not writable. Most likely podman will fail. Error: creating events dirs: mkdir /run/user/$ID: permission denied