### PR TITLE
ceph-dev-pipeline: Fix archive-skipping

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -505,7 +505,7 @@ pipeline {
             post {
               always {
                 script {
-                  if (env.SCCACHE?.trim() == "true") {
+                  if (fileExists('dist/ceph/sccache_log.txt')) {
                     sh """
                       if [ -f "${env.WORKSPACE}/dist/ceph/sccache_log.txt" ]; then
                         ln dist/ceph/sccache_log.txt sccache_log_${env.DIST}_${env.ARCH}_${env.FLAVOR}.txt


### PR DESCRIPTION
If sccache is supposed to be enabled, but isn't - for example due to the feature not being backported - we were still attempting to archive, and hanging. Check for the existence of the file directly.