### PR TITLE
ceph-dev-pipeline: Fix escaping of find command

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -515,7 +515,7 @@ pipeline {
                     // dist/ceph/qa and get stuck trying to follow the .qa symlinks. This was
                     // discovered by seeing many messages about "too many levels of symbolic links"
                     // in the system journal.
-                    sh "find ${env.WORKSPACE}/dist/ceph/ -name .qa -exec rm {} \;"
+                    sh "find ${env.WORKSPACE}/dist/ceph/ -name .qa -exec rm {} \\;"
                     archiveArtifacts(
                       artifacts: 'sccache_log*.txt',
                       allowEmptyArchive: true,


### PR DESCRIPTION
The linter didn't catch this one.