### PR TITLE
kernel: install bc

### DIFF
--- a/kernel/build/build_deb
+++ b/kernel/build/build_deb
@@ -41,9 +41,6 @@ echo "*****"
 env
 echo "*****"
 
-# Install build dependencies
-sudo apt-get install -y bc
-
 # Clean the upper level debs
 rm -f ../*.deb
 

--- a/kernel/build/setup
+++ b/kernel/build/setup
@@ -30,6 +30,7 @@ fi
 export LC_ALL=C # the following is vulnerable to i18n
 
 if test -f /etc/redhat-release ; then
+    $SUDO yum install -y bc
     $SUDO yum install -y elfutils-libelf-devel  # for ORC unwinder
     $SUDO yum install -y flex bison  # for Kconfig
     $SUDO yum install -y dwarves
@@ -42,6 +43,7 @@ if test -f /etc/redhat-release ; then
 fi
 
 if which apt-get > /dev/null ; then
+    $SUDO apt-get install -y bc
     $SUDO apt-get install -y lsb-release
     $SUDO apt-get install -y libelf-dev  # for ORC unwinder
     $SUDO apt-get install -y flex bison  # for Kconfig


### PR DESCRIPTION
bc has been required for building the Linux kernel for a long time. It was installed explicitly (albeit from the wrong script) in the deb case, but not installed in the rpm case:

  error: Failed build dependencies:
  	bc is needed by kernel-6.17.0_rc1_g0dccf5229fc7-1.x86_64
  make[2]: *** [scripts/Makefile.package:75: binrpm-pkg] Error 11