### PR TITLE
scripts/dashboard/install-cephadm-e2e-deps.sh: Put back DISTRO

### DIFF
--- a/scripts/dashboard/install-cephadm-e2e-deps.sh
+++ b/scripts/dashboard/install-cephadm-e2e-deps.sh
@@ -45,6 +45,8 @@ sudo usermod -aG libvirt $(id -un)
 newgrp libvirt  # Avoid having to log out and log in for group addition to take effect.
 sudo systemctl enable --now libvirtd
 
+DISTRO="$(lsb_release -cs)"
+
 if [[ $(command -v docker) == '' ]]; then
     # Set up docker official repo and install docker.
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg


### PR DESCRIPTION
fcf4dfee46bfafc678a20c769d0473acb6d42af7 removed the setting of DISTRO.  Unfortunately one usage of the variable remained in the script.  Put back the setting.