### PR TITLE
scripts/build_utils.sh: only do gcc ppa version dance on Ubuntu

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -636,8 +636,10 @@ setup_pbuilder() {
         echo "USENETWORK=yes" >> ~/.pbuilderrc
         local hookdir
         hookdir=$(recreate_hookdir)
-        setup_updates_repo $hookdir
-        setup_pbuilder_for_ppa $hookdir
+        if [[ "$NORMAL_DISTRO" = ubuntu ]]; then
+            setup_updates_repo $hookdir
+            setup_pbuilder_for_ppa $hookdir
+        fi
         echo "HOOKDIR=$hookdir" >> ~/.pbuilderrc
     fi
 


### PR DESCRIPTION
This doesn't apply to debian.  Maybe debian has similar needs, but who knows, because we don't test the builds (or indeed even do them until release time), but this code is definitely not appropriate for bookworm, so avoid it for now.