### PR TITLE
sync-pull: in the 'ugly loop', skip nonexistent repos

### DIFF
--- a/scripts/sync-pull
+++ b/scripts/sync-pull
@@ -17,7 +17,11 @@ if [[ "$project" == "ceph" ]] ; then
   # This ugly loop checks all possible DEB combinations to see which repo has the most packages since that's likely the repo you want to sync.
   current_highest_count=0
   for combo in debian/bookworm debian/bullseye ubuntu/bionic ubuntu/focal ubuntu/jammy ubuntu/noble; do
-    combo_count=$(curl -fs https://chacra.ceph.com/r/$project/$release/$sha1/${combo}/flavors/default/pool/main/c/ceph/ | wc -l)
+    combo_count=$(curl -fs https://chacra.ceph.com/r/$project/$release/$sha1/${combo}/flavors/default/pool/main/c/ceph/ | wc -l || /bin/true)
+    if [[ ${PIPESTATUS[0]} -eq 22 ]] ; then
+      echo "$combo packages not found, skipping"
+      continue
+    if
     if [ $combo_count -gt $current_highest_count ]; then
       current_highest_count=$combo_count
       highest_combo=$combo


### PR DESCRIPTION
This heuristic remains questionable, but continue it on by allowing some named distro/version repos to not exist without stopping sync-pull from working