### PR TITLE
ceph-build-pull-requsts: unpin urllib3

### DIFF
--- a/ceph-build-pull-requests/build/build
+++ b/ceph-build-pull-requests/build/build
@@ -6,7 +6,7 @@ set -e
 PATH=$PATH:$HOME/.local/bin
 uv venv
 
-pkgs=( "ansible" "ansible-core" "jenkins-job-builder>=6.4.3" "urllib3==1.26.1" "pyopenssl" "ndg-httpsclient" "pyasn1" "xmltodict" )
+pkgs=( "ansible" "ansible-core" "jenkins-job-builder>=6.4.3" "urllib3" "pyopenssl" "ndg-httpsclient" "pyasn1" "xmltodict" )
 VENV=./.venv/bin
 uv pip install "${pkgs[@]}"
 


### PR DESCRIPTION
It probably shouldn't have been pinned to a specific version anyway, but because it had custom import code, it broke with the Python in noble (3.13 I think).  Removing the pin gets a version without the problem (I think the custom import code went away altogether).