### PR TITLE
ceph-pull-requests*: require node with centos9 or noble

### DIFF
--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -9,7 +9,7 @@
     concurrent: true
     disabled: false
     name: ceph-pull-requests-arm64
-    node: 'arm64 && !centos7 && !centos8 && !centos9'
+    node: 'arm64 && (noble || centos9)'
     parameters:
     - string:
         name: ghprbPullId

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -4,7 +4,7 @@
     defaults: global
     concurrent: true
     # We want make check to only run on Bionic b/c it has python2 and python3 and b/c all builds should build on Bionic
-    node: huge && bionic && x86_64 && !smithi
+    node: x86_64 && (noble || centos9)
     display-name: 'ceph: Pull Requests'
     quiet-period: 5
     block-downstream: false


### PR DESCRIPTION
When containerized, we need a newer podman.  Limit to these nodes for now; eventually that will cover almost every node as we transition to noble from jammy.