### PR TITLE
setup_container_runtime: Fix image pruning

### DIFF
--- a/scripts/setup_container_runtime.sh
+++ b/scripts/setup_container_runtime.sh
@@ -52,9 +52,8 @@ function setup_container_runtime () {
           sudo find "$PODMAN_STORAGE_DIR/overlay" -xdev -type d -path '*/work/work' -exec chmod u+rwx {} + 2>/dev/null || true
         fi
         if [ "$(podman unshare du -s --block-size=1G "$PODMAN_STORAGE_DIR" | awk '{print $1}')" -ge 50 ]; then
-          time podman system prune --force || \
-            time podman image prune --force --all --external
-          time podman image prune --filter=until="$((24*7))h" --all --force
+          time podman system prune --force
+          time podman image prune --filter=until="$((24*7))h" --all --force --external
           if [ "$(podman version -f "{{ ge .Client.Version \"5\" }}")" = "true" ]; then
             time podman system check --repair --quick
           fi


### PR DESCRIPTION
`podman system prune --force` can still exit 0 even if there are images still in use by external containers.  e.g.,

```
+ podman system prune --force
Deleted Images
63ce0076aa6cdd5544433330d81d0a116b3cfcace3d3ca7aabcf953d97ee819d
2234e3448b78b20836a83c3559ba45ec0d3713786c9ce8ccaadd0ae728b6c3b5
Total reclaimed space: 1.607GB

real	0m1.948s
user	0m0.536s
sys	0m1.061s
+ podman image prune --filter=until=168h --all --force
Error: 2 errors occurred:
	* image used by b0c2fcd16e3423046b704d626ee30f1e9d455efb844640aa83f61d0f2bf7b426: image is in use by a container: consider listing external containers and force-removing image
	* image used by fe06141e65c607edd79df847d793116c00b9749cea2bb5b1b247cfca1c72e9d9: image is in use by a container: consider listing external containers and force-removing image

real	0m19.330s
user	0m1.280s
sys	0m10.139s
Build step 'Execute shell' marked build as failure
```

Since this script is already pretty destructive, just add --external unconditionally.