### PR TITLE
scripts/build_utils: default to gcc-14 for ubuntu noble

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -804,7 +804,7 @@ setup_pbuilder_for_old_gcc() {
         jammy)
             old=11;;
         noble)
-            old=13;;
+            old=14;;
     esac
     setup_gcc_hook $old > $hookdir/D10update-gcc-alternatives
     chmod +x $hookdir/D10update-gcc-alternatives


### PR DESCRIPTION
noble provides both gcc-13 and 14, but its gcc 13.2.0 suffers from an LTO bug that causes ceph daemons to crash horribly (tracked in https://tracker.ceph.com/issues/63867)