### PR TITLE
ceph-dev-pipeline/build/Jenkinsfile: add missing '=' to env setting

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -462,7 +462,7 @@ pipeline {
                     env.CEPH_EXTRA_CMAKE_ARGS = "${env.CEPH_EXTRA_CMAKE_ARGS} ${sccache_flag}"
                   }
                   sh '''#!/bin/bash
-                    echo "DEB_BUILD_PROFILES${DEB_BUILD_PROFILES}" >> .env
+                    echo "DEB_BUILD_PROFILES=${DEB_BUILD_PROFILES}" >> .env
                   '''
                   bwc_command = "${bwc_command} -e debs"
                 } else if ( env.DIST =~ /^(centos|rhel|rocky|fedora).*/ ) {


### PR DESCRIPTION
when setting DEB_BUILD_PROFILES, a '=' was missing, so the env file didn't contain an actual setting of the value.