### PR TITLE
ceph-pr-commits: support target branch in docs commit summary

### DIFF
--- a/ceph-pr-commits/build/test_commits.py
+++ b/ceph-pr-commits/build/test_commits.py
@@ -39,7 +39,12 @@ class TestCommits(object):
 
     @pytest.mark.doc_test
     def test_doc_title(self):
-        doc_regex = '^doc'
+        if self.target_branch == 'main':
+            doc_regex = '^doc'
+        else:
+            # the title of a non-cherry-pick commit starts with the target branch name, like
+            # "squid: doc: ...." instead of "doc: ..."
+            doc_regex = f'^({self.target_branch}: )?doc'
         all_commits = f'git log -z --no-merges --pretty=format:%s origin/{self.target_branch}..{self.source_branch}'
         wrong_commits = list(filterfalse(
             re.compile(doc_regex).search,

--- a/ceph-pr-commits/build/test_commits.py
+++ b/ceph-pr-commits/build/test_commits.py
@@ -39,9 +39,8 @@ class TestCommits(object):
 
     @pytest.mark.doc_test
     def test_doc_title(self):
-        doc_regex = '\nDate:[^\n]+\n\n    doc'
-        all_commits = 'git log -z --no-merges origin/%s..%s' % (
-            self.target_branch, self.source_branch)
+        doc_regex = '^doc'
+        all_commits = f'git log -z --no-merges --pretty=format:%s origin/{self.target_branch}..{self.source_branch}'
         wrong_commits = list(filterfalse(
             re.compile(doc_regex).search,
             self.command(all_commits).split('\0')))


### PR DESCRIPTION
ceph/ceph@0a54fcdfc491ce2b2bb3ded77e319a7cff785e73 added a [new policy](https://github.com/ceph/ceph/blame/main/SubmittingPatches-backports.rst#L48) that backport PRs with not-cherry-picked commits need the commit message summary to begin with the target branch name.
This policy conflicted with docs-only commits that must have the same line start with `doc`, as enforced by this job.

Modify the regex used to allow an additional optional `targetbranch: ` string in front of the `doc` string in the beginning of the commit message summary, only if `target_branch` is something else than `main` and allow only the target branch name.

This is a rather naive attempt and the same result could have been done differently so feedback is appreciated.

In essence it allows commit message summary lines such as:
```console
tentacle: doc: fix foo
```