### PR TITLE
Build specific commits with new build pipelines

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -146,6 +146,7 @@ pipeline {
               parameters: [
                 string(name: "BRANCH", value: env.BRANCH),
                 // Below are just for ceph-source-dist
+                string(name: "SHA1", value: env.SHA1),
                 string(name: "CEPH_REPO", value: env.CEPH_REPO),
                 string(name: "CEPH_BUILD_BRANCH", value: env.CEPH_BUILD_BRANCH),
               ]
@@ -263,9 +264,13 @@ pipeline {
                 )
               }
               script {
+                def sha1_trimmed = env.SHA1.trim().toLowerCase()
                 def sha1_props = readProperties file: "${WORKSPACE}/dist/sha1"
-                env.SHA1 = sha1_props.SHA1
-                println "SHA1=${env.SHA1}"
+                sha1_from_artifact = sha1_props.SHA1.trim().toLowerCase()
+                if ( env.SHA1 && sha1_from_artifact != sha1_trimmed ) {
+                  error message: "SHA1 from artifact (${sha1_from_artifact}) does not match parameter value (${sha1_trimmed})"
+                }
+                println "SHA1=${sha1_trimmed}"
                 env.VERSION = readFile(file: "${WORKSPACE}/dist/version").trim()
                 def shaman_url = "https://shaman.ceph.com/builds/ceph/${env.BRANCH}/${env.SHA1}"
                 def build_description = """\

--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -24,6 +24,10 @@
           description: "The git branch (or tag) to build"
           default: main
 
+      - string:
+          name: SHA1
+          description: "The specific commit to build"
+
       - choice:
           name: CEPH_REPO
           choices:

--- a/ceph-source-dist/build/Jenkinsfile
+++ b/ceph-source-dist/build/Jenkinsfile
@@ -1,3 +1,5 @@
+def checkout_ref = ""
+
 pipeline {
   agent {
     label "gigantic"
@@ -6,8 +8,15 @@ pipeline {
     stage("repository") {
       steps {
         dir("ceph") {
+          script {
+            if ( env.SHA1 ) {
+              checkout_ref = env.SHA1
+            } else {
+              checkout_ref = env.BRANCH
+            }
+          }
           checkout scmGit(
-            branches: [[name: env.BRANCH]],
+            branches: [[name: checkout_ref]],
             userRemoteConfigs: [[
               url: env.CEPH_REPO,
               credentialsId: 'jenkins-build'

--- a/ceph-source-dist/config/definitions/ceph-source-dist.yml
+++ b/ceph-source-dist/config/definitions/ceph-source-dist.yml
@@ -38,6 +38,10 @@
           description: "The Ceph branch to build"
 
       - string:
+          name: SHA1
+          description: "The specific commit to build"
+
+      - string:
           name: CEPH_BUILD_BRANCH
           description: "Use the Jenkinsfile from this ceph-build branch"
           default: main

--- a/ceph-trigger-build/build/Jenkinsfile
+++ b/ceph-trigger-build/build/Jenkinsfile
@@ -95,6 +95,7 @@ pipeline {
       steps {
         script {
           initialParams.BRANCH = env.ref.replace("refs/heads/", "")
+          initialParams.SHA1 = env.head_commit_id
           initialParams.putAll(defaults)
           println("BRANCH=${initialParams.BRANCH}")
         }


### PR DESCRIPTION
With these changes:

- `ceph-trigger-build` will pass a `SHA1` parameter to the triggered job, set to the ID of the HEAD commit
- `ceph-dev-pipeline` will pass that to the setup job
- `ceph-source-dist` will clone that specific commit - if specified - otherwise it will clone the branch as it does now
- `ceph-dev-pipeline` will check that source tarballs represent the requested SHA1 - if one is supplied