### PR TITLE
ceph-source-dist: Deepen clone as necessary

### DIFF
--- a/ceph-source-dist/build/Jenkinsfile
+++ b/ceph-source-dist/build/Jenkinsfile
@@ -51,9 +51,14 @@ pipeline {
       steps {
         script {
           dir("ceph") {
+            sh '''#!/bin/bash
+              while [ -z "$(git describe --abbrev=8 --match 'v*' | sed s/^v//)" ]; do
+                git fetch --deepen 50
+              done
+            '''
             def ceph_version_git = sh(
-                  script: "git describe --abbrev=8 --match 'v*' | sed s/^v//",
-                  returnStdout: true,
+              script: "git describe --abbrev=8 --match 'v*' | sed s/^v//",
+              returnStdout: true,
             ).trim()
             sh """
               mkdir dist


### PR DESCRIPTION
We do a shallow clone, but I have seen a few branches that fail because the clone is _too_ shallow. In rare cases like this we can simply deepen until we find the tag.