### PR TITLE
ceph-dev-pipeline: -DWITH_STATIC_LIBSTDCXX=ON for focal

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -445,6 +445,9 @@ pipeline {
                   case "default":
                     ceph_extra_cmake_args += " -DALLOCATOR=tcmalloc"
                     ceph_extra_cmake_args += " -DWITH_SYSTEM_BOOST=OFF -DWITH_BOOST_VALGRIND=ON"
+                    if (os.version_name == "focal") {
+                      ceph_extra_cmake_args += " -DWITH_STATIC_LIBSTDCXX=ON"
+                    }
                     break
                   case ~/crimson.*/:
                     deb_build_profiles = "pkg.ceph.crimson";


### PR DESCRIPTION
This was set in use_ppa() in build_utils.sh.  It's mistakenly been off since we switched to ceph-dev-pipeline as the default build job.