### PR TITLE
builder.yml: Ensure consistent subuid and subgid across builders

### DIFF
--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -785,8 +785,14 @@
       become_user: "{{ jenkins_user }}"
       when: ansible_os_family == "Suse"
 
-    - name: Ensure the home dir has the right owner permissions
-      command: "sudo chown -R {{ jenkins_user }}:{{ jenkins_user }} /home/{{ jenkins_user}}"
+    # Do NOT try to chown the podman storage dirs.  This breaks all subsequent builds.
+    - name: Ensure the build dir has the right owner permissions
+      become: true
+      ansible.builtin.file:
+        path: "/home/{{ jenkins_user }}/build"
+        owner: "{{ jenkins_user }}"
+        group: "{{ jenkins_user }}"
+        recurse: true
       tags: chown
 
     - name: Set system locale (systemd)

--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -54,6 +54,9 @@
     libvirt: false # Should vagrant be installed?
     permanent: false # Is this a permanent builder?  Since the ephemeral (non-permanent) tasks get run more often, we'll default to false.
     jenkins_user: 'jenkins-build'
+    subid_range_size: 65536
+    subid_uid_start: 1148577
+    subid_gid_start: 1148577
     api_user: 'ceph-jenkins'
     api_uri: 'https://jenkins.ceph.com'
     jenkins_credentials_uuid: 'jenkins-build'
@@ -677,6 +680,20 @@
     - name: "loginctl enable-linger {{ jenkins_user }}"
       command: "loginctl enable-linger {{ jenkins_user }}"
 
+    - name: Ensure subuid range for {{ jenkins_user }}
+      ansible.builtin.lineinfile:
+        path: /etc/subuid
+        create: true
+        regexp: "^{{ jenkins_user }}:"
+        line: "{{ jenkins_user }}:{{ subid_uid_start }}:{{ subid_range_size }}"
+
+    - name: Ensure subgid range for {{ jenkins_user }}
+      ansible.builtin.lineinfile:
+        path: /etc/subgid
+        create: true
+        regexp: "^{{ jenkins_user }}:"
+        line: "{{ jenkins_user }}:{{ subid_gid_start }}:{{ subid_range_size }}"
+
     - name: "Create a {{ jenkins_user }} home directory"
       file:
         path: "/home/{{ jenkins_user }}/"
@@ -775,6 +792,34 @@
     - name: Set system locale (systemd)
       command: localectl set-locale LANG=en_US.utf8
       when: ansible_service_mgr == "systemd"
+
+    - name: Reset rootless podman storage for {{ jenkins_user }} (required after subuid/subgid changes)
+      block:
+        - name: Stop and remove any running rootless containers
+          become: true
+          become_user: "{{ jenkins_user }}"
+          command: /bin/sh -lc 'podman ps -aq | xargs -r podman rm -f'
+          args:
+            chdir: "/home/{{ jenkins_user }}"
+          changed_when: false
+          failed_when: false
+
+        - name: Remove rootless podman storage
+          file:
+            path: "/home/{{ jenkins_user }}/.local/share/containers/storage"
+            state: absent
+
+        - name: Remove rootless podman cache
+          file:
+            path: "/home/{{ jenkins_user }}/.local/share/containers/cache"
+            state: absent
+
+        - name: Restore SELinux labels on containers directory (if applicable)
+          command: >
+            restorecon -R -T0 -x /home/{{ jenkins_user }}/.local/share/containers
+          when: ansible_selinux.status == "enabled"
+      tags:
+        - podman-reset
 
     ## DEBIAN GPG KEY TASKS
     - name: Install Debian GPG Keys on Ubuntu

--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -786,6 +786,7 @@
       when: ansible_os_family == "Suse"
 
     # Do NOT try to chown the podman storage dirs.  This breaks all subsequent builds.
+    # follow: false avoids following our silly qa/ dir symlinks
     - name: Ensure the build dir has the right owner permissions
       become: true
       ansible.builtin.file:
@@ -793,6 +794,7 @@
         owner: "{{ jenkins_user }}"
         group: "{{ jenkins_user }}"
         recurse: true
+        follow: false
       tags: chown
 
     - name: Set system locale (systemd)


### PR DESCRIPTION
This might explain a lot of the storage weirdness we've been observing.  If a container image layer is create in rootless on podman on one machine, that image layer is restored to another host with *different* subuid or subgid, errors can occur.