### PR TITLE
ceph-release-container: add setup_container_runtime.sh

### DIFF
--- a/ceph-release-containers/build/Jenkinsfile
+++ b/ceph-release-containers/build/Jenkinsfile
@@ -40,6 +40,8 @@ pipeline {
               CONTAINER_REPO = "${(env.ARCH == 'x86_64') ? 'prerelease-amd64' : 'prerelease-arm64'}"
             }
             steps {
+              sh './scripts/setup_container_runtime.sh'
+              sh 'echo "Building on $(hostname)"'
               buildDescription "${env.CONTAINER_REPO} image build"
               dir('ceph') {
                 checkout scmGit(


### PR DESCRIPTION
A ceph-release-container run suffered from

error running container: from /usr/bin/crun creating container for [<sh command>]: sd-bus call: Interactive authentication required.: Permission denied

That is thought to be because of the lack of 'linger' on the jenkins-build user, such that the /run/user directory didn't persist.  The exact mechanism of failure isn't fully understood, but this script has fixed similar issues for ceph-dev-pipeline.

Also, add an echo of the node for convenience.