### PR TITLE
ceph-release-containers: only use --version on v21 and later: fix missing fi

### DIFF
--- a/ceph-release-containers/build/Jenkinsfile
+++ b/ceph-release-containers/build/Jenkinsfile
@@ -102,6 +102,7 @@ pipeline {
                 ./make-manifest-list.py --version ${VERSION}
               else
                 ./make-manifest-list.py
+              fi
               '''
           }
         }


### PR DESCRIPTION
This should be temporary and replaced with a proper backport; doing this to allow v20.2.1 to be released without rebuilding packages

fix missing 'fi'