### PR TITLE
quay-pruner: completely overhaul prune-quay.py

### DIFF
--- a/quay-pruner/build/get-tagdates.py
+++ b/quay-pruner/build/get-tagdates.py
@@ -24,7 +24,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    print('Getting ceph-ci container tags from quay.ceph.io', file=sys.stderr)
+    print(f'Getting tags from {util.QUAYBASE}{util.REPO}', file=sys.stderr)
     quaytags, digest_to_tags = util.get_all_quay_tags(None, args.start, args.pages)
 
     tagdates = defaultdict(str)

--- a/quay-pruner/build/prune-quay.py
+++ b/quay-pruner/build/prune-quay.py
@@ -16,7 +16,7 @@ def parse_args():
                         help="start page (of 100 tags)")
     parser.add_argument('-p', '--pages', type=int, default=100000,
                         help="number of pages")
-    parser.add_argument('-n', '--dryrun', action='store_true',
+    parser.add_argument('-n', '--dry-run', action='store_true',
                         help="don't actually delete")
     parser.add_argument('-v', '--verbose', action='count', default=0,
                         help="say more (-vv for more info)")
@@ -34,7 +34,7 @@ def main():
     args = parse_args()
 
     quaytoken = None
-    if not args.dryrun:
+    if not args.dry_run:
         if 'QUAYTOKEN' in os.environ:
             quaytoken = os.environ['QUAYTOKEN']
         else:
@@ -43,7 +43,7 @@ def main():
                 'rb'
             ).read().strip().decode()
 
-    print('Getting ceph-ci container tags from quay.ceph.io', file=sys.stderr)
+    print(f'Getting tags from {util.QUAYBASE}{util.REPO}', file=sys.stderr)
     quaytags, digest_to_tags = util.get_all_quay_tags(quaytoken, args.start, args.pages)
 
     tagstat = defaultdict(int)
@@ -123,7 +123,7 @@ def main():
     # and now delete all the ones we found
     for (alltags, date) in tags_to_delete:
         for tagname in alltags:
-            util.delete_from_quay(tagname, date, quaytoken, args.dryrun)
+            util.delete_from_quay(tagname, date, quaytoken, args.dry_run)
         tagstat['deleted'] += 1
         tagstat['subtags_deleted'] += len(alltags)
 


### PR DESCRIPTION
Pruning had stopped working (up to >26000 image tags), and the reasons were many; one, pruning's always been less deterministic than I'd hope; two, when I switched us to ceph.git/container for building images, I mistakenly changed the format of the 'fulltag' (no longer has a short sha1 in it) and that was sort of driving the pruning process.  three, I suspect some of the newer flavors etc. were slipping through the cracks.

So here's an attempt to fix all that by changing the algorithm fundamentally; now, tags of a certain manifest digest are considered at the same time, and their sha1 checked in shaman as usual (but only their sha1); if it's found, the tags are all left, and if not, they're all removed.  This should be cleaner, faster, and more reliable.

Also refactored a lot of the worker routines to util.py so I could add some helper/debug/info scripts:

get-tagdates.py generates JSON showing tag-to-age for examining the state of things

delete-tags.py takes tags on the CLI to delete, or can be invoked with '--stragglers <age>' to remove anything older than age (as long as it's not in shaman or seems like it might be a 'distinguished' build (with recent release names in its name)).

prune-quay.py also now reports summary statistics of its operation.