### PR TITLE
ceph-dev-pipeline: Validate given BRANCH param against derived BRANCH

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -177,7 +177,7 @@ def doSourceDistribution() {
 
 // Stage 4 (copy artifacts): copy artifacts from the setup job, verify SHA1, set VERSION/build description, and extract the source tarball.
 def doCopyArtifactsStage() {
-  def artifact_filter = "dist/sha1,dist/version,dist/other_envvars,dist/ceph-*.tar.bz2"
+  def artifact_filter = "dist/sha1,dist/version,dist/branch,dist/other_envvars,dist/ceph-*.tar.bz2"
   def os = get_os_info(env.DIST)
   if ( env.CI_COMPILE && os.pkg_type == "deb" ) {
     artifact_filter += ",dist/ceph_*.diff.gz,dist/ceph_*.dsc"
@@ -198,6 +198,10 @@ def doCopyArtifactsStage() {
     env.SHA1 = sha1_from_artifact
   }
   println "SHA1=${sha1_trimmed}"
+  // Derive canonical BRANCH from artifact.
+  // This way, if SHA1 and BRANCH were both provided as params and BRANCH didn't match, it will now.
+  def branch_props = readProperties file: "${env.WORKSPACE}/dist/branch"
+  env.BRANCH = branch_props.BRANCH.trim()
   env.VERSION = readFile(file: "${env.WORKSPACE}/dist/version").trim()
   // In a release build, dist/other_envvars contains CEPH_REPO, and chacra_url
   // as written during ceph-source-dist but we don't to be able to define
@@ -209,11 +213,11 @@ def doCopyArtifactsStage() {
   def branch_ui_value = env.BRANCH
   def sha1_ui_value = env.SHA1
   if (env.CEPH_REPO?.find(/https?:\/\/github.com\//)) {
-      // If this is a release build, link to ceph-release.git's $BRANCH-release branch
-      def suffix = (env.RELEASE_BUILD?.trim() == "true") ? "-release" : ""
-
-      def branch_url = "${env.CEPH_REPO}/tree/${env.BRANCH}${suffix}"
-      branch_ui_value = "<a href=\"${branch_url}\">${env.BRANCH}${suffix}</a>"
+      // In a release build, env.BRANCH already carries the -release suffix
+      // (derived from dist/branch above), so the link points at
+      // ceph-releases.git's $BRANCH-release branch without appending it here.
+      def branch_url = "${env.CEPH_REPO}/tree/${env.BRANCH}"
+      branch_ui_value = "<a href=\"${branch_url}\">${env.BRANCH}</a>"
       def commit_url = "${env.CEPH_REPO}/commit/${env.SHA1}"
       sha1_ui_value = "<a href=\"${commit_url}\">${env.SHA1}</a>"
   }

--- a/ceph-source-dist/build/Jenkinsfile
+++ b/ceph-source-dist/build/Jenkinsfile
@@ -107,6 +107,21 @@ pipeline {
                 bzip2 -dc ceph-$ceph_version_tarball.$extension | gzip > ceph-$ceph_version_tarball.tar.gz
                 popd
               else
+                if [ -n "${SHA1:-}" ]; then
+                  # The checkout preferred SHA1 over BRANCH, so the BRANCH
+                  # parameter may not match the code actually built
+                  # (https://tracker.ceph.com/issues/73658).  The fetch put every
+                  # branch head in refs/remotes/origin, so list the branches whose
+                  # tip is the built commit (HEAD) and keep BRANCH only if it is
+                  # one of them.
+                  mapfile -t tip_branches < <(git for-each-ref --points-at HEAD --format='%(refname:strip=3)' refs/remotes/origin)
+                  if [ "${#tip_branches[@]}" -eq 0 ]; then
+                    echo "WARNING: $(git rev-parse HEAD) is not the tip of any branch; keeping BRANCH=${BRANCH}"
+                  elif ! printf '%s\n' "${tip_branches[@]}" | grep -qxF "${BRANCH}"; then
+                    echo "BRANCH=${BRANCH} does not point at SHA1=$(git rev-parse HEAD); using ${tip_branches[0]}"
+                    BRANCH="${tip_branches[0]}"
+                  fi
+                fi
                 echo "BRANCH=${BRANCH}" > dist/branch
               fi
 


### PR DESCRIPTION
Handles an unlikely edge case but handled nonetheless.  This could be problematic if, for example, a user triggered ceph-dev-pipeline by specifying::

    SHA1=1234abcd
    BRANCH=main

But that SHA1 actually belongs to a wip branch.  Now both chacra and shaman think the tip of main is 1234abcd.

Fixes: https://tracker.ceph.com/issues/73658