### PR TITLE
Create ceph-release-pipeline for upstream release builds

### DIFF
--- a/ansible/roles/ceph-release/tasks/create.yml
+++ b/ansible/roles/ceph-release/tasks/create.yml
@@ -106,6 +106,8 @@
     chdir: ceph
   when: tag|bool is true
 
+- import_tasks: write_sha1_file.yml
+
 - name: tag the version
   command: git tag -f "v{{ version }}" -m "v{{ version }}"
   args:

--- a/ansible/roles/ceph-release/tasks/create.yml
+++ b/ansible/roles/ceph-release/tasks/create.yml
@@ -47,7 +47,6 @@
   when:
     - "release != 'SECURITY'"
     - tag|bool is false
-    - throwaway|bool is false
 
 # SECURITY
 - name: "git checkout security {{ branch }}-release branch"

--- a/ansible/roles/ceph-release/tasks/main.yml
+++ b/ansible/roles/ceph-release/tasks/main.yml
@@ -7,3 +7,9 @@
     - "stage == 'push'"
     - "release != 'SECURITY'"
     - tag|bool is true
+
+# This only runs to prevent the Archive Artifacts plugin from hanging
+- import_tasks: write_sha1_file.yml
+  when:
+    - "stage == 'push'"
+    - "release == 'SECURITY'"

--- a/ansible/roles/ceph-release/tasks/push.yml
+++ b/ansible/roles/ceph-release/tasks/push.yml
@@ -36,6 +36,8 @@
   args:
     chdir: ceph
 
+- import_tasks: write_sha1_file.yml
+
 - name: push version commit to BRANCH-release branch
   command: git push upstream {{ branch }}-release
   args:

--- a/ansible/roles/ceph-release/tasks/write_sha1_file.yml
+++ b/ansible/roles/ceph-release/tasks/write_sha1_file.yml
@@ -1,0 +1,23 @@
+---
+# These tasks write the version commit's sha1 to a file for
+# ceph-source-dist and ceph-dev-pipeline to later consume.
+#
+# We write it again when running the playbook with stage=push only so
+# the Archive Artifacts plugin doesn't hang indefinitely.  We don't want
+# to configure the plugin to allow an empty or missing file.
+
+- name: record commit sha1
+  command: git rev-parse HEAD
+  args:
+    chdir: ceph
+  register: commit_sha
+
+- name: ensure ceph/dist dir exists
+  file:
+    path: ceph/dist
+    state: directory
+
+- name: save commit sha1 to file
+  copy:
+    content: "{{ commit_sha.stdout }}"
+    dest: ceph/dist/sha1

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -149,6 +149,10 @@ pipeline {
                 string(name: "SHA1", value: env.SHA1),
                 string(name: "CEPH_REPO", value: env.CEPH_REPO),
                 string(name: "CEPH_BUILD_BRANCH", value: env.CEPH_BUILD_BRANCH),
+                // Below are only for actual releases
+                string(name: 'RELEASE_TYPE',  value: env.RELEASE_TYPE ?: ''),
+                string(name: 'RELEASE_BUILD', value: env.RELEASE_BUILD ?: ''),
+                string(name: 'VERSION',       value: env.VERSION ?: '')
               ]
             )
             env.SETUP_BUILD_ID = setup_build.getNumber()
@@ -272,13 +276,25 @@ pipeline {
                 }
                 println "SHA1=${sha1_trimmed}"
                 env.VERSION = readFile(file: "${WORKSPACE}/dist/version").trim()
+                script {
+                  // In a release build, dist/other_envvars contains CEPH_REPO, and chacra_url
+                  // as written during ceph-source-dist but we don't to be able to define
+                  // ceph-releases.git or chacra.ceph.com as parameters for ceph-dev-pipeline.
+                  def props = readProperties file: "${WORKSPACE}/dist/other_envvars"
+                  for (p in props) {
+                    env."${p.key}" = p.value
+                  }
+                }
                 def branch_ui_value = env.BRANCH
                 def sha1_ui_value = env.SHA1
