### PR TITLE
Change quay-quay-quay.... to quay.ceph.io

### DIFF
--- a/ceph-dev-new/config/definitions/ceph-dev-new.yml
+++ b/ceph-dev-new/config/definitions/ceph-dev-new.yml
@@ -64,7 +64,7 @@
       - string:
           name: CONTAINER_REPO_HOSTNAME
           description: "For CI_CONTAINER: Name of container repo server (i.e. 'quay.io')"
-          default: "quay-quay-quay.apps.os.sepia.ceph.com"
+          default: "quay.ceph.io"
 
       - string:
           name: CONTAINER_REPO_ORGANIZATION

--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -81,7 +81,7 @@
       - string:
           name: CONTAINER_REPO_HOSTNAME
           description: "FQDN of container repo server (e.g. 'quay.io')"
-          default: "quay-quay-quay.apps.os.sepia.ceph.com"
+          default: "quay.ceph.io"
 
       - string:
           name: CONTAINER_REPO_ORGANIZATION


### PR DESCRIPTION
The external name works from locations outside the existing sepia lab, and there's no good reason not to use the public name.