### PR TITLE
ceph-dev-pipeline/build/Jenkinsfile: fix crimson-debug

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -449,7 +449,11 @@ pipeline {
                       ceph_extra_cmake_args += " -DWITH_STATIC_LIBSTDCXX=ON"
                     }
                     break
-                  case ~/crimson.*/:
+                  case "crimson-debug":
+                    deb_build_profiles = "pkg.ceph.crimson"
+                    ceph_extra_cmake_args += " -DCMAKE_BUILD_TYPE=Debug"
+                    break
+                  case "crimson-release":
                     deb_build_profiles = "pkg.ceph.crimson";
                     break
                   default:


### PR DESCRIPTION
When ceph-dev-pipeline was introduced, crimson-debug cmake flag was left out. The corresponding ceph_build_args_from_flavor from scrips/build_utils.sh is defined correctly.