### PR TITLE
setup_container_runtime.sh: add podman rm -f ceph_build

### DIFF
--- a/scripts/setup_container_runtime.sh
+++ b/scripts/setup_container_runtime.sh
@@ -26,6 +26,13 @@ function setup_container_runtime () {
   fi
 
   if command -v podman; then
+     
+    # remove any leftover containers that might be present because of
+    # bad exits from podman (like an oom kill or something).
+    # We've observed new jobs failing to run because they can't create
+    # a container named ceph_build
+    podman rm -f ceph_build 
+
     if [ "$(podman version -f "{{ lt .Client.Version \"5.6.1\" }}")" = "true" ] && \
     ! echo "928238bfcdc79a26ceb51d7d9759f99144846c0a  /etc/tmpfiles.d/podman.conf" | sha1sum --status --check -; then
       # Pull in this fix: https://github.com/containers/podman/pull/26986


### PR DESCRIPTION
build-with-container.py's build containers are named ceph_build. If something happens to a build and the container is left behind, we can't start another.  Force-remove it at the beginning of a job.