### PR TITLE
No chgrp

### DIFF
--- a/scripts/setup_container_runtime.sh
+++ b/scripts/setup_container_runtime.sh
@@ -26,13 +26,6 @@ function setup_container_runtime () {
   fi
 
   if command -v podman; then
-     
-    # remove any leftover containers that might be present because of
-    # bad exits from podman (like an oom kill or something).
-    # We've observed new jobs failing to run because they can't create
-    # a container named ceph_build
-    podman rm -f ceph_build 
-
     if [ "$(podman version -f "{{ lt .Client.Version \"5.6.1\" }}")" = "true" ] && \
     ! echo "928238bfcdc79a26ceb51d7d9759f99144846c0a  /etc/tmpfiles.d/podman.conf" | sha1sum --status --check -; then
       # Pull in this fix: https://github.com/containers/podman/pull/26986
@@ -66,6 +59,11 @@ function setup_container_runtime () {
         fi
       fi
     fi
+    # remove any leftover containers that might be present because of
+    # bad exits from podman (like an oom kill or something).
+    # We've observed new jobs failing to run because they can't create
+    # a container named ceph_build
+    podman rm -f ceph_build
   fi
 }
 


### PR DESCRIPTION
```
+ ./scripts/setup_container_runtime.sh
++ basename -- ./scripts/setup_container_runtime.sh
++ basename -- ./scripts/setup_container_runtime.sh
+ '[' setup_container_runtime.sh = setup_container_runtime.sh ']'
+ setup_container_runtime
++ id -nu
+ loginctl enable-linger jenkins-build
+ command -v podman
/usr/bin/podman
+ podman system info
++ podman version -f '{{ lt .Client.Version "4" }}'
+ '[' false = true ']'
+ command -v podman
/usr/bin/podman
+ command -v podman
/usr/bin/podman
++ podman version -f '{{ lt .Client.Version "5.6.1" }}'
+ '[' true = true ']'
+ echo '928238bfcdc79a26ceb51d7d9759f99144846c0a  /etc/tmpfiles.d/podman.conf'
+ sha1sum --status --check -
++ podman version -f '{{ ge .Client.Version "4" }}'
+ '[' true = true ']'
+ PODMAN_DIR=/home/jenkins-build/.local/share/containers
+ test -d /home/jenkins-build/.local/share/containers
+ command -v restorecon
+ PODMAN_STORAGE_DIR=/home/jenkins-build/.local/share/containers/storage
+ '[' -d /home/jenkins-build/.local/share/containers/storage ']'
+ sudo find /home/jenkins-build/.local/share/containers/storage -xdev -mindepth 1 -maxdepth 5 -user root -print -quit
+ grep -q .
++ podman unshare du -s --block-size=1G /home/jenkins-build/.local/share/containers/storage
++ awk '{print $1}'
+ '[' 77 -ge 50 ']'
+ podman system prune --force
Total reclaimed space: 0B

real	0m0.265s
user	0m0.167s
sys	0m0.171s
+ podman image prune --filter=until=168h --all --force

real	0m0.119s
user	0m0.080s
sys	0m0.079s
++ podman version -f '{{ ge .Client.Version "5" }}'
+ '[' false = true ']'
+ podman rm -f ceph_build

```