### PR TITLE
ceph-website-pr: Enable ceph team members to be admins on website prs

### DIFF
--- a/ceph-website-prs/config/definitions/ceph-website-prs.yml
+++ b/ceph-website-prs/config/definitions/ceph-website-prs.yml
@@ -23,6 +23,7 @@
 
     triggers:
       - github-pull-request:
+          allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
           cancel-builds-on-update: true


### PR DESCRIPTION
This will allow anyone in the `ceph` github org team to sign off on PRs from outside contributor to trigger the Jenkins jobs