### PR TITLE
ceph-release-containers: only use --version on v21 and later

### DIFF
--- a/ceph-release-containers/build/Jenkinsfile
+++ b/ceph-release-containers/build/Jenkinsfile
@@ -97,7 +97,11 @@ pipeline {
               podman login -u ${CONTAINER_REPO_CREDS_USR} -p ${CONTAINER_REPO_CREDS_PSW} ${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}
               skopeo login -u ${CONTAINER_REPO_CREDS_USR} -p ${CONTAINER_REPO_CREDS_PSW} ${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}
               cd container;
-              ./make-manifest-list.py --version ${VERSION}
+              MAJOR_VERSION=${VERSION%%.*}
+              if [[ ${MAJOR_VERSION} -ge 21 ]] ; then
+                ./make-manifest-list.py --version ${VERSION}
+              else
+                ./make-manifest-list.py
               '''
           }
         }


### PR DESCRIPTION
This should be temporary and replaced with a proper backport; doing this to allow v20.2.1 to be released without rebuilding packages