### PR TITLE
ceph-dev-pipeline: Clean up workspace in post

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -596,6 +596,13 @@ pipeline {
             }
           }
         }
+        post {
+          always {
+            script {
+              sh 'podman unshare chown -R 0 $WORKSPACE/dist/ceph'
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
[The build I tested with](https://jenkins.ceph.com/job/ceph-dev-pipeline/392/pipeline-overview/?selected-node=296) this failed, which was helpful in that I was able to manually verify `jenkins-build` was able to `rm -rf` the workspace without using `sudo`