### PR TITLE
ceph-dev-pipeline: Avoid unhelpful error in post

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -636,7 +636,7 @@ pipeline {
           always {
             script {
               sh 'hostname'
-              sh 'sudo journalctl -k -c $(cat ${WORKSPACE}/cursor)'
+              sh 'test -r ${WORKSPACE}/cursor && sudo journalctl -k -c $(cat ${WORKSPACE}/cursor)'
               sh 'podman unshare chown -R 0:0 ${WORKSPACE}/'
             }
           }


### PR DESCRIPTION
Some failures during node setup were making it look like the job failed because of a missing journal cursor file.