### PR TITLE
scripts/build_container: calculate and use FROM_IMAGE

### DIFF
--- a/scripts/build_container
+++ b/scripts/build_container
@@ -37,5 +37,11 @@ if [[ $CI_CONTAINER == "true" && $DISTRO == "centos" && "$RELEASE" =~ 8|9 ]] ; t
     cd ${WORKSPACE}
     # older jobs used a versioned directory; ceph-dev-pipeline uses an unversioned dir.
     [[ -d ./dist/ceph/container ]] && cd ./dist/ceph/container || cd dist/ceph-${cephver}/container
-    CEPH_SHA1=${SHA1} ./build.sh
+    from_image_spec="${DISTRO}:${RELEASE}"
+    case "${from_image_spec}" in
+        "centos:stream9")  FROM_IMAGE=quay.io/centos/centos:stream9 ;;
+        "rocky:10") FROM_IMAGE=docker.io/rockylinux/rockylinux:10 ;;
+        *) echo "Don't know requested FROM image ${from_image_spec}; exit 1 ;;
+    esac
+    FROM_IMAGE=${FROM_IMAGE} CEPH_SHA1=${SHA1} ./build.sh
 fi


### PR DESCRIPTION
Instruct ceph.git's container/build.sh which image to use as the container base, specified by env vars DISTRO and RELEASE