### PR TITLE
ceph-tag: Add TAG_PHASE var

### DIFF
--- a/ceph-tag/config/definitions/ceph-tag.yml
+++ b/ceph-tag/config/definitions/ceph-tag.yml
@@ -28,6 +28,16 @@
 Defaults to checked."
           default: true
 
+      - choice:
+          name: TAG_PHASE
+          description: "
+create: When TAG=true, pull BRANCH-release and create the tag/version commit on top of it
+push: When TAG=true, push the afformentioned tag to ceph.git, and create the PR to merge BRANCH-release back into BRANCH."
+          default: push
+          choices:
+            - push
+            - create
+
       - bool:
           name: THROWAWAY
           description: "


### PR DESCRIPTION
While this job is intended to be called from ceph-release-pipeline, it can be ran manually, but was missing the ability to set TAG_PHASE.