### PR TITLE
cephadm-dashboard-e2e: use node version from dashboard/frontend

### DIFF
--- a/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
+++ b/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
@@ -80,6 +80,10 @@
           export NVM_DIR="$HOME/.nvm"
           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
           [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+
+          # use the node version from dashboard/frontend
+          nvm use "$(cat src/pybind/mgr/dashboard/frontend/.nvmrc)"
+
           timeout 7200 ./src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
 
     wrappers:


### PR DESCRIPTION
via .nvmrc