-                if ( env.CEPH_REPO.find(/https?:\/\/github.com\//) ) {
-                  def branch_url = "${env.CEPH_REPO}/tree/${env.BRANCH}"
-                  branch_ui_value = "<a href=\"${branch_url}\">${env.BRANCH}</a>"
-                  def commit_url = "${env.CEPH_REPO}/commit/${env.SHA1}"
-                  sha1_ui_value = "<a href=\"${commit_url}\">${env.SHA1}</a>"
+                if (env.CEPH_REPO?.find(/https?:\/\/github.com\//)) {
+                    // If this is a release build, link to ceph-release.git's $BRANCH-release branch
+                    def suffix = (env.RELEASE_BUILD?.trim() == "true") ? "-release" : ""
+
+                    def branch_url = "${env.CEPH_REPO}/tree/${env.BRANCH}${suffix}"
+                    branch_ui_value = "<a href=\"${branch_url}\">${env.BRANCH}${suffix}</a>"
+                    def commit_url = "${env.CEPH_REPO}/commit/${env.SHA1}"
+                    sha1_ui_value = "<a href=\"${commit_url}\">${env.SHA1}</a>"
                 }
                 def shaman_url = "https://shaman.ceph.com/builds/ceph/${env.BRANCH}/${env.SHA1}"
                 def build_description = """\
@@ -295,12 +311,6 @@ pipeline {
               }
               sh "sha256sum dist/*"
               sh "cat dist/sha1 dist/version"
-              script {
-                def props = readProperties file: "${WORKSPACE}/dist/other_envvars"
-                for (p in props) {
-                  env."${p.key}" = p.value
-                }
-              }
               sh '''#!/bin/bash
                 set -ex
                 cd dist
@@ -428,7 +438,9 @@ pipeline {
                 switch (env.FLAVOR) {
                   case "default":
                     env.CEPH_EXTRA_CMAKE_ARGS+=" -DALLOCATOR=tcmalloc"
-                    env.CEPH_EXTRA_CMAKE_ARGS+=" -DWITH_SYSTEM_BOOST=OFF -DWITH_BOOST_VALGRIND=ON"
+                    if (env.RELEASE_BUILD?.toBoolean()) {
+                      env.CEPH_EXTRA_CMAKE_ARGS+=" -DWITH_SYSTEM_BOOST=OFF -DWITH_BOOST_VALGRIND=ON"
+                    }
                     break
                   case ~/crimson.*/:
                     env.DEB_BUILD_PROFILES="pkg.ceph.crimson"
@@ -490,16 +502,18 @@ pipeline {
             post {
               always {
                 script {
-                  sh """
-                    if [ -f "${env.WORKSPACE}/dist/ceph/sccache_log.txt" ]; then
-                      ln dist/ceph/sccache_log.txt sccache_log_${env.DIST}_${env.ARCH}_${env.FLAVOR}.txt
-                    fi
-                  """
-                  archiveArtifacts(
-                    artifacts: 'sccache_log*.txt',
-                    allowEmptyArchive: true,
-                    fingerprint: true,
-                  )
+                  if (env.SCCACHE?.trim() == "true") {
+                    sh """
+                      if [ -f "${env.WORKSPACE}/dist/ceph/sccache_log.txt" ]; then
+                        ln dist/ceph/sccache_log.txt sccache_log_${env.DIST}_${env.ARCH}_${env.FLAVOR}.txt
+                      fi
+                    """
+                    archiveArtifacts(
+                      artifacts: 'sccache_log*.txt',
+                      allowEmptyArchive: true,
+                      fingerprint: true,
+                    )
+                  }
                 }
               }
               unsuccessful {
@@ -532,6 +546,8 @@ pipeline {
                       mkdir -p ./rpmbuild/SRPMS/
                       ln ceph-*.src.rpm ./rpmbuild/SRPMS/
                   """
+                  // Push packages to chacra.ceph.com under the 'test' ref if ceph-release-pipeline's TEST=true
+                  env.SHA1 = env.TEST?.toBoolean() ? 'test' : env.SHA1
                   def spec_text = get_ceph_release_spec_text("${chacra_url}r/ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}/")
                   writeFile(
                     file: "dist/ceph/rpmbuild/SPECS/ceph-release.spec",

--- a/ceph-release-pipeline/build/Jenkinsfile
+++ b/ceph-release-pipeline/build/Jenkinsfile
@@ -1,0 +1,101 @@
+// Global variables to use across stages
+def CEPH_TAG_CREATE_JOB_ID, CEPH_TAG_CREATE_JOB_URL
+def PACKAGE_BUILD_ID, PACKAGE_BUILD_URL
+def CEPH_TAG_PUSH_JOB_ID, CEPH_TAG_PUSH_JOB_URL
+
+pipeline {
+  agent any
+  stages {
+    stage('create ceph release tag') {
+      steps {
+        script {
+          def createTagJob = build(
+            job: 'ceph-tag',
+            parameters: [
+              string(name: 'VERSION',             value: env.VERSION),
+              string(name: 'BRANCH',              value: env.BRANCH),
+              booleanParam(name: 'FORCE',         value: env.FORCE?.toBoolean()),
+              booleanParam(name: 'FORCE_VERSION', value: env.FORCE_VERSION?.toBoolean()),
+              string(name: 'RELEASE_TYPE',        value: env.RELEASE_TYPE),
+              booleanParam(name: 'RELEASE_BUILD', value: true),
+              booleanParam(name: 'TAG',           value: env.TAG?.toBoolean()),
+              booleanParam(name: "THROWAWAY",     value: env.THROWAWAY?.toBoolean()),
+              string(name: "CEPH_BUILD_BRANCH",   value: env.CEPH_BUILD_BRANCH),
+              string(name: 'TAG_PHASE',           value: 'create')
+            ],
+          )
+          CEPH_TAG_CREATE_JOB_ID  = createTagJob.getNumber()
+          CEPH_TAG_CREATE_JOB_URL = new URI([env.JENKINS_URL, "job", "ceph-tag", CEPH_TAG_CREATE_JOB_ID].join("/")).normalize()
+
+          copyArtifacts projectName: 'ceph-tag',
+                    selector: specific("${CEPH_TAG_CREATE_JOB_ID}"),
+                    filter: 'ceph-build/ansible/ceph/dist/sha1',
+                    target: '.',
+                    flatten: true
+
+          def sha1 = readFile('sha1').trim()
+          env.SHA1 = sha1
+          echo "Downstream returned: ${env.SHA1}"
+          def build_description = """\
+                  BRANCH=${env.BRANCH}<br />
+                  VERSION=${env.VERSION}<br />
+                  SHA1=${env.SHA1}<br />
+          """.stripIndent()
+          // Note: This requires the 'build-name-setter' plugin
+          buildDescription build_description
+        }
+      }
+    }
+    stage("package build") {
+      steps {
+        script {
+          def package_build = build(
+            job: 'ceph-dev-pipeline',
+            parameters: [
+              // These are in order of the parameters ceph-dev-pipeline takes
+              string(name: "BRANCH",              value: env.BRANCH),
+              string(name: "SHA1",                value: env.SHA1),
+              string(name: "DISTROS",             value: env.DISTROS),
+              string(name: "ARCHS",               value: env.ARCHS),
+              string(name: "FLAVORS",             value: 'default'),
+              booleanParam(name: "CI_COMPILE",    value: true),
+              booleanParam(name: "THROWAWAY",     value: env.THROWAWAY),
+              booleanParam(name: "FORCE",         value: env.FORCE),
+              string(name: 'FLAVOR',              value: 'default'),
+              // Release containers are built manually from signed packages so we don't need to build them here
+              booleanParam(name: 'CI_CONTAINER',  value: false),
+              booleanParam(name: 'DWZ',           value: true),
+              booleanParam(name: 'SCCACHE',       value: false),
+              string(name: "CEPH_BUILD_BRANCH",   value: env.CEPH_BUILD_BRANCH),
+              string(name: 'RELEASE_TYPE',        value: env.RELEASE_TYPE),
+              booleanParam(name: 'RELEASE_BUILD', value: true),
+              string(name: 'VERSION',             value: env.VERSION)
+            ]
+          )
+          PACKAGE_BUILD_ID  = package_build.getNumber()
+          PACKAGE_BUILD_URL = new URI([env.JENKINS_URL, "job", "ceph-dev-pipeline", PACKAGE_BUILD_ID].join("/")).normalize()
+        }
+      }
+    }
+    stage('push ceph release tag') {
+      steps {
+        script {
+          def pushTagJob = build(
+            job: 'ceph-tag',
+            parameters: [
+              string(name: 'VERSION',             value: env.VERSION ?: ''),
+              string(name: 'BRANCH',              value: env.BRANCH ?: ''),
+              booleanParam(name: 'FORCE_VERSION', value: env.FORCE_VERSION),
+              string(name: 'RELEASE_TYPE',        value: env.RELEASE_TYPE ?: ''),
+              booleanParam(name: 'RELEASE_BUILD', value: true),
+              booleanParam(name: 'TAG',           value: env.TAG),
+              string(name: 'TAG_PHASE',           value: 'push')
+            ],
+          )
+          CEPH_TAG_PUSH_JOB_ID  = pushTagJob.getNumber()
+          CEPH_TAG_PUSH_JOB_URL = new URI([env.JENKINS_URL, "job", "ceph-tag", CEPH_TAG_PUSH_JOB_ID].join("/")).normalize()
+        }
+      }
+    }
+  }
+}

--- a/ceph-release-pipeline/config/definitions/ceph-release-pipeline.yml
+++ b/ceph-release-pipeline/config/definitions/ceph-release-pipeline.yml
@@ -1,0 +1,97 @@
+- job:
+    name: ceph-release-pipeline
+    description: 'This Jenkins pipeline creates upstream release tags, and packages.'
+    project-type: pipeline
+    quiet-period: 1
+    concurrent: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/ceph/ceph-build
+            branches:
+              - ${{CEPH_BUILD_BRANCH}}
+            shallow-clone: true
+            submodule:
+              disable: true
+            wipe-workspace: true
+      script-path: ceph-release-pipeline/build/Jenkinsfile
+      lightweight-checkout: true
+      do-not-fetch-tags: true
+
+    parameters:
+      - string:
+          name: BRANCH
+          description: "The release branch to build (e.g., pacific)"
+          default: main
+
+      - string:
+          name: VERSION
+          description: "The version for release, e.g. 0.94.4"
+
+      - bool:
+          name: TEST
+          description: |
+            If this is unchecked, then the builds will be pushed to chacra with the correct ref. This is the default.
+
+            If this is checked, then the builds will be pushed to chacra under the 'test' ref.
+
+      - bool:
+          name: TAG
+          description: |
+            When this is checked, Jenkins will remove the previous private tag and recreate it again, changing the control files and committing again. When this is unchecked, Jenkins will not do any commit or tag operations. If you've already created the private tag separately or are re-running a build, leave this unchecked.
+            Defaults to checked.
+          default: true
+
+      - bool:
+          name: THROWAWAY
+          description: |
+            Default: False. When True it will not POST binaries to chacra. Artifacts will not be around for long. Useful to test builds.
+          default: false
+
+      - bool:
+          name: FORCE_VERSION
+          description: |
+            Default: False. When True it will force the Debian version (when wanting to release older versions after newer ones have been released.
+            Mostly useful for DEBs to append the `-b` flag for dhc.)
+          default: false
+
+      - bool:
+          name: FORCE
+          description: |
+            If this is unchecked, then then nothing is built or pushed if they already exist in chacra. This is the default.
+
+            If this is checked, then the binaries will be built and pushed to chacra even if they already exist in chacra.
+
+      - choice:
+          name: RELEASE_TYPE
+          description: |
+            STABLE: A normal release. Builds from BRANCH branch and pushed to BRANCH-release branch.
+            RELEASE_CANDIDATE: A normal release except the binaries will be pushed to chacra using the $BRANCH-rc name
+            HOTFIX: Builds from BRANCH-release branch. BRANCH-release will be git merged back into BRANCH.
+            SECURITY: Builds from BRANCH-release branch in ceph-private.git (private repo).
+          choices:
+            - STABLE
+            - RELEASE_CANDIDATE
+            - HOTFIX
+            - SECURITY
+
+      - string:
+          name: DISTROS
+          description: "A list of distros to build for. Available options are: centos9, noble, jammy, focal, bionic, xenial, trusty, precise, wheezy, jessie, buster, bullseye, bookworm"
+          default: "noble jammy centos8 centos9 bookworm"
+
+      - string:
+          name: ARCHS
+          description: "A list of architectures to build for. Available options are: x86_64, and arm64"
+          default: "x86_64 arm64"
+
+      - string:
+          name: CEPH_BUILD_BRANCH
+          description: "Use the Jenkinsfile from this ceph-build.git branch"
+          default: main
+
+
+    wrappers:
+      - build-name:
+          name: "#${{BUILD_NUMBER}} ${{BRANCH}}, ${{VERSION}}"
+

--- a/ceph-source-dist/build/Jenkinsfile
+++ b/ceph-source-dist/build/Jenkinsfile
@@ -14,25 +14,35 @@ pipeline {
             } else {
               checkout_ref = env.BRANCH
             }
-          }
-          checkout scmGit(
-            branches: [[name: checkout_ref]],
-            userRemoteConfigs: [[
-              url: env.CEPH_REPO,
-              credentialsId: 'jenkins-build'
-            ]],
-            extensions: [
-              [$class: 'CleanBeforeCheckout'],
-              [
-                $class: 'CloneOption',
-                shallow: true,
-                depth:   100,
-                timeout: 90
-              ],
-            ],
-          )
-          script {
-            sh 'git fetch --tags https://github.com/ceph/ceph.git'
+
+            // Rewrite repo + ref if RELEASE_BUILD=true.
+            // RELEASE_BUILD is intentionally undefinable as a ceph-source-dist parameter but instead
+            // defined by ceph-release-pipeline so that only that job may clone from ceph-releases.git.
+            def repoUrl = params.RELEASE_BUILD ? 'git@github.com:ceph/ceph-releases.git' : env.CEPH_REPO
+            env.checkout_ref = params.RELEASE_BUILD ? "v${params.VERSION}" : env.BRANCH
+            env.CEPH_REPO = repoUrl
+
+            checkout scmGit(
+              branches: [[name: checkout_ref]],
+              userRemoteConfigs: [[
+                url: env.CEPH_REPO,
+                credentialsId: 'jenkins-build'
+              ]],
+              extensions: [
+                [$class: 'CleanBeforeCheckout'],
+                [
+                  $class: 'CloneOption',
+                  shallow: true,
+                  depth: 100,
+                  timeout: 90
+                ]
+              ]
+            )
+
+            // No need to fetch tags if this is a release build
+            if (!params.RELEASE_BUILD?.toBoolean()) {
+              sh 'git fetch --tags https://github.com/ceph/ceph.git'
+            }
           }
         }
       }
@@ -69,7 +79,24 @@ pipeline {
               ln ceph-$ceph_version_tarball.$extension dist/
 
               echo "SHA1=$(git rev-parse HEAD)" > dist/sha1
-              echo "BRANCH=${BRANCH}" > dist/branch
+
+              if [ "${RELEASE_BUILD:-}" = "true" ]; then
+                # For security, the following vars are written to dist/other_envvars to be passed
+                # to ceph-dev-pipeline instead of via parameters.
+                # ceph-dev-pipeline does not offer ceph-releases.git as an option for CEPH_REPO,
+                # and we don't want RELEASE_BUILD to be settable by the user to avoid being able
+                # clone from ceph-releases.git.
+                if [ "${RELEASE_TYPE}" = "PRIVATE" ]; then
+                  echo "CEPH_REPO=https://github.com/ceph/ceph-private" > dist/other_envvars
+                else
+                  echo "CEPH_REPO=https://github.com/ceph/ceph-releases" > dist/other_envvars
+                fi
+                echo "RELEASE_BUILD=true" >> dist/other_envvars
+                echo "chacra_url=https://chacra.ceph.com/" >> dist/other_envvars
+                echo "BRANCH=${BRANCH}-release" > dist/branch
+              else
+                echo "BRANCH=${BRANCH}" > dist/branch
+              fi
 
               mv dist ..
             '''

--- a/ceph-tag/build/build
+++ b/ceph-tag/build/build
@@ -2,20 +2,16 @@
 
 set -ex
 
-if [ "$TAG" = false ] ; then
-    echo "Assuming tagging process has succeeded before because TAG was set to false"
-else
-    # the following two methods exist in scripts/build_utils.sh
-    pkgs=( "ansible" )
-    TEMPVENV=$(create_venv_dir)
-    VENV=${TEMPVENV}/bin
-    install_python_packages $TEMPVENV "pkgs[@]"
-    
-    # remove "-release" from $BRANCH variable in case it was accidentally passed in the Jenkins UI
-    BRANCH=${BRANCH//-release/}
-    
-    # run ansible to do all the tagging and release specifying
-    # a local connection and 'localhost' as the host where to execute
-    cd "$WORKSPACE/ceph-build/ansible/"
-    $VENV/ansible-playbook -i "localhost," -c local release.yml --extra-vars="stage=push version=$VERSION branch=$BRANCH force_version=$FORCE_VERSION release=$RELEASE_TYPE tag=$TAG project=ceph token=$GITHUB_TOKEN"
-fi
+# the following two methods exist in scripts/build_utils.sh
+pkgs=( "ansible" )
+TEMPVENV=$(create_venv_dir)
+VENV=${TEMPVENV}/bin
+install_python_packages $TEMPVENV "pkgs[@]"
+
+# remove "-release" from $BRANCH variable in case it was accidentally passed in the Jenkins UI
+BRANCH=${BRANCH//-release/}
+
+# run ansible to do all the tagging and release specifying
+# a local connection and 'localhost' as the host where to execute
+cd "$WORKSPACE/ceph-build/ansible/"
+$VENV/ansible-playbook -i "localhost," -c local release.yml --extra-vars="stage=push version=$VERSION branch=$BRANCH force_version=$FORCE_VERSION release=$RELEASE_TYPE tag=$TAG project=ceph token=$GITHUB_TOKEN"

--- a/ceph-tag/build/build
+++ b/ceph-tag/build/build
@@ -14,4 +14,4 @@ BRANCH=${BRANCH//-release/}
 # run ansible to do all the tagging and release specifying
 # a local connection and 'localhost' as the host where to execute
 cd "$WORKSPACE/ceph-build/ansible/"
-$VENV/ansible-playbook -i "localhost," -c local release.yml --extra-vars="stage=push version=$VERSION branch=$BRANCH force_version=$FORCE_VERSION release=$RELEASE_TYPE tag=$TAG project=ceph token=$GITHUB_TOKEN"
+$VENV/ansible-playbook -i "localhost," -c local release.yml --extra-vars="stage=$TAG_PHASE version=$VERSION branch=$BRANCH force_version=$FORCE_VERSION release=$RELEASE_TYPE tag=$TAG project=ceph token=$GITHUB_TOKEN"

--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -50,6 +50,12 @@ SECURITY: Builds from BRANCH-release branch in ceph-private.git (private repo)."
             - RELEASE_CANDIDATE
             - HOTFIX
             - SECURITY
+
+      - string:
+          name: CEPH_BUILD_BRANCH
+          description: "The ceph-build.git branch to use.  Useful for testing changes to the ceph-tag job"
+          default: main
+
     scm:
       - git:
           url: https://github.com/ceph/ceph-build.git
@@ -59,8 +65,7 @@ SECURITY: Builds from BRANCH-release branch in ceph-private.git (private repo)."
           wipe-workspace: true
           basedir: "ceph-build"
           branches:
-            - origin/main
-
+            - ${{CEPH_BUILD_BRANCH}}
 
     builders:
       - shell:

--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -13,6 +13,8 @@
           artifact-num-to-keep: -1
       - github:
           url: https://github.com/ceph/ceph
+      - copyartifact:
+          projects: ceph-dev-pipeline,ceph-release-pipeline
 
     parameters:
       - string:
@@ -65,6 +67,12 @@ SECURITY: Builds from BRANCH-release branch in ceph-private.git (private repo)."
           !include-raw-verbatim:
             - ../../../scripts/build_utils.sh
             - ../../build/build
+
+    publishers:
+      - archive:
+          artifacts: 'ceph-build/ansible/ceph/dist/sha1'
+          allow-empty: false
+          latest-only: false
 
     wrappers:
       - inject-passwords:

--- a/scripts/setup_chacractl.sh
+++ b/scripts/setup_chacractl.sh
@@ -8,7 +8,9 @@ pipx ensurepath
 pipx install uv
 ~/.local/bin/uv tool install chacractl
 
-chacra_url=`curl -u $SHAMAN_API_USER:$SHAMAN_API_KEY https://shaman.ceph.com/api/nodes/next/`
+if [ -z "$chacra_url" ]; then
+  chacra_url=$(curl -u "$SHAMAN_API_USER:$SHAMAN_API_KEY" https://shaman.ceph.com/api/nodes/next/)
+fi
 cat > $HOME/.chacractl << EOF
 url = "$chacra_url"
 user = "$CHACRACTL_USER"


### PR DESCRIPTION
- Uses new ceph-source-dist job for creation of tarball inside container
- Uses new ceph-dev-pipeline pipeline to build in containers

Example here: https://2.jenkins.ceph.com/job/ceph-release-pipeline/17/pipeline-overview/
It failed during the automated version commit PR creation.  Unrelated to this PR.