### PR TITLE
ceph-source-dist: Avoid arm64 machines

### DIFF
--- a/ceph-source-dist/build/Jenkinsfile
+++ b/ceph-source-dist/build/Jenkinsfile
@@ -2,7 +2,7 @@ def checkout_ref = ""
 
 pipeline {
   agent {
-    label "gigantic"
+    label "gigantic&&x86_64"
   }
   stages {
     stage("repository") {


### PR DESCRIPTION
They are very slow when running this job.