### PR TITLE
ceph-trigger-build: Do not trigger on tag pushes

### DIFF
--- a/ceph-trigger-build/config/definitions/ceph-trigger-build.yml
+++ b/ceph-trigger-build/config/definitions/ceph-trigger-build.yml
@@ -57,6 +57,6 @@
             - type: JSONPath
               key: is_delete
               value: $.deleted
-          regex-filter-text: $is_delete
-          regex-filter-expression: "(?i)false"
+          regex-filter-text: $is_delete $ref
+          regex-filter-expression: "(?i)false refs/heads/.*"
           cause: "Push to $ref by $pusher"


### PR DESCRIPTION
This pipeline doesn't support tags, and it doesn't seem like shaman does either.