### PR TITLE
introduce debug builds for rocky10

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -204,7 +204,7 @@ pipeline {
             values 'default', 'debug'
           }
         }
-        // debug flavor is currently only supported on centos9 x86_64
+        // debug flavor is currently only supported on centos9 and rocky10, x86_64
         excludes {
           exclude {
             axis {
@@ -213,7 +213,7 @@ pipeline {
             }
             axis {
               name 'DIST'
-              notValues 'centos9'
+              notValues 'centos9', 'rocky10'
             }
           }
           exclude {

--- a/ceph-trigger-build/build/Jenkinsfile
+++ b/ceph-trigger-build/build/Jenkinsfile
@@ -58,7 +58,7 @@ def params_from_branch(initialParams) {
       if ( !singleSet ) {
         params << params[0].clone()
         params[-1]['ARCHS'] = 'x86_64'
-        params[-1]['DISTROS'] = 'centos9'
+        params[-1]['DISTROS'] = 'centos9 rocky10'
         params[-1]['FLAVOR'] = 'debug'
       } else {
         params[0]['ARCHS'] += ' arm64'
@@ -78,7 +78,7 @@ def params_from_branch(initialParams) {
       if ( !singleSet ) {
         params << params[0].clone()
         params[-1]['ARCHS'] = 'x86_64'
-        params[-1]['DISTROS'] = 'centos9'
+        params[-1]['DISTROS'] = 'centos9 rocky10'
         params[-1]['FLAVOR'] = 'debug'
       } else {
         params[0]['FLAVOR'] += ' debug'


### PR DESCRIPTION
This PR adds debug builds for rocky10. So far we are only building release builds for rocky10. Debug builds are helpful for testing, especially for crimson.

Fixes: https://tracker.ceph.com/issues/75952