### PR TITLE
scripts/build_utils: setup_pbuilder_for_old_gcc() installs requested version

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -806,6 +806,13 @@ setup_pbuilder_for_old_gcc() {
         noble)
             old=14;;
     esac
+
+    # make sure the requested version is installed. this isn't the case by default on noble
+    cat > $hookdir/D05install-old-gcc <<EOF
+env DEBIAN_FRONTEND=noninteractive apt-get install -y g++-$old
+EOF
+    chmod +x $hookdir/D05install-old-gcc
+
     setup_gcc_hook $old > $hookdir/D10update-gcc-alternatives
     chmod +x $hookdir/D10update-gcc-alternatives
 }


### PR DESCRIPTION
ubuntu noble is special in that gcc-14 is available but gcc-13 is the default. before using update-alternatives to prefer gcc-14, we need to make sure it's installed

copy the relevant bit from `setup_pbuilder_for_new_gcc()`'s hook `D05install-new-gcc` to make sure the requested version is installed before running the `D10update-gcc-alternatives` hook