### PR TITLE
ceph-dev-pipeline: WITH_BOOST_VALGRIND is not specific to releases

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -444,9 +444,7 @@ pipeline {
                 switch (env.FLAVOR) {
                   case "default":
                     ceph_extra_cmake_args += " -DALLOCATOR=tcmalloc"
-                    if (env.RELEASE_BUILD?.toBoolean()) {
-                      ceph_extra_cmake_args += " -DWITH_SYSTEM_BOOST=OFF -DWITH_BOOST_VALGRIND=ON"
-                    }
+                    ceph_extra_cmake_args += " -DWITH_SYSTEM_BOOST=OFF -DWITH_BOOST_VALGRIND=ON"
                     break
                   case ~/crimson.*/:
                     deb_build_profiles = "pkg.ceph.crimson";


### PR DESCRIPTION
the corresponding logic from scripts/build_utils.sh, added in https://github.com/ceph/ceph-build/pull/2043, was not specific to release builds

the rgw team needs this enabled for all packages tested in ci, because we rely heavily on valgrind coverage. the rgw suite has been an absolute mess of valgrind issues lately, and this appears to be the primary cause