### PR TITLE
dashboard-cephadm-e2e: install node via nvm

### DIFF
--- a/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
+++ b/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
@@ -77,6 +77,9 @@
             - ../../../scripts/dashboard/install-cephadm-e2e-deps.sh
       - shell: |
           export CYPRESS_ARGS="--record --key $CYPRESS_RECORD_KEY --tag $ghprbTargetBranch" COMMIT_INFO_MESSAGE="$ghprbPullTitle"
+          export NVM_DIR="$HOME/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
           timeout 7200 ./src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
 
     wrappers:

--- a/scripts/dashboard/install-cephadm-e2e-deps.sh
+++ b/scripts/dashboard/install-cephadm-e2e-deps.sh
@@ -20,25 +20,24 @@ sudo apt update -y
 sudo apt install -y apt-transport-https ca-certificates curl gnupg lsb-release \
     openssh-server software-properties-common
 
-NODEJS_MAJOR_VERSION=16
-DISTRO="$(lsb_release -cs)"
-if [[ ! $(command -v node) || $(node --version | grep -oE "v([0-9])+" | cut -c 2-) < ${NODEJS_MAJOR_VERSION} ]]; then
-    sudo add-apt-repository -y -r ppa:chris-lea/node.js
-    sudo rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list
-    sudo rm -f /etc/apt/sources.list.d/chris-lea-node_js-*.list.save
+# install nvm
+if [[ ! $(command -v nvm) ]]; then
+    LATEST_NVM_VERSION=$(curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
+    echo "Installing nvm version ${LATEST_NVM_VERSION}"
 
-    NODEJS_KEYRING=/usr/share/keyrings/nodesource.gpg
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee "${NODEJS_KEYRING}" >/dev/null
-    gpg --no-default-keyring --keyring "${NODEJS_KEYRING}" --list-keys
+    curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/${LATEST_NVM_VERSION}/install.sh | bash
 
-    NODEJS_VERSION="node_${NODEJS_MAJOR_VERSION}.x"
-    echo "deb [signed-by=${NODEJS_KEYRING}] https://deb.nodesource.com/${NODEJS_VERSION} ${DISTRO} main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-    echo "deb-src [signed-by=${NODEJS_KEYRING}] https://deb.nodesource.com/${NODEJS_VERSION} ${DISTRO} main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list
-
-    sudo apt update -y
-    sudo apt install -y nodejs
-    sudo rm -f /etc/apt/sources.list.d/nodesource.list
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
 fi
+
+echo "Installing nodejs from nvm with version $(cat .nvmrc)"
+pushd src/pybind/mgr/dashboard/frontend
+nvm install
+nvm use
+popd
+
 sudo apt install -y libvirt-daemon-system libvirt-daemon-driver-qemu qemu-kvm libvirt-clients runc
 
 sudo usermod -aG libvirt $(id -un)


### PR DESCRIPTION
to avoid pinning the node versions