### PR TITLE
scripts/build_utils: use ppa on ubuntu jammy for gcc-12

### DIFF
--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -683,6 +683,8 @@ use_ppa() {
             case $DIST in
                 focal)
                     use_ppa=true;;
+                jammy)
+                    use_ppa=true;;
                 *)
                     use_ppa=false;;
             esac
@@ -822,7 +824,7 @@ EOF
 setup_pbuilder_for_ppa() {
     local hookdir=$1
     if use_ppa; then
-        local gcc_ver=11
+        local gcc_ver=12
         setup_pbuilder_for_new_gcc $hookdir $gcc_ver
     else
         setup_pbuilder_for_old_gcc $hookdir


### PR DESCRIPTION
with https://github.com/ceph/ceph/commit/0f3b651fcc1736cf484ca9881ba36985ea87242d, ceph-dev-pipeline builds for ubuntu jammy switched to gcc-12 through the ubuntu toolchain ppa

update scripts/build_utils.sh to use the same toolchain so that changes qa'd successfully through ceph-dev-pipeline don't end up breaking the build on main