### PR TITLE
Update ceph-website-prs.yml to comment with website link on success

### DIFF
--- a/ceph-website-prs/config/definitions/ceph-website-prs.yml
+++ b/ceph-website-prs/config/definitions/ceph-website-prs.yml
@@ -35,8 +35,7 @@
           started-status: "Compiling site"
           success-status: "Site compiled successfully!"
           failure-status: "Site compilation failed"
-#         This is kinda noisy if there's lots of force pushes
-#         success-comment: "Site built successfully!  https://${{GIT_BRANCH}}.ceph.io"
+          success-comment: "Site built/updated successfully!  https://${{GIT_BRANCH}}.ceph.io"
 
     scm:
       - git:


### PR DESCRIPTION
it seems like this was commented out to reduce noisy comments on website site pr's. 

Right now the workflow is to go look at the Jenkins job console output and find the link. So having a update comment saying the site has been successfully built and can be viewed at xxx is a better workflow.