### PR TITLE
[WIP] Include Crimson binary by default (Centos)

### DIFF
--- a/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
+++ b/ceph-dev-cron/config/definitions/ceph-dev-cron.yml
@@ -103,7 +103,6 @@
       # build main on:
       # default: noble jammy centos9 windows
       # crimson-debug: centos9
-      # crimson-release: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*main.*
@@ -126,13 +125,6 @@
                     FORCE=True
                     DISTROS=centos9
                     FLAVOR=crimson-debug
-                    ARCHS=x86_64
-                - project: 'ceph-dev'
-                  predefined-parameters: |
-                    BRANCH=${{GIT_BRANCH}}
-                    FORCE=True
-                    DISTROS=centos9
-                    FLAVOR=crimson-release
                     ARCHS=x86_64
 
     wrappers:

--- a/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
+++ b/ceph-dev-new-trigger/config/definitions/ceph-dev-new-trigger.yml
@@ -139,7 +139,6 @@
       # Build only the `crimson` flavour, don't waste resources on the default one.
       # Useful for the crimson's bug-hunt at Sepia
       # crimson-debug: centos9
-      # crimson-release: centos9
       - conditional-step:
           condition-kind: regex-match
           regex: .*crimson-only.*
@@ -157,14 +156,6 @@
                     FORCE=True
                     DISTROS=centos9
                     FLAVOR=crimson-debug
-                    ARCHS=x86_64
-            - trigger-builds:
-                - project: 'ceph-dev-new'
-                  predefined-parameters: |
-                    BRANCH=${{GIT_BRANCH}}
-                    FORCE=True
-                    DISTROS=centos9
-                    FLAVOR=crimson-release
                     ARCHS=x86_64
       # sccache
       - conditional-step:

--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -52,9 +52,8 @@
           choices:
             - default
             - crimson-debug
-            - crimson-release
           default: "default"
-          description: "Type of Ceph build, choices are: crimson-debug, crimson-release, default. Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: crimson-debug, default. Defaults to: 'default'"
 
       - string:
           name: CI_CONTAINER

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -200,7 +200,7 @@ pipeline {
           }
           axes {
             name 'FLAVOR'
-            values 'default', 'crimson-release', 'crimson-debug'
+            values 'default', 'crimson-debug'
           }
         }
         // crimson is only supported on centos9 x86_64
