### PR TITLE
Update jenkins-job-builder spec to released version

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -6,7 +6,7 @@ set -e
 PATH=$PATH:$HOME/.local/bin
 uv venv
 
-pkgs=( "ansible" "ansible-core" "git+https://opendev.org/jjb/jenkins-job-builder@60f0316389" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" "xmltodict" )
+pkgs=( "ansible" "ansible-core" "jenkins-job-builder>=6.4.3" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" "xmltodict" )
 VENV=./.venv/bin
 uv pip install "${pkgs[@]}"
 

--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -16,7 +16,7 @@ set -euxo pipefail
 # when jenkins-job-builder 6.5 or later is released, this requirement should change to
 # jenkins-job-builder>=6.5
 
-pkgs=( "dataclasses" "git+https://opendev.org/jjb/jenkins-job-builder@60f0316389" )
+pkgs=( "dataclasses" "jenkins-job-builder>=6.4.3" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]" latest


### PR DESCRIPTION
jenkins-job-builder finally released 6.4.3, which includes https://review.opendev.org/c/jjb/jenkins-job-builder/+/941310, so we can stop using the git url