### PR TITLE
jenkins-job-builder: pin setuptools for JJB on Python 3.12

### DIFF
--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -16,7 +16,10 @@ set -euxo pipefail
 # when jenkins-job-builder 6.5 or later is released, this requirement should change to
 # jenkins-job-builder>=6.5
 
-pkgs=( "dataclasses" "jenkins-job-builder>=6.4.3" )
+# setuptools>=82 drops pkg_resources in practice; stevedore (used by JJB) still
+# imports pkg_resources when loading CLI subcommands, which breaks `jenkins-jobs`
+# on Python 3.12 with "No module named 'pkg_resources'".
+pkgs=( "dataclasses" "jenkins-job-builder>=6.4.3" "setuptools<82" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]" latest


### PR DESCRIPTION
Stevedore still imports pkg_resources when loading jenkins-jobs CLI extensions. setuptools>=82 can leave that module unavailable in fresh venvs on newer agents, causing No module named pkg_resources and No jjb.cli.subcommands extensions found.

Install setuptools<82 after bootstrap so jenkins-jobs works on both Python 3.10 and 3.12 workers until upstream drops pkg_resources.