@@ -208,7 +208,7 @@ pipeline {
           exclude {
             axis {
               name 'FLAVOR'
-              values 'crimson-release', 'crimson-debug'
+              values 'crimson-debug'
             }
             axis {
               name 'DIST'
@@ -218,7 +218,7 @@ pipeline {
           exclude {
             axis {
               name 'FLAVOR'
-              values 'crimson-release', 'crimson-debug'
+              values 'crimson-debug'
             }
             axis {
               name 'ARCH'
@@ -451,10 +451,6 @@ pipeline {
                   case "crimson-debug":
                     ceph_extra_cmake_args += " -DWITH_CRIMSON=true -DCMAKE_BUILD_TYPE=Debug"
                     deb_build_profiles = "pkg.ceph.crimson"
-                    break
-                  case "crimson-release":
-                    ceph_extra_cmake_args += " -DWITH_CRIMSON=true"
-                    deb_build_profiles = "pkg.ceph.crimson";
                     break
                   default:
                     println "FLAVOR=${env.FLAVOR} is invalid"

--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -46,7 +46,7 @@
 
       - string:
           name: FLAVORS
-          description: "A list of flavors to build. Available options are: default, crimson-release, crimson-debug"
+          description: "A list of flavors to build. Available options are: default, crimson-debug"
           default: "default"
 
       - bool:
@@ -69,9 +69,8 @@
           choices:
             - default
             - crimson-debug
-            - crimson-release
           default: "default"
-          description: "Type of Ceph build, choices are: crimson-debug, crimson-release, default. Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: crimson-debug, default. Defaults to: 'default'"
 
       - bool:
           name: CI_CONTAINER

--- a/ceph-dev/config/definitions/ceph-dev.yml
+++ b/ceph-dev/config/definitions/ceph-dev.yml
@@ -54,9 +54,8 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           choices:
             - default
             - crimson-debug
-            - crimson-release
           default: "default"
-          description: "Type of Ceph build, choices are: crimson-debug, crimson-release, default. Defaults to: 'default'"
+          description: "Type of Ceph build, choices are: crimson-debug, default. Defaults to: 'default'"
 
       - bool:
           name: CI_CONTAINER

--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -65,17 +65,6 @@
                   break
               fi
           done
-          if test {osd-flavor} = "crimson-release" ; then
-              export WITH_CRIMSON=true
-              # TODO use clang-10 on ubuntu/focal
-              timeout 7200 src/script/run-make.sh \
-                --cmake-args "-DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_C_COMPILER=$c_compiler -DCMAKE_BUILD_TYPE=Release -DWITH_CRIMSON=ON -DWITH_TESTS=OFF" \
-                vstart-base crimson-osd
-              src/script/run-cbt.sh --build-dir $PWD/build --source-dir $PWD --cbt ${{WORKSPACE}}/cbt -a $archive_dir src/test/crimson/cbt/radosbench_4K_read.yaml
-          else
-              timeout 7200 src/script/run-make.sh --cmake-args "-DCMAKE_BUILD_TYPE=Release -DWITH_TESTS=OFF" vstart-base
-              src/script/run-cbt.sh --build-dir $PWD/build --source-dir $PWD --cbt ${{WORKSPACE}}/cbt -a $archive_dir src/test/crimson/cbt/radosbench_4K_read.yaml --classical
-          fi
 
 - builder:
     name: compare-cbt-results
@@ -247,7 +236,6 @@
     name: ceph-perf
     osd-flavor:
       - crimson-debug
-      - crimson-release
       - classic
     jobs:
       - ceph-perf-{osd-flavor}

--- a/ceph-trigger-build/README.md
+++ b/ceph-trigger-build/README.md
@@ -19,7 +19,7 @@ This pipeline's role is to:
 |CEPH-BUILD-JOB|Which Jenkins job to trigger. Only ceph-dev-pipeline supports the options below.|ceph-dev-pipeline, ceph-dev-new|`ceph-dev-pipeline`|
 |DISTROS|Space-sparated list of Linux distributions to build for|focal, jammy, noble, centos9, windows|Depends on keywords in branch name|
 |ARCHS|Space-separated list of architectures to build on|x86_64, arm64|`x86_64 arm64`|
-|FLAVORS|Crimson or non-Crimson|default, crimson-debug, crimson-release|`default`|
+|FLAVORS|Crimson or non-Crimson|default, crimson-debug|`default`|
 |CI-COMPILE|Compile binaries and packages[^1]|Boolean|`true`|
 |CI-CONTAINER|Build a dev container using the packages built|Boolean|`true`|
 |DWZ|Use [DWZ](https://sourceware.org/dwz/) to make debuginfo packages smaller|Boolean|`true` when using ceph-dev-new<br>`false` when using ceph-dev-pipeline[^2]|

--- a/ceph-trigger-build/build/Jenkinsfile
+++ b/ceph-trigger-build/build/Jenkinsfile
@@ -73,9 +73,8 @@ def params_from_branch(initialParams) {
       if ( !singleSet ) {
         params << params[0].clone()
         params[0]['FLAVOR'] = 'crimson-debug'
-        params[1]['FLAVOR'] = 'crimson-release'
       } else {
-        params[0]['FLAVOR'] = 'crimson-debug crimson-release'
+        params[0]['FLAVOR'] = 'crimson-debug'
       }
       break
     default:

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -20,7 +20,7 @@ page_limit = 100000
 NAME_RE = re.compile(
     r'(.*)-([0-9a-f]{7})-centos-.*([0-9]+)-(x86_64|aarch64)-devel'
 )
-SHA1_RE = re.compile(r'([0-9a-f]{40})(-crimson-debug|-crimson-release|-aarch64)*')
+SHA1_RE = re.compile(r'([0-9a-f]{40})(-crimson-debug|-aarch64)*')
 
 
 def get_all_quay_tags(quaytoken):
@@ -291,7 +291,7 @@ def main():
                 continue
             # <sha1>-crimson tags don't have full or ref tags to go with.
             # Delete them iff the default <sha1> tag is to be deleted
-            if match[2] in ('-crimson', '-crimson-debug', '-crimson-release') and sha1 in tags_to_delete:
+            if match[2] in ('-crimson', '-crimson-debug') and sha1 in tags_to_delete:
                 if args.verbose:
                     print(
                         'Marking %s for deletion: orphaned sha1 tag' % name

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -889,10 +889,6 @@ ceph_build_args_from_flavor() {
         DEB_BUILD_PROFILES="pkg.ceph.crimson"
         CEPH_EXTRA_CMAKE_ARGS+=" -DCMAKE_BUILD_TYPE=Debug"
         ;;
-    crimson-release)
-        CEPH_EXTRA_RPMBUILD_ARGS="--with crimson"
-        DEB_BUILD_PROFILES="pkg.ceph.crimson"
-        ;;
     *)
         echo "unknown FLAVOR: ${FLAVOR}" >&2
         exit 1


### PR DESCRIPTION
### Pushed for **early** discussion purposes

Dependencies:
* https://github.com/ceph/ceph/pull/65782 
* https://github.com/ceph/ceph-build/pull/2494

---


Once https://github.com/ceph/ceph/pull/65782 is merged, we would be able to build
Crimson (ceph-osd-crimson) as part of the default build flavor with
rpm builds.

ceph-osd-crimson and ceph-osd-classic are selected based on their
priorities.
ceph-osd-classic has the highest priority of 100 when installed.
Crimson could only be used if the following is run:
```
update-alternatives --set ceph-osd /usr/bin/ceph-osd-crimson
```

---

crimson-debug flavor is remained since the project uses it for testing
