### PR TITLE
Add bookworm as a buildable distro version

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -186,7 +186,7 @@ pipeline {
         axes {
           axis {
             name 'DIST'
-            values 'centos9', 'centos10', 'rocky9', 'rocky10', 'jammy', 'noble'
+            values 'centos9', 'centos10', 'rocky9', 'rocky10', 'jammy', 'noble', 'bookworm'
           }
           axis {
             name 'ARCH'


### PR DESCRIPTION
Now that we are using ceph-dev-pipeline to build release images, we need to be able to request bookworm