### PR TITLE
ceph-dev-pipeline: Parse distro for container build

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -614,18 +614,11 @@ pipeline {
               script {
                 env.CONTAINER_REPO_USERNAME = env.CONTAINER_REPO_CREDS_USR
                 env.CONTAINER_REPO_PASSWORD = env.CONTAINER_REPO_CREDS_PSW
-                distro = sh(
-                  script: '. /etc/os-release && echo -n $ID',
-                  returnStdout: true,
-                )
-                release = sh(
-                  script: '. /etc/os-release && echo -n $VERSION_ID',
-                  returnStdout: true,
-                )
+                def os = get_os_info(env.DIST)
                 cephver = env.VERSION.trim()
                 sh """#!/bin/bash
-                  export DISTRO=${distro}
-                  export RELEASE=${release}
+                  export DISTRO=${os.name}
+                  export RELEASE=${os.version}
                   export cephver=${cephver}
                   ./scripts/build_container
                 """


### PR DESCRIPTION
Using /etc/os-release was a holdover from past iterations of the pipeline.