### PR TITLE
Fix: when conditional failure due to non-boolean result

### DIFF
--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -815,40 +815,32 @@
     ## DEBIAN GPG KEY TASKS
     - name: Install Debian GPG Keys on Ubuntu
       block:
-        - name: Add the Debian Buster Key
-          apt_key:
-           id: 3CBBABEE
-           url: https://ftp-master.debian.org/keys/archive-key-10.asc
-           keyring: /etc/apt/trusted.gpg
-           state: present
-      
-        - name: Add the Debian Security Buster Key
-          apt_key:
-            id: CAA96DFA
-            url: https://ftp-master.debian.org/keys/archive-key-10-security.asc
-            keyring: /etc/apt/trusted.gpg
-            state: present
-      
-        - name: Add the Debian Buster Stable Key
-          apt_key:
-            id: 77E11517
-            url: https://ftp-master.debian.org/keys/release-10.asc
-            keyring: /etc/apt/trusted.gpg
-            state: present
+        - name: Ensure keyrings directory exists
+          file:
+            path: /etc/apt/keyrings
+            state: directory
+            mode: '0755'
+            owner: root
+            group: root
 
-        - name: Add the Debian Bookworm Key
-          apt_key:
-           id: 350947F8
-           url: https://ftp-master.debian.org/keys/archive-key-12.asc
-           keyring: /etc/apt/trusted.gpg
-           state: present
+        - name: Download Debian archive keys
+          get_url:
+            url: "{{ item.url }}"
+            dest: "/etc/apt/keyrings/{{ item.name }}"
+            mode: '0644'
+            owner: root
+            group: root
+          register: key_download
+          until: key_download is succeeded
+          retries: 5
+          delay: 5
+          loop:
+            - { name: debian-archive-key-10.asc,          url: "https://ftp-master.debian.org/keys/archive-key-10.asc" }
+            - { name: debian-archive-key-10-security.asc, url: "https://ftp-master.debian.org/keys/archive-key-10-security.asc" }
+            - { name: debian-release-10.asc,              url: "https://ftp-master.debian.org/keys/release-10.asc" }
+            - { name: debian-archive-key-12.asc,          url: "https://ftp-master.debian.org/keys/archive-key-12.asc" }
+            - { name: debian-archive-key-12-security.asc, url: "https://ftp-master.debian.org/keys/archive-key-12-security.asc" }
 
-        - name: Add the Debian Security Bookworm Key
-          apt_key:
-            id: AEC0A8F0
-            url: https://ftp-master.debian.org/keys/archive-key-12-security.asc
-            keyring: /etc/apt/trusted.gpg
-            state: present
       when: ansible_os_family == "Debian"
       tags: debian-keys
 

--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -442,7 +442,7 @@
         permanent: true
         nodename: "{{ ansible_hostname }}"
       with_items: "{{ ansible_all_ipv4_addresses }}"
-      when: item | regex_search('^(172\\.21\\.|8\\.43\\.|10\\.20\\.)')
+      when: item is match('^(172\\.21\\.|8\\.43\\.|10\\.20\\.)')
       tags: always
 
     ## EPHEMERAL SLAVE TASKS

--- a/builder-reimage/Jenkins-job/poc-jenkins/Jenkinsfile
+++ b/builder-reimage/Jenkins-job/poc-jenkins/Jenkinsfile
@@ -1,0 +1,144 @@
+// =========================================
+//   Jenkins Builder Reimage POC (Sandbox-Safe)
+//   - Includes Offline Agents
+//   - Skips Protected Label "libvirt"
+//   - No ScriptApproval Needed
+// =========================================
+
+pipeline {
+    agent { label 'master' }
+
+    environment {
+        CONCURRENCY = "3"
+        PROTECTED_LABEL = "libvirt"
+    }
+
+    stages {
+
+        // -------------------------------------------------------
+        // 1. DISCOVER ELIGIBLE AGENTS USING REST API
+        // -------------------------------------------------------
+        stage('Discover Eligible Nodes') {
+            steps {
+                script {
+
+                    echo "Querying Jenkins for agent list..."
+
+                    // Pull node information safely (REST API)
+                    def jsonRaw = sh(
+                        script: "curl -ks ${JENKINS_URL}/computer/api/json",
+                        returnStdout: true
+                    )
+
+                    def data = readJSON(text: jsonRaw)
+
+                    def eligible = []
+
+                    data.computer.each { comp ->
+
+                        def name    = comp.displayName
+                        def labels  = comp.assignedLabels.collect { it.name }
+                        def offline = comp.offline
+                        def busy    = comp.busyExecutors
+
+                        // Skip master
+                        if (name == "master") return
+
+                        // Skip protected nodes
+                        if (labels.contains(PROTECTED_LABEL)) {
+                            echo "Skipping PROTECTED node: ${name}"
+                            return
+                        }
+
+                        // New logic:
+                        // Include OFFLINE nodes or ONLINE + IDLE nodes
+                        if (offline) {
+                            echo "Found OFFLINE node: ${name}"
+                            eligible << name
+
+                        } else if (!offline && busy == 0) {
+                            echo "Found ONLINE + IDLE node: ${name}"
+                            eligible << name
+                        }
+                    }
+
+                    echo "Eligible nodes: ${eligible}"
+
+                    if (eligible.isEmpty()) {
+                        echo "No eligible nodes — stopping POC."
+                        currentBuild.result = "SUCCESS"
+                    }
+
+                    // Export as comma list
+                    env.IDLE_NODES = eligible.join(',')
+                }
+            }
+        }
+
+
+        // -------------------------------------------------------
+        // 2. SIMULATE REIMAGE WORKFLOW ON ALL ELIGIBLE AGENTS
+        // -------------------------------------------------------
+        stage('Simulate Reimage Workflow') {
+            when { expression { env.IDLE_NODES?.trim() } }
+            steps {
+                script {
+
+                    def idleNodes = env.IDLE_NODES.split(',') as List
+                    def concurrency = CONCURRENCY.toInteger()
+                    def nodes = idleNodes
+
+                    echo "Processing nodes: ${nodes}"
+
+                    while (nodes.size() > 0) {
+
+                        def batch = nodes.take(concurrency)
+                        nodes = nodes.drop(concurrency)
+
+                        echo "Processing batch: ${batch}"
+
+                        def parallelStages = [:]
+
+                        batch.each { nodeName ->
+
+                            parallelStages["Reimage-${nodeName}"] = {
+
+                                node('master') {
+                                    script {
+
+                                        echo "===== Starting POC for ${nodeName} ====="
+
+                                        echo "[${nodeName}] Simulating OFFLINE..."
+                                        sleep 2
+
+                                        echo "[${nodeName}] Checking (simulated) executors..."
+                                        sleep 2
+
+                                        echo "[${nodeName}] Simulating REIMAGE..."
+                                        sleep 5
+
+                                        echo "[${nodeName}] Simulating POST-REIMAGE tasks..."
+                                        sleep 5
+
+                                        echo "[${nodeName}] Simulating ONLINE..."
+                                        sleep 2
+
+                                        echo "===== Completed POC for ${nodeName} ====="
+                                    }
+                                }
+                            }
+                        }
+
+                        parallel parallelStages
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            echo "Reimage POC complete."
+        }
+    }
+}

--- a/builder-reimage/Jenkins-job/poc-jenkins/reimage_pipeline.yaml
+++ b/builder-reimage/Jenkins-job/poc-jenkins/reimage_pipeline.yaml
@@ -1,0 +1,35 @@
+---
+- job:
+    name: "poc-reimage-pipeline"
+    display-name: "POC – Jenkins Builder Reimage Workflow"
+    description: |
+      Proof-of-Concept pipeline to simulate reimage workflow.
+      Runs only on master, discovers idle nodes, marks them offline,
+      simulates reimage & post-reimage tasks, then brings them online.
+      Protects libvirt builders.
+
+    project-type: pipeline
+    concurrent: false
+
+    parameters:
+      - string:
+          name: CONCURRENCY
+          default: "3"
+          description: "How many nodes to process in parallel"
+
+    triggers: []   # Manual only
+
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 20
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: "https://github.com/jitendrasahu1803/builder-reimage.git"
+            branches:
+              - "main"
+            shallow-clone: true
+      script-path: "Jenkins-job/poc-jenkins/Jenkinsfile"
+

--- a/builder-reimage/Jenkins-job/preprod-jenkins/Jenkins_builder-reimage.py
+++ b/builder-reimage/Jenkins-job/preprod-jenkins/Jenkins_builder-reimage.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+
+"""
+MAAS Reimage Automation Script
+
+Provides:
+- Connect to MAAS
+- Query machines
+- List machines
+- Deploy a machine
+- Reimage a machine
+- Reimage all machines
+- List OS images
+"""
+
+import asyncio
+import argparse
+import configparser
+import sys
+import time
+from datetime import datetime, timezone
+from cryptography.fernet import Fernet
+import os
+
+from maas.client import connect
+from aiohttp.client_exceptions import (
+    ClientConnectorError,
+    ServerDisconnectedError,
+    ClientResponseError,
+    ClientOSError
+)
+
+# -------------------------------------------------------------------------
+# Missing minimal helper functions required by main()
+# -------------------------------------------------------------------------
+
+def load_config():
+    # Prefer Jenkins MAAS_URL env if provided, else fall back to script constant
+    return os.environ.get("MAAS_URL", MAAS_URL)
+
+def load_api_key():
+    return MAAS_API_KEY
+
+def get_machine(client, hostname):
+    """
+    Minimal helper used by wait_online(), returns dict with hostname & status_name.
+    """
+    machines = getattr(client, "_machines_cache", []) or []
+    for m in machines:
+        if m.hostname == hostname:
+            return {
+                "hostname": m.hostname,
+                "status_name": getattr(m, "status_name", None) or getattr(getattr(m, "status", None), "name", "-")
+            }
+    return {"hostname": hostname, "status_name": "Unknown"}
+
+# -------------------------------------------------------------------------
+# Global Defaults
+# -------------------------------------------------------------------------
+
+LOG_FILE_DEFAULT = "maas_reimage.log"
+STATUS_WAIT_TIMEOUT = 1200
+POLL_INTERVAL = 10
+DEFAULT_OWNER = "jitendra" # use --owner to tag manually
+
+# -------------------------------------------------------------------------
+# Small helpers
+# -------------------------------------------------------------------------
+
+def log(msg, log_file=None):
+    """Print message and optionally append to a log file with a timestamp."""
+    print(msg)
+    if log_file:
+        try:
+            with open(log_file, "a") as f:
+                f.write(f"{datetime.now().isoformat()} - {msg}\n")
+        except Exception:
+            print(f"(warning) Unable to write to log file: {log_file}")
+
+def sanitize_owner(name):
+    return name.replace(" ", "_").replace("@", "_")
+
+async def safe_list_tags_for_machine(machine):
+    """
+    Return list of tag objects applied to the machine.
+    Some MAAS clients expose machine.tags as a proxy; the reliable way is:
+    await machine.tags.list()
+    """
+    try:
+        return await machine.tags.list()
+    except Exception:
+        # fallback: try to read machine.tags attribute (may not be useful)
+        mt = getattr(machine, "tags", None)
+        if isinstance(mt, list):
+            return mt
+        return []
+
+def get_normalized_status(machine):
+    """
+    Return lowercased status name using the most reliable available attribute.
+    Handles both `status_name` and `status.name` forms.
+    """
+    status_name = getattr(machine, "status_name", None)
+    if status_name:
+        return str(status_name).lower()
+    status_obj = getattr(machine, "status", None)
+    if status_obj is not None:
+        name = getattr(status_obj, "name", None)
+        if name:
+            return str(name).lower()
+    return ""
+
+# -------------------------------------------------------------------------
+# Configuration (use Jenkins credential via env)
+# -------------------------------------------------------------------------
+MAAS_URL = "http://sepia-maas.front.sepia.ceph.com:5240/MAAS"
+
+# MAAS API key must be supplied by Jenkins as an environment variable named MAAS_API_KEY
+MAAS_API_KEY = os.environ.get("MAAS_API_KEY")
+if not MAAS_API_KEY:
+    print("Error: MAAS_API_KEY environment variable not set. Please configure your Jenkins job to pass the API key as an env var 'MAAS_API_KEY'.")
+    sys.exit(1)
+
+# -------------------------------------------------------------------------
+# MAAS connect with retries
+# -------------------------------------------------------------------------
+
+async def connect_maas(maas_url, api_key, retries=3):
+    """Connect to MAAS with retries and clear error handling."""
+    for attempt in range(1, retries + 1):
+        try:
+            client = await connect(maas_url, apikey=api_key)
+            return client
+        except (ClientConnectorError, ClientOSError) as e:
+            print(f"Connection attempt {attempt} failed: {e}")
+        except ClientResponseError as e:
+            print(f"MAAS server responded with error: {e.status} {e.message}")
+        except asyncio.TimeoutError:
+            print(f"Connection timed out on attempt {attempt}")
+        except ServerDisconnectedError:
+            print(f"Server disconnected unexpectedly (attempt {attempt})")
+        if attempt < retries:
+            print("Retrying in 2 seconds...")
+            await asyncio.sleep(2)
+    print("Error: Unable to connect to MAAS after several attempts.")
+    print("Please check:")
+    print("  • Network or VPN connection")
+    print("  • MAAS server hostname and port")
+    print("  • MAAS service availability")
+    sys.exit(1)
+
+# -------------------------------------------------------------------------
+# Cache + refresh helpers
+# -------------------------------------------------------------------------
+
+async def get_cached_machines(client):
+    """Return a cached copy of client.machines.list() for script lifetime."""
+    if getattr(client, "_machines_cache", None) is None:
+        log("Fetching machines list...")
+        client._machines_cache = await client.machines.list()
+    return client._machines_cache
+
+async def refresh_machine(client, machine):
+    """
+    Refresh machine object. Prefer machine.refresh() if available.
+    """
+    try:
+        ref = getattr(machine, "refresh", None)
+        if callable(ref):
+            maybe = ref()
+            if asyncio.iscoroutine(maybe):
+                await maybe
+            return machine
+    except Exception:
+        pass
+
+    try:
+        return await client.machines.get(system_id=machine.system_id)
+    except Exception:
+        return machine
+
+# -------------------------------------------------------------------------
+# Tag-based ownership helpers
+# -------------------------------------------------------------------------
+
+async def ensure_tag_exists(client, tag_name, log_file=None):
+    """Ensure a tag with `tag_name` exists in MAAS; create it if not."""
+    try:
+        tags = await client.tags.list()
+        if not any(getattr(t, "name", t) == tag_name for t in tags):
+            log(f"Creating tag '{tag_name}'...", log_file)
+            await client.tags.create(name=tag_name)
+        return True
+    except Exception as e:
+        log(f"[ERROR] Unable to ensure tag exists '{tag_name}': {e}", log_file)
+        return False
+
+async def assign_owner_tag(client, machine, owner_name, log_file=None):
+    """
+    Assign owner tag to machine using client.tags.get() and machine.tags.add(tag).
+    Refresh machine after applying tag so later reads see it.
+    """
+    sanitized = sanitize_owner(owner_name)
+    if not await ensure_tag_exists(client, sanitized, log_file):
+        return False
+
+    try:
+        tag = await client.tags.get(name=sanitized)
+        applied = await safe_list_tags_for_machine(machine)
+        applied_names = [getattr(t, "name", None) for t in applied]
+        if sanitized in applied_names:
+            return True
+
+        log(f"Assigning tag '{sanitized}' to {machine.hostname}...", log_file)
+        await machine.tags.add(tag)
+        # Refresh so tag is visible
+        await refresh_machine(client, machine)
+        return True
+    except Exception as e:
+        log(f"[ERROR] Failed to assign tag '{sanitized}' to {getattr(machine, 'hostname', machine)}: {e}", log_file)
+        return False
+
+async def get_owner_from_tags(client, machine, owner_pattern):
+    """
+    Determine owner by checking machine's applied tags.
+    owner_pattern should be sanitized (e.g., DEFAULT_OWNER sanitized).
+    Returns the matching tag name or '-' if none.
+    """
+    try:
+        applied = await safe_list_tags_for_machine(machine)
+        applied_names = [getattr(t, "name", None) for t in applied]
+        if owner_pattern in applied_names:
+            return owner_pattern
+        # try prefix match too
+        for n in applied_names:
+            if n and n.startswith(owner_pattern):
+                return n
+    except Exception:
+        pass
+    return "-"
+
+# -------------------------------------------------------------------------
+# Query Machine
+# -------------------------------------------------------------------------
+
+async def query_machine(client, hostname, log_file=None, quiet=False):
+    """
+    Query machine details and print them.
+    Owner detection is tag-based (matches sanitized DEFAULT_OWNER).
+    """
+    owner_tag = "-"  # initialize to avoid undefined variable on errors
+
+    try:
+        machines = await get_cached_machines(client)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machines list: {e}", log_file)
+        return None
+
+    system_id = None
+    for m in machines:
+        if m.hostname == hostname:
+            system_id = m.system_id
+            break
+
+    if not system_id:
+        log(f"[ERROR] Machine '{hostname}' not found.", log_file)
+        return None
+
+    try:
+        log(f"Fetching details for {hostname}...", log_file)
+        machine = await client.machines.get(system_id=system_id)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machine details: {e}", log_file)
+        return None
+
+    if not quiet:
+        sanitized = sanitize_owner(DEFAULT_OWNER)
+        owner_tag = await get_owner_from_tags(client, machine, sanitized)
+
+        # Fetch all tags applied to this machine for display
+        try:
+            applied = await safe_list_tags_for_machine(machine)
+            tag_names = [getattr(t, "name", None) for t in applied if getattr(t, "name", None)]
+            tags_display = ", ".join(tag_names) if tag_names else "-"
+        except Exception:
+            tags_display = "-"
+
+        # resolve status display
+        status_display = getattr(machine, "status_name", None)
+        if not status_display:
+            st = getattr(machine, "status", None)
+            status_display = getattr(st, "name", "-") if st else "-"
+
+        log("\nMachine Details\n" + "-" * 60, log_file)
+        log(
+            f"Name:             {machine.hostname}\n"
+            f"System ID:        {machine.system_id}\n"
+            f"Status:           {status_display}\n"
+            f"OS Distro:        {getattr(machine, 'distro_series', '-')}\n"
+            f"OS Type:          {getattr(machine, 'osystem', '-')}\n"
+           # f"Owner:            {owner_tag}\n"
+           # f"Tags:             {tags_display}\n"
+            f"Power Type:       {getattr(machine, 'power_type', '-')}\n"
+            f"Power Status:     {getattr(machine, 'power_state', '-')}",
+            log_file
+        )
+
+    return machine
+
+# -------------------------------------------------------------------------
+# List machines / distros
+# -------------------------------------------------------------------------
+
+async def list_machines(client, log_file=None):
+    machines = await get_cached_machines(client)
+    log(f"{'Hostname':20} | {'System ID':10} | {'Status':10} | {'OS':10}", log_file)
+    log("-" * 65, log_file)
+    for m in machines:
+        status_display = getattr(m, "status_name", None) or getattr(getattr(m, "status", None), "name", "-")
+        osname = getattr(m, "distro_series", "-")
+        log(f"{m.hostname:20} | {m.system_id:10} | {status_display:10} | {osname:10}", log_file)
+
+async def list_distros(client, log_file=None):
+    try:
+        log("Fetching available OS images...", log_file)
+        resources = await client.boot_resources.list()
+    except Exception as e:
+        log(f"[ERROR] Unable to list boot resources: {e}", log_file)
+        return
+
+    log(f"{'ID':<5} | {'OS Type':<15} | {'Release':<15} | {'Architecture':<12}", log_file)
+    log("-" * 60, log_file)
+    for r in resources:
+        name = getattr(r, "name", "-")
+        os_type, release = "-", "-"
+        if "/" in name:
+            os_type, release = name.split("/", 1)
+        log(f"{r.id:<5} | {os_type:<15} | {release:<15} | {r.architecture:<12}", log_file)
+
+# -------------------------------------------------------------------------
+# Status polling helper
+# -------------------------------------------------------------------------
+
+async def wait_for_status(client, system_id, expected, timeout=STATUS_WAIT_TIMEOUT):
+    """
+    Wait for a machine to reach the expected state (case-insensitive).
+    """
+    log(f"Waiting for machine {system_id} to reach '{expected}'...", None)
+    start = time.time()
+    poll = 2
+    max_poll = 8
+    expected_l = expected.lower()
+
+    while time.time() - start < timeout:
+        try:
+            m = await client.machines.get(system_id=system_id)
+        except Exception as e:
+            print(f"Error fetching machine {system_id}: {e}")
+            await asyncio.sleep(poll)
+            poll = min(max_poll, poll + 1)
+            continue
+
+        current = get_normalized_status(m)
+        if current == expected_l:
+            log(f"{getattr(m, 'hostname', system_id)} reached expected status: {expected}", None)
+            return True
+
+        await asyncio.sleep(poll)
+        poll = min(max_poll, poll + 1)
+
+    print(f"Timeout waiting for {system_id} to reach {expected}.")
+    return False
+
+# -------------------------------------------------------------------------
+# Deploy machine
+# -------------------------------------------------------------------------
+
+async def deploy_machine(client, machine_ref, os_release=None, log_file=None):
+    """
+    Deploy (reimage) a machine. Accepts hostname (str) or machine object.
+    NOTE: this function assumes owner tag is already applied when called from reimage flow.
+    If user invokes deploy action directly, main() will ensure tag is applied before calling this.
+    """
+    if isinstance(machine_ref, str):
+        # Avoid calling query_machine() (which prints full details) to prevent duplicate fetches.
+        machines = await get_cached_machines(client)
+        found = next((m for m in machines if m.hostname == machine_ref), None)
+        if not found:
+            log(f"[ERROR] Machine '{machine_ref}' not found.", log_file)
+            return False
+        machine = await client.machines.get(system_id=found.system_id)
+    else:
+        machine = machine_ref
+
+    machine = await refresh_machine(client, machine)
+
+    hostname = machine.hostname
+    system_id = machine.system_id
+    status = get_normalized_status(machine)
+
+    if status == "deployed":
+        log(f"[INFO] {hostname} is already deployed.", log_file)
+        return True
+
+    if status in ["failed", "broken", "error", "unknown"]:
+        log(f"[ERROR] {hostname} cannot be reimaged (state: {status}).", log_file)
+        return False
+
+    os_to_use = os_release or getattr(machine, "distro_series", None) or "focal"
+    log(f"[ACTION] Reimaging {hostname} using OS '{os_to_use}'...", log_file)
+
+    try:
+        await machine.deploy(distro_series=os_to_use)
+    except Exception as e:
+        log(f"[ERROR] Failed to trigger reimage for {hostname}: {e}", log_file)
+        return False
+
+    if not await wait_for_status(client, system_id, "deployed"):
+        log(f"[ERROR] Reimage timeout for {hostname}.", log_file)
+        return False
+
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    log(f"[SUCCESS] Reimage completed for {hostname}.", log_file)
+    log(f"[INFO] Deployment timestamp for {hostname}: {ts} IST", log_file)
+    return True
+
+# -------------------------------------------------------------------------
+# Release machine
+# -------------------------------------------------------------------------
+
+async def release_machine(client, machine, log_file=None):
+    status = get_normalized_status(machine)
+    if status != "deployed":
+        return True
+
+    log(f"[ACTION] Releasing {machine.hostname}...", log_file)
+    try:
+        await machine.release()
+        return True
+    except Exception as e:
+        log(f"[ERROR] Failed to release: {e}", log_file)
+        return False
+
+# -------------------------------------------------------------------------
+# Reimage machine
+# -------------------------------------------------------------------------
+
+async def reimage_machine(client, hostname, os_release=None, log_file=None):
+    # First, fetch machine (and print its details)
+    machine = await query_machine(client, hostname, log_file)
+    if not machine:
+        return
+
+    force_flag = getattr(args, "force", False)
+    status = get_normalized_status(machine)
+
+    if force_flag and status == "deploying":
+        log(f"[FORCE] Aborting active deployment for {hostname}...", log_file)
+        try:
+            await machine.abort()
+        except Exception as e:
+            log(f"[ERROR] Unable to abort deployment for {hostname}: {e}", log_file)
+            return
+
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after abort.", log_file)
+            return
+
+        log(f"[FORCE] Deployment aborted. Releasing {hostname}...", log_file)
+        try:
+            await machine.release()
+        except Exception:
+            pass
+
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after forced release.", log_file)
+            return
+
+        machine = await refresh_machine(client, machine)
+
+    # Ensure owner tag is applied (only once here)
+    if not await assign_owner_tag(client, machine, DEFAULT_OWNER, log_file):
+        return
+
+    # choose OS
+    current_os = getattr(machine, "distro_series", None)
+    if os_release:
+        os_to_use = os_release
+    elif current_os:
+        os_to_use = current_os
+    else:
+        log(f"[ERROR] No OS detected for machine '{hostname}'. Provide --os.", log_file)
+        return
+
+    # if deployed -> release then wait for Ready
+    status = get_normalized_status(machine)
+    if status == "deployed":
+        log(f"[ACTION] Releasing {machine.hostname} for reimage...", log_file)
+        if not await release_machine(client, machine, log_file):
+            return
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after release.", log_file)
+            return
+        machine = await refresh_machine(client, machine)
+
+    # trigger deploy (deploy_machine will not re-assign tag)
+    if await deploy_machine(client, hostname, os_to_use, log_file):
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        log(f"[SUCCESS] Reimage completed for {hostname}.", log_file)
+        log(f"[INFO] Reimage timestamp for {hostname}: {ts} IST", log_file)
+        # print detected OS for downstream consumption (simple marker)
+        print(f"DETECTED_OS={os_to_use}")
+
+# -------------------------------------------------------------------------
+# Reimage all machines
+# -------------------------------------------------------------------------
+
+async def reimage_all(client, os_release=None, log_file=None):
+    try:
+        machines = await get_cached_machines(client)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machines list: {e}", log_file)
+        return
+
+    for m in machines:
+        hostname = m.hostname
+        target_os = os_release or getattr(m, "distro_series", "focal")
+        log(f"[INFO] Starting reimage for {hostname}", log_file)
+        try:
+            await reimage_machine(client, hostname, target_os, log_file)
+        except Exception as e:
+            log(f"[ERROR] Reimage error for {hostname}: {e}", log_file)
+
+# -------------------------------------------------------------------------
+# Find last deployed
+# -------------------------------------------------------------------------
+
+async def find_last_deployed_machine(client):
+    try:
+        machines = await get_cached_machines(client)
+    except Exception:
+        return None
+
+    time_fields = [
+        "deployed_at", "deployment_finished_at", "deployment_completed",
+        "deployment_started", "deployment_started_at"
+    ]
+
+    candidates = []
+    for m in machines:
+        status = get_normalized_status(m)
+        if status != "deployed":
+            continue
+
+        timestamp = None
+        for field in time_fields:
+            val = getattr(m, field, None)
+            if val:
+                try:
+                    if isinstance(val, str):
+                        val = val.replace("Z", "+00:00")
+                        timestamp = datetime.fromisoformat(val)
+                    elif isinstance(val, datetime):
+                        timestamp = val
+                except Exception:
+                    continue
+        if timestamp:
+            candidates.append((timestamp, m))
+
+    if candidates:
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        return candidates[0][1]
+
+    for m in machines:
+        if get_normalized_status(m) == "deployed":
+            return m
+
+    return None
+
+# -------------------------------------------------------------------------
+# wait_online
+#
+# This feature is dedicately added for Jenkins job only
+# because:
+#    After triggering MAAS reimage, machines enter deploying or rebooting state.
+#    Jenkins or MAAS does not guarantee immediate readiness.
+#    So a wait/poll function is required to safely run ansible afterwards. 
+# -------------------------------------------------------------------------
+
+def wait_online(client, machine_name, timeout=1800, interval=20):
+    """
+    Poll MAAS for machine status until it's Deploying / Running / Ready.
+    """
+    import time
+
+    allowed_statuses = ["Deployed", "Ready", "Running"]
+
+    start = time.time()
+    while True:
+        machine = get_machine(client, machine_name)
+        status_name = machine.get("status_name", "")
+
+        print(f"[wait_online] {machine_name} status: {status_name}")
+
+        if status_name in allowed_statuses:
+            print(f"[wait_online] Machine {machine_name} is online and ready.")
+            return
+
+        if time.time() - start > timeout:
+            print(f"[wait_online] Timeout reached ({timeout}s). Machine not ready.")
+            sys.exit(1)
+
+        time.sleep(interval)
+
+
+# -------------------------------------------------------------------------
+# Main
+# -------------------------------------------------------------------------
+
+async def main():
+    global args
+    global DEFAULT_OWNER
+
+    parser = argparse.ArgumentParser(description="MAAS Reimage Automation Script")
+    parser.add_argument("--action", required=True,
+                        choices=[
+                            "list", "list-distros", "query", "status",
+                            "deploy", "reimage", "reimage-all", "last-deployed", "wait_online"
+                        ])
+    parser.add_argument("--machine", help="Hostname for query, deploy, or reimage")
+    parser.add_argument("--os", help="Target OS release")
+    parser.add_argument("--log-file", help="Path to log file")
+    parser.add_argument("--force", action="store_true",
+                        help="Force reimage even if machine is deploying")
+    parser.add_argument("--owner", help="Owner username (fallback: DEFAULT_OWNER)")
+
+    args = parser.parse_args()
+
+    if args.owner:
+        DEFAULT_OWNER = args.owner
+
+    maas_url = load_config()
+    api_key = load_api_key()
+
+    client = await connect_maas(maas_url, api_key)
+
+    # initialize cache immediately
+    try:
+        client._machines_cache = await client.machines.list()
+    except Exception:
+        client._machines_cache = None
+
+    log_file = args.log_file or LOG_FILE_DEFAULT
+
+    if args.action == "list":
+        await list_machines(client, log_file)
+
+    elif args.action == "query":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await query_machine(client, args.machine, log_file)
+
+    elif args.action == "status":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await query_machine(client, args.machine, log_file)
+
+    elif args.action == "list-distros":
+        await list_distros(client, log_file)
+
+    elif args.action == "deploy":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            # ensure owner tag when user runs deploy directly
+            # fetch machine object (no extra printed details)
+            machines = await get_cached_machines(client)
+            found = next((m for m in machines if m.hostname == args.machine), None)
+            if not found:
+                log(f"[ERROR] Machine '{args.machine}' not found.", log_file)
+            else:
+                machine_obj = await client.machines.get(system_id=found.system_id)
+                await assign_owner_tag(client, machine_obj, DEFAULT_OWNER, log_file)
+                await deploy_machine(client, args.machine, args.os, log_file)
+
+    elif args.action == "reimage":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await reimage_machine(client, args.machine, args.os, log_file)
+
+    elif args.action == "reimage-all":
+        await reimage_all(client, args.os, log_file)
+    
+    elif args.action == "wait_online":
+        wait_online(client, args.machine)
+
+    elif args.action == "last-deployed":
+        machine = await find_last_deployed_machine(client)
+        if machine:
+            log(f"Last deployed machine: {machine.hostname} ({machine.system_id})", log_file)
+        else:
+            log("No deployed machines found.", log_file)
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("Interrupted by user.")
+    except Exception as e:
+        print(f"Fatal error: {e}")

--- a/builder-reimage/Jenkins-job/preprod-jenkins/bootstrap_env.sh
+++ b/builder-reimage/Jenkins-job/preprod-jenkins/bootstrap_env.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -e
+
+# -----------------------------------------------------------------------------
+# Script Name: bootstrap_env.sh
+# Description:
+#   Bootstraps the local Python environment for running the MAAS reimage script.
+#   - Installs MAAS CLI (Linux/macOS)
+#   - Creates Python virtual environment
+#   - Installs dependencies
+# -----------------------------------------------------------------------------
+
+echo "Starting environment setup..."
+
+# -----------------------------------------------------------------------------
+# Step 1: Install MAAS CLI based on OS
+# -----------------------------------------------------------------------------
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Detect Linux distribution
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        DISTRO=$ID
+    else
+        DISTRO="unknown"
+    fi
+
+    echo "Detected Linux distribution: $DISTRO"
+
+    case "$DISTRO" in
+        ubuntu|debian)
+            echo "Installing MAAS CLI (Debian/Ubuntu)..."
+            sudo apt update -y
+            sudo apt install -y maas-cli 
+            ;;
+        rhel|centos|fedora|rocky|almalinux)
+            echo "Installing MAAS CLI (RHEL/CentOS/Fedora)..."
+            # Ensure EPEL repo is enabled for dependencies
+            if command -v dnf >/dev/null 2>&1; then
+                sudo dnf install -y epel-release || true
+                sudo dnf install -y snapd 
+            else
+                sudo yum install -y epel-release || true
+                sudo yum install -y snapd
+            fi
+
+            # Enable and use snap to install MAAS CLI
+            sudo systemctl enable --now snapd.socket
+            sudo ln -sf /var/lib/snapd/snap /snap
+            echo "Installing MAAS CLI via snap..."
+            sudo snap install maas --classic
+            ;;
+        *)
+            echo "Unsupported Linux distribution: $DISTRO"
+            echo "Please install MAAS CLI manually."
+            exit 1
+            ;;
+    esac
+
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Installing MAAS CLI (macOS)..."
+    brew install maas || true
+else
+    echo "Unsupported OS type: $OSTYPE"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Step 2: Create and activate Python virtual environment
+# -----------------------------------------------------------------------------
+echo "Creating Python virtual environment..."
+python3 -m venv .venv
+source .venv/bin/activate
+
+echo "Installing Python dependencies..."
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# -----------------------------------------------------------------------------
+# Step 3: Check for encrypted secrets
+# -----------------------------------------------------------------------------
+if [[ ! -f "maas_api.key" || ! -f "maas_api_key.encrypted" ]]; then
+    echo "Missing 'maas_api.key' or 'maas_api_key.encrypted'. Ensure both files are present."
+    exit 1
+fi
+
+echo
+echo "Setup complete."

--- a/builder-reimage/Jenkins-job/preprod-jenkins/jenkins-pipeline/build/Jenkinsfile
+++ b/builder-reimage/Jenkins-job/preprod-jenkins/jenkins-pipeline/build/Jenkinsfile
@@ -1,0 +1,271 @@
+pipeline {
+    agent { label 'reimage' }
+
+    environment {
+        VENV_DIR    = ".venv"
+        REPO_DIR    = "${WORKSPACE}/Jenkins-job/preprod-jenkins"
+        VENV_PATH   = "${REPO_DIR}/${VENV_DIR}"
+        WORK_DIR    = "${WORKSPACE}/ci-work"
+        DOMAIN      = "front.sepia.ceph.com"
+    }
+
+    parameters {
+        booleanParam(name: 'SKIP_REIMAGE', defaultValue: false, description: 'Skip reimage and only run post-reimage tasks')
+        booleanParam(name: 'DRY_RUN', defaultValue: false, description: 'If true: only discover and list nodes without executing')
+        choice(name: 'ACTION', choices: ['reimage','reimage-all','wait_online','discover'], description: 'Action to perform')
+        string(name: 'MACHINE', defaultValue: '', description: 'Single machine or comma-separated list (ignored in discover mode)')
+        string(name: 'OS', defaultValue: '', description: 'OS to deploy (optional). Example: jammy, focal')
+    }
+
+    stages {
+
+        /* ---------------------------------------------------------------------
+           Stage 1: Setup Python Virtual Environment
+        --------------------------------------------------------------------- */
+        stage('Setup Python Virtual Environment') {
+            steps {
+                withCredentials([string(credentialsId: 'maas-api-key', variable: 'MAAS_API_KEY')]) {
+                    sh '''#!/bin/bash
+                        set -euo pipefail
+                        cd "$REPO_DIR"
+
+                        if [ -d "$VENV_PATH" ]; then
+                            echo "Removing incompatible virtual environment..."
+                            rm -rf "$VENV_PATH"
+                        fi
+
+                        python3 -m venv "$VENV_PATH"
+                        source "$VENV_PATH/bin/activate"
+
+                        pip install --upgrade pip
+                        pip install -r requirements.txt
+                    '''
+                }
+            }
+        }
+
+        /* ---------------------------------------------------------------------
+           Stage 2: Determine target nodes (single / multi / discover)
+        --------------------------------------------------------------------- */
+        stage('Determine Target Nodes') {
+            steps {
+                script {
+                    // Hardcoded protected labels (NO FILE)
+                    def protectedLabels = ["master", "teuthology", "www", "reimage", "mira", "ec2"]
+
+                    def parseMachines = { String m ->
+                        if (!m?.trim()) return []
+                        m.split(',').collect { it.trim() }.findAll { it }
+                    }
+
+                    def candidates = []
+
+                    if (params.ACTION == 'discover') {
+                        echo "Discover mode enabled: scanning Jenkins nodes..."
+
+                        def j = Jenkins.instance
+                        j.nodes.each { node ->
+                            def name = node.name
+                            def labels = node.getAssignedLabels()*.name
+                            def comp = node.computer
+
+                            // skip protected
+                            if (protectedLabels.any { labels.contains(it) }) {
+                                echo "Skipping protected node: ${name}"
+                                return
+                            }
+
+                            // offline → eligible
+                            if (comp?.offline) {
+                                echo "${name} is OFFLINE → eligible"
+                                candidates << name
+                                return
+                            }
+
+                            // check idle + no queue target
+                            def idle = (comp.countBusy() == 0)
+                            def hasQueue = j.queue.items.any { item ->
+                                try {
+                                    item.assignedLabel && node.getAssignedLabels().any { it.name == item.assignedLabel.name }
+                                } catch (e) {
+                                    false
+                                }
+                            }
+
+                            if (idle && !hasQueue) {
+                                echo "${name} ONLINE + IDLE → eligible"
+                                candidates << name
+                            } else {
+                                echo "${name} busy or queued → skip"
+                            }
+                        }
+                    } else {
+                        candidates = parseMachines(params.MACHINE)
+                        if (candidates.isEmpty()) {
+                            error "MACHINE parameter required unless ACTION=discover"
+                        }
+                    }
+
+                    if (candidates.isEmpty()) error "No eligible nodes found!"
+
+                    env.TARGET_NODES = candidates.join(',')
+                    echo "Final target nodes: ${env.TARGET_NODES}"
+
+                    /* DRY RUN MODE: Exit safely */
+                    if (params.DRY_RUN) {
+                        echo ""
+                        echo "===== DRY RUN MODE (NO ACTION EXECUTED) ====="
+                        candidates.each { echo " - $it" }
+                        echo "Stopping pipeline due to DRY_RUN=true"
+                        currentBuild.result = 'SUCCESS'
+                        error("DRY_RUN completed")
+                    }
+                }
+            }
+        }
+
+        /* ---------------------------------------------------------------------
+           Stage 3: Process nodes (parallel)
+        --------------------------------------------------------------------- */
+        stage('Process Target Nodes (parallel)') {
+            steps {
+                script {
+                    def nodesList = env.TARGET_NODES.split(',').collect { it.trim() }
+
+                    def branches = [:]
+
+                    nodesList.each { shortName ->
+                        def n = shortName
+
+                        branches["${n}"] = {
+                            node('reimage') {
+                                catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+                                    script {
+                                        echo "=== Processing node: ${n} ==="
+
+                                        /* Mark node temporarily offline */
+                                        try {
+                                            def nodeObj = Jenkins.instance.getNode(n)
+                                            def comp = nodeObj?.toComputer()
+
+                                            if (comp && !comp.offline) {
+                                                def msg = "Marked for scheduled reimage via Jenkins automation pipeline"
+                                                try {
+                                                    comp.doChangeOfflineCause(msg)
+                                                } catch (x) {
+                                                    comp?.setTemporarilyOffline(true)
+                                                }
+                                                echo "[${n}] Node marked temporarily offline"
+                                            }
+                                        } catch (e) {
+                                            echo "[${n}] WARNING: could not mark offline: ${e}"
+                                        }
+
+                                        /* Reimage */
+                                        if (!params.SKIP_REIMAGE) {
+                                            echo "[${n}] Starting reimage"
+                                            withCredentials([string(credentialsId: 'maas-api-key', variable: 'MAAS_API_KEY')]) {
+                                                sh """#!/bin/bash
+                                                    set -euo pipefail
+                                                    cd "$REPO_DIR"
+                                                    source "$VENV_PATH/bin/activate"
+
+                                                    OS="${OS}"
+                                                    CMD="python Jenkins_builder-reimage.py --action reimage --machine ${n}"
+                                                    [ -n "${OS}" ] && CMD="\$CMD --os ${OS}"
+
+                                                    echo "\$CMD"
+                                                    eval "\$CMD"
+                                                """
+                                            }
+                                        }
+
+                                        /* Wait online */
+                                        if (!params.SKIP_REIMAGE) {
+                                            echo "[${n}] Waiting for deployment/ready state"
+                                            withCredentials([string(credentialsId: 'maas-api-key', variable: 'MAAS_API_KEY')]) {
+                                                sh """#!/bin/bash
+                                                    set -euo pipefail
+                                                    cd "$REPO_DIR"
+                                                    source "$VENV_PATH/bin/activate"
+                                                    python Jenkins_builder-reimage.py --action wait_online --machine ${n}
+                                                """
+                                            }
+                                        }
+
+                                        /* Post reimage ansible tasks */
+                                        echo "[${n}] Running post-reimage tasks"
+                                        withCredentials([
+                                            string(credentialsId: 'builder-api-token', variable: 'BUILDER_TOKEN'),
+                                            string(credentialsId: 'ansible-vault-pass', variable: 'VAULT_PASS'),
+                                            sshUserPrivateKey(credentialsId: 'ansible-ssh-key', keyFileVariable: 'SSH_KEY')
+                                        ]) {
+                                            sh """#!/bin/bash
+                                                set -euo pipefail
+
+                                                TARGET_FQDN="${n}.${DOMAIN}"
+
+                                                mkdir -p "${WORK_DIR}"
+                                                cp "${SSH_KEY}" /tmp/jenkins_git_key
+                                                chmod 600 /tmp/jenkins_git_key
+
+                                                VAULT_FILE="/home/jenkins-build/.vault_pass.txt"
+                                                TMP_FILE="\$(mktemp /tmp/vault.XXXXXX)"
+                                                umask 077
+                                                printf "%s" "${VAULT_PASS}" > "\${TMP_FILE}"
+                                                mv -f "\${TMP_FILE}" "\${VAULT_FILE}"
+                                                chmod 600 "\${VAULT_FILE}"
+
+                                                cd "$WORKSPACE/Jenkins-job/preprod-jenkins/jenkins-pipeline/build"
+                                                bash scripts/prepare_env.sh "\${TARGET_FQDN}" "${WORK_DIR}" true \
+                                                    git@github.com:ceph/ceph-build.git \
+                                                    git@github.com:ceph/ceph-cm-ansible.git \
+                                                    git@github.com:ceph/ceph-sepia-secrets.git
+
+                                                bash scripts/ansible_runner.sh \
+                                                    "\${TARGET_FQDN}" \
+                                                    "${WORK_DIR}" \
+                                                    "${VENV_PATH}" \
+                                                    "${OS}" \
+                                                    "${BUILDER_TOKEN}"
+                                            """
+                                        }
+
+                                        /* Verify node online */
+                                        echo "[${n}] Verifying Jenkins node state..."
+                                        try {
+                                            def nodeObj2 = Jenkins.instance.getNode(n)
+                                            def comp2 = nodeObj2?.toComputer()
+                                            if (comp2?.online) {
+                                                echo "[${n}] SUCCESS: Builder online & ready"
+                                            } else {
+                                                echo "[${n}] WARNING: Builder not yet connected"
+                                                currentBuild.result = 'UNSTABLE'
+                                            }
+                                        } catch (v) {
+                                            echo "[${n}] Verification error: ${v}"
+                                            currentBuild.result = 'UNSTABLE'
+                                        }
+
+                                        echo "=== Finished ${n} ==="
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    parallel branches
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            sh 'rm -f /home/jenkins-build/.vault_pass.txt || true'
+            echo 'Build finished!'
+        }
+        success { echo 'Build succeeded for all nodes' }
+        failure { echo 'Build failed on one or more nodes' }
+    }
+}

--- a/builder-reimage/Jenkins-job/preprod-jenkins/jenkins-pipeline/build/scripts/ansible_runner.sh
+++ b/builder-reimage/Jenkins-job/preprod-jenkins/jenkins-pipeline/build/scripts/ansible_runner.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ansible_runner.sh
+#
+# Usage:
+#   ansible_runner.sh <target_fqdn> <work_dir> <venv_dir> <os> <builder_token>
+
+TARGET_FQDN="$1"
+WORK_DIR="$2"
+VENV_DIR="$3"
+OS_VALUE="${4,,}"        # normalize OS → lowercase (can be empty)
+BUILDER_TOKEN="$5"
+
+ANSIBLE_DIR="${WORK_DIR}/repos/ansible"
+MAIN_DIR="${WORK_DIR}/repos/main"
+LOG_DIR="${WORK_DIR}/ansible-logs"
+
+# Vault now ALWAYS comes from this file (created by Jenkinsfile)
+VAULT_FILE="/home/jenkins-build/.vault_pass.txt"
+VAULT_ARG="--vault-password-file=${VAULT_FILE}"
+
+mkdir -p "${LOG_DIR}"
+
+##############################################
+# Activate virtualenv if present
+##############################################
+if [[ -f "${WORK_DIR}/${VENV_DIR}/bin/activate" ]]; then
+    echo "[ansible_runner] Activating venv: ${WORK_DIR}/${VENV_DIR}"
+    # shellcheck disable=SC1090
+    source "${WORK_DIR}/${VENV_DIR}/bin/activate"
+else
+    echo "[ansible_runner] WARNING: venv not found at ${WORK_DIR}/${VENV_DIR}. Continuing without venv."
+fi
+
+##############################################
+# Determine SSH user based on OS
+##############################################
+if [[ "$OS_VALUE" =~ (rhel|centos|rocky|almai|9-stream|rhel10|centos70|8) ]]; then
+    SSH_USER="cloud-user"
+else
+    SSH_USER="ubuntu"
+fi
+
+echo "[ansible_runner] SSH user selected = ${SSH_USER}"
+
+##############################################
+# Admin user JSON builder
+##############################################
+ADMIN_USERS=(
+  "akraitma"
+  "dgalloway"
+  "dmick"
+  "falcocer"
+  "jitendra"
+  "zack"
+)
+
+build_admin_users_json() {
+    local json='{"managed_admin_users":['
+    for u in "${ADMIN_USERS[@]}"; do
+        json+="{\"name\":\"${u}\"},"
+    done
+    json="${json%,}]}"
+    echo "${json}"
+}
+
+##############################################
+# Playbook runner with retries (3 attempts)
+##############################################
+run_playbook() {
+    local pb_name="$1"
+    local cmd="$2"
+    local logfile="${LOG_DIR}/${TARGET_FQDN}-${pb_name}.log"
+
+    echo "[ansible_runner] Running ${pb_name} -> ${logfile}"
+
+    attempts=0
+    max_attempts=3
+
+    until [[ $attempts -ge $max_attempts ]]; do
+        attempts=$((attempts + 1))
+
+        eval "${cmd}" 2>&1 | tee "${logfile}"
+        rc=${PIPESTATUS[0]}
+
+        if [[ $rc -eq 0 ]]; then
+            echo "[ansible_runner] ${pb_name} succeeded on attempt ${attempts}"
+            return
+        fi
+
+        echo "[ansible_runner] ${pb_name} failed (rc=${rc}), attempt ${attempts}/${max_attempts}"
+
+        if [[ $attempts -lt $max_attempts ]]; then
+            sleep $((attempts * 10))
+        else
+            echo "[ansible_runner] Max attempts reached for ${pb_name}; failing"
+            exit "${rc}"
+        fi
+    done
+}
+
+##############################################
+# PLAYBOOK 1 — ansible_managed.yml
+# (NO VAULT)
+##############################################
+(
+  cd "${ANSIBLE_DIR}"
+
+  CMD="ANSIBLE_SSH_ARGS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' ansible-playbook ansible_managed.yml \
+        --limit='${TARGET_FQDN}' \
+        -e ansible_ssh_user='${SSH_USER}'"
+
+  run_playbook "play1-ansible_managed" "${CMD}"
+)
+
+##############################################
+# PLAYBOOK 2 — users.yml
+# (NO VAULT)
+##############################################
+(
+  cd "${ANSIBLE_DIR}"
+
+  ADMIN_USERS_JSON="$(build_admin_users_json)"
+
+  CMD="ANSIBLE_SSH_ARGS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' ansible-playbook users.yml -v \
+        --limit='${TARGET_FQDN}' \
+        --tags='user,pubkeys' \
+        --ssh-extra-args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+        --extra-vars='${ADMIN_USERS_JSON}'"
+
+  run_playbook "play2-users" "${CMD}"
+)
+
+##############################################
+# PLAYBOOK 3 — jenkins-builder-disk.yml
+# (NO VAULT)
+##############################################
+(
+  cd "${ANSIBLE_DIR}"
+
+  CMD="ANSIBLE_SSH_ARGS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' ansible-playbook -vvv tools/jenkins-builder-disk.yml \
+        --ssh-extra-args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \ 
+        --limit='${TARGET_FQDN}'"
+
+  run_playbook "play3-tools-disk" "${CMD}"
+)
+
+##############################################
+# PLAYBOOK 4 — builder.yml
+# (USES VAULT)
+##############################################
+(
+  cd "${MAIN_DIR}/ansible"
+
+  CMD="ANSIBLE_SSH_ARGS='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' ansible-playbook -vvv \
+        ${VAULT_ARG} \
+        -M ./library/ \
+        examples/builder.yml \
+        -e '{\"token\":\"${BUILDER_TOKEN}\", \"jenkins_credentials_uuid\":\"jenkins-build\", \"api_uri\":\"https://jenkins.ceph.com\"}' \
+        -e permanent=true \
+        --ssh-extra-args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+        --limit='${TARGET_FQDN}'"
+
+  run_playbook "play4-main-builder" "${CMD}"
+)
+
+echo "[ansible_runner] All playbooks completed successfully for ${TARGET_FQDN}"

--- a/builder-reimage/Jenkins-job/preprod-jenkins/jenkins-pipeline/build/scripts/prepare_env.sh
+++ b/builder-reimage/Jenkins-job/preprod-jenkins/jenkins-pipeline/build/scripts/prepare_env.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# prepare_env.sh
+# Usage:
+#   prepare_env.sh <target_fqdn> <work_dir> <ssh_available> <ansible_repo> <main_repo> <secrets_repo>
+#
+# Example:
+#   prepare_env.sh irvingi04.front.sepia.ceph.com /var/lib/jenkins/ci-work true git@github.com:org/repo-ansible.git ...
+
+TARGET_FQDN="$1"
+WORK_DIR="$2"
+SSH_AVAILABLE="${3:-false}"
+MAIN_REPO="${4:-git@github.com:ceph/ceph-build.git}"  ## ceph-build
+ANSIBLE_REPO="${5:-git@github.com:ceph/ceph-cm-ansible.git}" ## ceph-ci-ansible
+SECRETS_REPO="${6:-git@github.com:ceph/ceph-sepia-secrets.git}" ## ceph-sepia-secrets
+
+SHORTNAME="${TARGET_FQDN%%.*}"
+
+REPOS_DIR="${WORK_DIR}/repos"
+ANSIBLE_DIR="${REPOS_DIR}/ansible"
+MAIN_DIR="${REPOS_DIR}/main"
+SECRETS_DIR="${REPOS_DIR}/secret-repo"
+VENV_DIR="${WORK_DIR}/.venv"
+
+mkdir -p "${REPOS_DIR}"
+cd "${REPOS_DIR}"
+
+log() { echo "[prepare_env] $*"; }
+
+adjust_url() {
+  local url="$1"
+  if [ "${SSH_AVAILABLE}" = "true" ]; then
+    echo "${url}"
+  else
+    # convert git@github.com:org/repo.git -> https://github.com/org/repo.git
+    echo "${url}" | sed 's|git@github.com:|https://github.com/|'
+  fi
+}
+
+clone_repo() {
+  local url="$1"
+  local dir="$2"
+  if [ -d "${dir}/.git" ]; then
+    log "Updating existing repo ${dir}"
+    (cd "${dir}" && git fetch --all --prune)
+  else
+    log "Cloning ${url} -> ${dir}"
+    if [ "${SSH_AVAILABLE}" = "true" ] && [ -f /tmp/jenkins_git_key ]; then
+      GIT_SSH_COMMAND='ssh -i /tmp/jenkins_git_key -o StrictHostKeyChecking=no' git clone --depth 1 "${url}" "${dir}"
+    else
+      git clone --depth 1 "${url}" "${dir}"
+    fi
+  fi
+}
+
+ANSIBLE_URL=$(adjust_url "${ANSIBLE_REPO}")
+MAIN_URL=$(adjust_url "${MAIN_REPO}")
+SECRETS_URL=$(adjust_url "${SECRETS_REPO}")
+
+clone_repo "${ANSIBLE_URL}" "${ANSIBLE_DIR}"
+clone_repo "${MAIN_URL}" "${MAIN_DIR}"
+clone_repo "${SECRETS_URL}" "${SECRETS_DIR}"
+
+# Ensure venv exists (created by Jenkinsfile in WORK_DIR). If not, create here.
+if [ ! -d "${VENV_DIR}/bin" ]; then
+  log "Virtualenv not found at ${VENV_DIR}, creating..."
+  python3 -m venv "${VENV_DIR}"
+  source "${VENV_DIR}/bin/activate"
+  pip install --upgrade pip
+  pip install -r "${ANSIBLE_DIR}/requirements.txt" 2>/dev/null || true
+else
+  source "${VENV_DIR}/bin/activate"
+fi
+
+# Check ansible installation in venv or system
+if command -v ansible-playbook >/dev/null 2>&1; then
+  log "Ansible already installed."
+else
+  log "Ansible not found, attempting to install into venv..."
+
+  # Determine package manager depending on OS
+  install_ansible_system() {
+    if command -v apt-get >/dev/null 2>&1; then
+      log "Detected apt-based system. Installing ansible..."
+      sudo apt-get update && sudo apt-get install -y ansible || true
+
+    elif command -v dnf >/dev/null 2>&1; then
+      log "Detected dnf-based system (RHEL8+/Rocky/Alma). Installing ansible-core..."
+      sudo dnf install -y ansible-core || sudo dnf install -y ansible || true
+
+    elif command -v yum >/dev/null 2>&1; then
+      log "Detected yum-based system (RHEL7/CentOS7). Installing ansible..."
+      sudo yum install -y ansible || true
+
+    else
+      log "No supported package manager found. Cannot install ansible."
+    fi
+  }
+
+  if [ -n "${VENV_DIR}" ] && [ -f "${VENV_DIR}/bin/activate" ]; then
+    pip install ansible || {
+      log "Failed to install ansible in venv; trying system install (requires sudo)"
+      install_ansible_system
+    }
+  else
+    log "No venv available; attempting system install (requires sudo)"
+    install_ansible_system
+  fi
+fi
+
+# Create idempotent symlinks for /etc/ansible/secrets and /etc/ansible/hosts
+ensure_symlink() {
+  local src="$1"
+  local dst="$2"
+  if [ -L "${dst}" ]; then
+    log "Symlink ${dst} already exists"
+    return 0
+  fi
+  if [ -e "${dst}" ]; then
+    log "Target ${dst} exists and is not a symlink — leaving it untouched"
+    return 0
+  fi
+  # ensure parent directory exists
+  sudo mkdir -p "$(dirname "${dst}")"
+  sudo ln -s "${src}" "${dst}"
+  log "Created symlink ${dst} -> ${src}"
+}
+
+# Ensure /etc/ansible exists
+sudo mkdir -p /etc/ansible || true
+
+sudo rm -f /etc/ansible/secrets
+ensure_symlink "${SECRETS_DIR}/ansible/secrets" "/etc/ansible/secrets"
+sudo rm -f /etc/ansible/hosts
+ensure_symlink "${SECRETS_DIR}/ansible/inventory" "/etc/ansible/hosts"
+
+# Optional: Warn if target FQDN is not present in inventory file
+if ! grep -q -E "^${TARGET_FQDN}\\b" /etc/ansible/hosts 2>/dev/null; then
+  log "Warning: ${TARGET_FQDN} not found in /etc/ansible/hosts. Ensure dynamic inventory or update inventory."
+fi
+
+log "prepare_env completed for ${TARGET_FQDN} (shortname=${SHORTNAME})"

--- a/builder-reimage/Jenkins-job/preprod-jenkins/jenkins-pipeline/config/definitions/builder-reimage-pipeline.yml
+++ b/builder-reimage/Jenkins-job/preprod-jenkins/jenkins-pipeline/config/definitions/builder-reimage-pipeline.yml
@@ -1,0 +1,49 @@
+- job:
+    name: builder-reimage-discover
+    project-type: pipeline
+    description: "Pipeline to reimage Jenkins builders (single/multi/discover) and run post-reimage ansible tasks"
+
+    concurrent: false
+
+    parameters:
+      - choice:
+          name: ACTION
+          choices:
+            - reimage
+            - reimage-all
+            - wait_online
+            - discover
+          default: reimage
+          description: "Select operation mode: reimage single/multi, wait_online, or discover eligible nodes"
+      - bool:
+          name: DRY_RUN
+          default: false
+          description: "If true, only discover and list target nodes without marking offline or running tasks"
+      - string:
+          name: MACHINE
+          default: ""
+          description: "Machine shortname or comma-separated nodes (ignored when ACTION=discover)"
+      - string:
+          name: OS
+          default: ""
+          description: "OS to deploy (optional)"
+      - bool:
+          name: SKIP_REIMAGE
+          default: false
+          description: "Skip reimage stage and run only post-reimage tasks"
+
+    scm:
+      - git:
+          url: https://github.com/jitendrasahu1803/builder-reimage.git
+          branches:
+            - main
+          clean: true
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/jitendrasahu1803/builder-reimage.git
+            branches:
+              - main
+      script-path: Jenkins-job/preprod-jenkins/jenkins-pipeline/build/Jenkinsfile
+      lightweight-checkout: true

--- a/builder-reimage/Jenkins-job/preprod-jenkins/maas.conf
+++ b/builder-reimage/Jenkins-job/preprod-jenkins/maas.conf
@@ -1,0 +1,2 @@
+[maas]
+maas_url=http://sepia-maas.front.sepia.ceph.com:5240/MAAS

--- a/builder-reimage/Jenkins-job/preprod-jenkins/protected_labels.txt
+++ b/builder-reimage/Jenkins-job/preprod-jenkins/protected_labels.txt
@@ -1,0 +1,7 @@
+master
+teuthology
+libvirt
+mira
+www
+ec2
+reimage

--- a/builder-reimage/Jenkins-job/preprod-jenkins/requirements.txt
+++ b/builder-reimage/Jenkins-job/preprod-jenkins/requirements.txt
@@ -1,0 +1,8 @@
+requests>=2.31.0
+aiohttp>=3.9.0
+asyncio>=3.4.3
+python-dotenv>=1.0.1
+tabulate>=0.9.0
+cryptography>=36.0.0
+maas>=1.3.2
+python-libmaas>=0.6.8

--- a/builder-reimage/Jenkins-job/prod-jenkins/Jenkins_builder-reimage.py
+++ b/builder-reimage/Jenkins-job/prod-jenkins/Jenkins_builder-reimage.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+
+"""
+MAAS Reimage Automation Script
+
+Provides:
+- Connect to MAAS
+- Query machines
+- List machines
+- Deploy a machine
+- Reimage a machine
+- Reimage all machines
+- List OS images
+"""
+
+import asyncio
+import argparse
+import configparser
+import sys
+import time
+from datetime import datetime, timezone
+from cryptography.fernet import Fernet
+import os
+
+from maas.client import connect
+from aiohttp.client_exceptions import (
+    ClientConnectorError,
+    ServerDisconnectedError,
+    ClientResponseError,
+    ClientOSError
+)
+
+# -------------------------------------------------------------------------
+# Missing minimal helper functions required by main()
+# -------------------------------------------------------------------------
+
+def load_config():
+    # Prefer Jenkins MAAS_URL env if provided, else fall back to script constant
+    return os.environ.get("MAAS_URL", MAAS_URL)
+
+def load_api_key():
+    return MAAS_API_KEY
+
+def get_machine(client, hostname):
+    """
+    Minimal helper used by wait_online(), returns dict with hostname & status_name.
+    """
+    machines = getattr(client, "_machines_cache", []) or []
+    for m in machines:
+        if m.hostname == hostname:
+            return {
+                "hostname": m.hostname,
+                "status_name": getattr(m, "status_name", None) or getattr(getattr(m, "status", None), "name", "-")
+            }
+    return {"hostname": hostname, "status_name": "Unknown"}
+
+# -------------------------------------------------------------------------
+# Global Defaults
+# -------------------------------------------------------------------------
+
+LOG_FILE_DEFAULT = "maas_reimage.log"
+STATUS_WAIT_TIMEOUT = 1200
+POLL_INTERVAL = 10
+DEFAULT_OWNER = "jitendra" # use --owner to tag manually
+
+# -------------------------------------------------------------------------
+# Small helpers
+# -------------------------------------------------------------------------
+
+def log(msg, log_file=None):
+    """Print message and optionally append to a log file with a timestamp."""
+    print(msg)
+    if log_file:
+        try:
+            with open(log_file, "a") as f:
+                f.write(f"{datetime.now().isoformat()} - {msg}\n")
+        except Exception:
+            print(f"(warning) Unable to write to log file: {log_file}")
+
+def sanitize_owner(name):
+    return name.replace(" ", "_").replace("@", "_")
+
+async def safe_list_tags_for_machine(machine):
+    """
+    Return list of tag objects applied to the machine.
+    Some MAAS clients expose machine.tags as a proxy; the reliable way is:
+    await machine.tags.list()
+    """
+    try:
+        return await machine.tags.list()
+    except Exception:
+        # fallback: try to read machine.tags attribute (may not be useful)
+        mt = getattr(machine, "tags", None)
+        if isinstance(mt, list):
+            return mt
+        return []
+
+def get_normalized_status(machine):
+    """
+    Return lowercased status name using the most reliable available attribute.
+    Handles both `status_name` and `status.name` forms.
+    """
+    status_name = getattr(machine, "status_name", None)
+    if status_name:
+        return str(status_name).lower()
+    status_obj = getattr(machine, "status", None)
+    if status_obj is not None:
+        name = getattr(status_obj, "name", None)
+        if name:
+            return str(name).lower()
+    return ""
+
+# -------------------------------------------------------------------------
+# Configuration (use Jenkins credential via env)
+# -------------------------------------------------------------------------
+MAAS_URL = "http://soko02.front.sepia.ceph.com:5240/MAAS"
+
+# MAAS API key must be supplied by Jenkins as an environment variable named MAAS_API_KEY
+MAAS_API_KEY = os.environ.get("MAAS_API_KEY")
+if not MAAS_API_KEY:
+    print("Error: MAAS_API_KEY environment variable not set. Please configure your Jenkins job to pass the API key as an env var 'MAAS_API_KEY'.")
+    sys.exit(1)
+
+# -------------------------------------------------------------------------
+# MAAS connect with retries
+# -------------------------------------------------------------------------
+
+async def connect_maas(maas_url, api_key, retries=3):
+    """Connect to MAAS with retries and clear error handling."""
+    for attempt in range(1, retries + 1):
+        try:
+            client = await connect(maas_url, apikey=api_key)
+            return client
+        except (ClientConnectorError, ClientOSError) as e:
+            print(f"Connection attempt {attempt} failed: {e}")
+        except ClientResponseError as e:
+            print(f"MAAS server responded with error: {e.status} {e.message}")
+        except asyncio.TimeoutError:
+            print(f"Connection timed out on attempt {attempt}")
+        except ServerDisconnectedError:
+            print(f"Server disconnected unexpectedly (attempt {attempt})")
+        if attempt < retries:
+            print("Retrying in 2 seconds...")
+            await asyncio.sleep(2)
+    print("Error: Unable to connect to MAAS after several attempts.")
+    print("Please check:")
+    print("  • Network or VPN connection")
+    print("  • MAAS server hostname and port")
+    print("  • MAAS service availability")
+    sys.exit(1)
+
+# -------------------------------------------------------------------------
+# Cache + refresh helpers
+# -------------------------------------------------------------------------
+
+async def get_cached_machines(client):
+    """Return a cached copy of client.machines.list() for script lifetime."""
+    if getattr(client, "_machines_cache", None) is None:
+        log("Fetching machines list...")
+        client._machines_cache = await client.machines.list()
+    return client._machines_cache
+
+async def refresh_machine(client, machine):
+    """
+    Refresh machine object. Prefer machine.refresh() if available.
+    """
+    try:
+        ref = getattr(machine, "refresh", None)
+        if callable(ref):
+            maybe = ref()
+            if asyncio.iscoroutine(maybe):
+                await maybe
+            return machine
+    except Exception:
+        pass
+
+    try:
+        return await client.machines.get(system_id=machine.system_id)
+    except Exception:
+        return machine
+
+# -------------------------------------------------------------------------
+# Tag-based ownership helpers
+# -------------------------------------------------------------------------
+
+async def ensure_tag_exists(client, tag_name, log_file=None):
+    """Ensure a tag with `tag_name` exists in MAAS; create it if not."""
+    try:
+        tags = await client.tags.list()
+        if not any(getattr(t, "name", t) == tag_name for t in tags):
+            log(f"Creating tag '{tag_name}'...", log_file)
+            await client.tags.create(name=tag_name)
+        return True
+    except Exception as e:
+        log(f"[ERROR] Unable to ensure tag exists '{tag_name}': {e}", log_file)
+        return False
+
+async def assign_owner_tag(client, machine, owner_name, log_file=None):
+    """
+    Assign owner tag to machine using client.tags.get() and machine.tags.add(tag).
+    Refresh machine after applying tag so later reads see it.
+    """
+    sanitized = sanitize_owner(owner_name)
+    if not await ensure_tag_exists(client, sanitized, log_file):
+        return False
+
+    try:
+        tag = await client.tags.get(name=sanitized)
+        applied = await safe_list_tags_for_machine(machine)
+        applied_names = [getattr(t, "name", None) for t in applied]
+        if sanitized in applied_names:
+            return True
+
+        log(f"Assigning tag '{sanitized}' to {machine.hostname}...", log_file)
+        await machine.tags.add(tag)
+        # Refresh so tag is visible
+        await refresh_machine(client, machine)
+        return True
+    except Exception as e:
+        log(f"[ERROR] Failed to assign tag '{sanitized}' to {getattr(machine, 'hostname', machine)}: {e}", log_file)
+        return False
+
+async def get_owner_from_tags(client, machine, owner_pattern):
+    """
+    Determine owner by checking machine's applied tags.
+    owner_pattern should be sanitized (e.g., DEFAULT_OWNER sanitized).
+    Returns the matching tag name or '-' if none.
+    """
+    try:
+        applied = await safe_list_tags_for_machine(machine)
+        applied_names = [getattr(t, "name", None) for t in applied]
+        if owner_pattern in applied_names:
+            return owner_pattern
+        # try prefix match too
+        for n in applied_names:
+            if n and n.startswith(owner_pattern):
+                return n
+    except Exception:
+        pass
+    return "-"
+
+# -------------------------------------------------------------------------
+# Query Machine
+# -------------------------------------------------------------------------
+
+async def query_machine(client, hostname, log_file=None, quiet=False):
+    """
+    Query machine details and print them.
+    Owner detection is tag-based (matches sanitized DEFAULT_OWNER).
+    """
+    owner_tag = "-"  # initialize to avoid undefined variable on errors
+
+    try:
+        machines = await get_cached_machines(client)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machines list: {e}", log_file)
+        return None
+
+    system_id = None
+    for m in machines:
+        if m.hostname == hostname:
+            system_id = m.system_id
+            break
+
+    if not system_id:
+        log(f"[ERROR] Machine '{hostname}' not found.", log_file)
+        return None
+
+    try:
+        log(f"Fetching details for {hostname}...", log_file)
+        machine = await client.machines.get(system_id=system_id)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machine details: {e}", log_file)
+        return None
+
+    if not quiet:
+        sanitized = sanitize_owner(DEFAULT_OWNER)
+        owner_tag = await get_owner_from_tags(client, machine, sanitized)
+
+        # Fetch all tags applied to this machine for display
+        try:
+            applied = await safe_list_tags_for_machine(machine)
+            tag_names = [getattr(t, "name", None) for t in applied if getattr(t, "name", None)]
+            tags_display = ", ".join(tag_names) if tag_names else "-"
+        except Exception:
+            tags_display = "-"
+
+        # resolve status display
+        status_display = getattr(machine, "status_name", None)
+        if not status_display:
+            st = getattr(machine, "status", None)
+            status_display = getattr(st, "name", "-") if st else "-"
+
+        log("\nMachine Details\n" + "-" * 60, log_file)
+        log(
+            f"Name:             {machine.hostname}\n"
+            f"System ID:        {machine.system_id}\n"
+            f"Status:           {status_display}\n"
+            f"OS Distro:        {getattr(machine, 'distro_series', '-')}\n"
+            f"OS Type:          {getattr(machine, 'osystem', '-')}\n"
+           # f"Owner:            {owner_tag}\n"
+           # f"Tags:             {tags_display}\n"
+            f"Power Type:       {getattr(machine, 'power_type', '-')}\n"
+            f"Power Status:     {getattr(machine, 'power_state', '-')}",
+            log_file
+        )
+
+    return machine
+
+# -------------------------------------------------------------------------
+# List machines / distros
+# -------------------------------------------------------------------------
+
+async def list_machines(client, log_file=None):
+    machines = await get_cached_machines(client)
+    log(f"{'Hostname':20} | {'System ID':10} | {'Status':10} | {'OS':10}", log_file)
+    log("-" * 65, log_file)
+    for m in machines:
+        status_display = getattr(m, "status_name", None) or getattr(getattr(m, "status", None), "name", "-")
+        osname = getattr(m, "distro_series", "-")
+        log(f"{m.hostname:20} | {m.system_id:10} | {status_display:10} | {osname:10}", log_file)
+
+async def list_distros(client, log_file=None):
+    try:
+        log("Fetching available OS images...", log_file)
+        resources = await client.boot_resources.list()
+    except Exception as e:
+        log(f"[ERROR] Unable to list boot resources: {e}", log_file)
+        return
+
+    log(f"{'ID':<5} | {'OS Type':<15} | {'Release':<15} | {'Architecture':<12}", log_file)
+    log("-" * 60, log_file)
+    for r in resources:
+        name = getattr(r, "name", "-")
+        os_type, release = "-", "-"
+        if "/" in name:
+            os_type, release = name.split("/", 1)
+        log(f"{r.id:<5} | {os_type:<15} | {release:<15} | {r.architecture:<12}", log_file)
+
+# -------------------------------------------------------------------------
+# Status polling helper
+# -------------------------------------------------------------------------
+
+async def wait_for_status(client, system_id, expected, timeout=STATUS_WAIT_TIMEOUT):
+    """
+    Wait for a machine to reach the expected state (case-insensitive).
+    """
+    log(f"Waiting for machine {system_id} to reach '{expected}'...", None)
+    start = time.time()
+    poll = 2
+    max_poll = 8
+    expected_l = expected.lower()
+
+    while time.time() - start < timeout:
+        try:
+            m = await client.machines.get(system_id=system_id)
+        except Exception as e:
+            print(f"Error fetching machine {system_id}: {e}")
+            await asyncio.sleep(poll)
+            poll = min(max_poll, poll + 1)
+            continue
+
+        current = get_normalized_status(m)
+        if current == expected_l:
+            log(f"{getattr(m, 'hostname', system_id)} reached expected status: {expected}", None)
+            return True
+
+        await asyncio.sleep(poll)
+        poll = min(max_poll, poll + 1)
+
+    print(f"Timeout waiting for {system_id} to reach {expected}.")
+    return False
+
+# -------------------------------------------------------------------------
+# Deploy machine
+# -------------------------------------------------------------------------
+
+async def deploy_machine(client, machine_ref, os_release=None, log_file=None):
+    """
+    Deploy (reimage) a machine. Accepts hostname (str) or machine object.
+    NOTE: this function assumes owner tag is already applied when called from reimage flow.
+    If user invokes deploy action directly, main() will ensure tag is applied before calling this.
+    """
+    if isinstance(machine_ref, str):
+        # Avoid calling query_machine() (which prints full details) to prevent duplicate fetches.
+        machines = await get_cached_machines(client)
+        found = next((m for m in machines if m.hostname == machine_ref), None)
+        if not found:
+            log(f"[ERROR] Machine '{machine_ref}' not found.", log_file)
+            return False
+        machine = await client.machines.get(system_id=found.system_id)
+    else:
+        machine = machine_ref
+
+    machine = await refresh_machine(client, machine)
+
+    hostname = machine.hostname
+    system_id = machine.system_id
+    status = get_normalized_status(machine)
+
+    if status == "deployed":
+        log(f"[INFO] {hostname} is already deployed.", log_file)
+        return True
+
+    if status in ["failed", "broken", "error", "unknown"]:
+        log(f"[ERROR] {hostname} cannot be reimaged (state: {status}).", log_file)
+        return False
+
+    os_to_use = os_release or getattr(machine, "distro_series", None) or "focal"
+    log(f"[ACTION] Reimaging {hostname} using OS '{os_to_use}'...", log_file)
+
+    try:
+        await machine.deploy(distro_series=os_to_use)
+    except Exception as e:
+        log(f"[ERROR] Failed to trigger reimage for {hostname}: {e}", log_file)
+        return False
+
+    if not await wait_for_status(client, system_id, "deployed"):
+        log(f"[ERROR] Reimage timeout for {hostname}.", log_file)
+        return False
+
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    log(f"[SUCCESS] Reimage completed for {hostname}.", log_file)
+    log(f"[INFO] Deployment timestamp for {hostname}: {ts} IST", log_file)
+    return True
+
+# -------------------------------------------------------------------------
+# Release machine
+# -------------------------------------------------------------------------
+
+async def release_machine(client, machine, log_file=None):
+    status = get_normalized_status(machine)
+    if status != "deployed":
+        return True
+
+    log(f"[ACTION] Releasing {machine.hostname}...", log_file)
+    try:
+        await machine.release()
+        return True
+    except Exception as e:
+        log(f"[ERROR] Failed to release: {e}", log_file)
+        return False
+
+# -------------------------------------------------------------------------
+# Reimage machine
+# -------------------------------------------------------------------------
+
+async def reimage_machine(client, hostname, os_release=None, log_file=None):
+    # First, fetch machine (and print its details)
+    machine = await query_machine(client, hostname, log_file)
+    if not machine:
+        return
+
+    force_flag = getattr(args, "force", False)
+    status = get_normalized_status(machine)
+
+    if force_flag and status == "deploying":
+        log(f"[FORCE] Aborting active deployment for {hostname}...", log_file)
+        try:
+            await machine.abort()
+        except Exception as e:
+            log(f"[ERROR] Unable to abort deployment for {hostname}: {e}", log_file)
+            return
+
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after abort.", log_file)
+            return
+
+        log(f"[FORCE] Deployment aborted. Releasing {hostname}...", log_file)
+        try:
+            await machine.release()
+        except Exception:
+            pass
+
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after forced release.", log_file)
+            return
+
+        machine = await refresh_machine(client, machine)
+
+    # Ensure owner tag is applied (only once here)
+    if not await assign_owner_tag(client, machine, DEFAULT_OWNER, log_file):
+        return
+
+    # choose OS
+    current_os = getattr(machine, "distro_series", None)
+    if os_release:
+        os_to_use = os_release
+    elif current_os:
+        os_to_use = current_os
+    else:
+        log(f"[ERROR] No OS detected for machine '{hostname}'. Provide --os.", log_file)
+        return
+
+    # if deployed -> release then wait for Ready
+    status = get_normalized_status(machine)
+    if status == "deployed":
+        log(f"[ACTION] Releasing {machine.hostname} for reimage...", log_file)
+        if not await release_machine(client, machine, log_file):
+            return
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after release.", log_file)
+            return
+        machine = await refresh_machine(client, machine)
+
+    # trigger deploy (deploy_machine will not re-assign tag)
+    if await deploy_machine(client, hostname, os_to_use, log_file):
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        log(f"[SUCCESS] Reimage completed for {hostname}.", log_file)
+        log(f"[INFO] Reimage timestamp for {hostname}: {ts} IST", log_file)
+        # print detected OS for downstream consumption (simple marker)
+        print(f"DETECTED_OS={os_to_use}")
+
+# -------------------------------------------------------------------------
+# Reimage all machines
+# -------------------------------------------------------------------------
+
+async def reimage_all(client, os_release=None, log_file=None):
+    try:
+        machines = await get_cached_machines(client)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machines list: {e}", log_file)
+        return
+
+    for m in machines:
+        hostname = m.hostname
+        target_os = os_release or getattr(m, "distro_series", "focal")
+        log(f"[INFO] Starting reimage for {hostname}", log_file)
+        try:
+            await reimage_machine(client, hostname, target_os, log_file)
+        except Exception as e:
+            log(f"[ERROR] Reimage error for {hostname}: {e}", log_file)
+
+# -------------------------------------------------------------------------
+# Find last deployed
+# -------------------------------------------------------------------------
+
+async def find_last_deployed_machine(client):
+    try:
+        machines = await get_cached_machines(client)
+    except Exception:
+        return None
+
+    time_fields = [
+        "deployed_at", "deployment_finished_at", "deployment_completed",
+        "deployment_started", "deployment_started_at"
+    ]
+
+    candidates = []
+    for m in machines:
+        status = get_normalized_status(m)
+        if status != "deployed":
+            continue
+
+        timestamp = None
+        for field in time_fields:
+            val = getattr(m, field, None)
+            if val:
+                try:
+                    if isinstance(val, str):
+                        val = val.replace("Z", "+00:00")
+                        timestamp = datetime.fromisoformat(val)
+                    elif isinstance(val, datetime):
+                        timestamp = val
+                except Exception:
+                    continue
+        if timestamp:
+            candidates.append((timestamp, m))
+
+    if candidates:
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        return candidates[0][1]
+
+    for m in machines:
+        if get_normalized_status(m) == "deployed":
+            return m
+
+    return None
+
+# -------------------------------------------------------------------------
+# wait_online
+#
+# This feature is dedicately added for Jenkins job only
+# because:
+#    After triggering MAAS reimage, machines enter deploying or rebooting state.
+#    Jenkins or MAAS does not guarantee immediate readiness.
+#    So a wait/poll function is required to safely run ansible afterwards. 
+# -------------------------------------------------------------------------
+
+def wait_online(client, machine_name, timeout=1800, interval=20):
+    """
+    Poll MAAS for machine status until it's Deploying / Running / Ready.
+    """
+    import time
+
+    allowed_statuses = ["Deployed", "Ready", "Running"]
+
+    start = time.time()
+    while True:
+        machine = get_machine(client, machine_name)
+        status_name = machine.get("status_name", "")
+
+        print(f"[wait_online] {machine_name} status: {status_name}")
+
+        if status_name in allowed_statuses:
+            print(f"[wait_online] Machine {machine_name} is online and ready.")
+            return
+
+        if time.time() - start > timeout:
+            print(f"[wait_online] Timeout reached ({timeout}s). Machine not ready.")
+            sys.exit(1)
+
+        time.sleep(interval)
+
+
+# -------------------------------------------------------------------------
+# Main
+# -------------------------------------------------------------------------
+
+async def main():
+    global args
+    global DEFAULT_OWNER
+
+    parser = argparse.ArgumentParser(description="MAAS Reimage Automation Script")
+    parser.add_argument("--action", required=True,
+                        choices=[
+                            "list", "list-distros", "query", "status",
+                            "deploy", "reimage", "reimage-all", "last-deployed", "wait_online"
+                        ])
+    parser.add_argument("--machine", help="Hostname for query, deploy, or reimage")
+    parser.add_argument("--os", help="Target OS release")
+    parser.add_argument("--log-file", help="Path to log file")
+    parser.add_argument("--force", action="store_true",
+                        help="Force reimage even if machine is deploying")
+    parser.add_argument("--owner", help="Owner username (fallback: DEFAULT_OWNER)")
+
+    args = parser.parse_args()
+
+    if args.owner:
+        DEFAULT_OWNER = args.owner
+
+    maas_url = load_config()
+    api_key = load_api_key()
+
+    client = await connect_maas(maas_url, api_key)
+
+    # initialize cache immediately
+    try:
+        client._machines_cache = await client.machines.list()
+    except Exception:
+        client._machines_cache = None
+
+    log_file = args.log_file or LOG_FILE_DEFAULT
+
+    if args.action == "list":
+        await list_machines(client, log_file)
+
+    elif args.action == "query":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await query_machine(client, args.machine, log_file)
+
+    elif args.action == "status":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await query_machine(client, args.machine, log_file)
+
+    elif args.action == "list-distros":
+        await list_distros(client, log_file)
+
+    elif args.action == "deploy":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            # ensure owner tag when user runs deploy directly
+            # fetch machine object (no extra printed details)
+            machines = await get_cached_machines(client)
+            found = next((m for m in machines if m.hostname == args.machine), None)
+            if not found:
+                log(f"[ERROR] Machine '{args.machine}' not found.", log_file)
+            else:
+                machine_obj = await client.machines.get(system_id=found.system_id)
+                await assign_owner_tag(client, machine_obj, DEFAULT_OWNER, log_file)
+                await deploy_machine(client, args.machine, args.os, log_file)
+
+    elif args.action == "reimage":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await reimage_machine(client, args.machine, args.os, log_file)
+
+    elif args.action == "reimage-all":
+        await reimage_all(client, args.os, log_file)
+    
+    elif args.action == "wait_online":
+        wait_online(client, args.machine)
+
+    elif args.action == "last-deployed":
+        machine = await find_last_deployed_machine(client)
+        if machine:
+            log(f"Last deployed machine: {machine.hostname} ({machine.system_id})", log_file)
+        else:
+            log("No deployed machines found.", log_file)
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("Interrupted by user.")
+    except Exception as e:
+        print(f"Fatal error: {e}")

--- a/builder-reimage/Jenkins-job/prod-jenkins/bootstrap_env.sh
+++ b/builder-reimage/Jenkins-job/prod-jenkins/bootstrap_env.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -e
+
+# -----------------------------------------------------------------------------
+# Script Name: bootstrap_env.sh
+# Description:
+#   Bootstraps the local Python environment for running the MAAS reimage script.
+#   - Installs MAAS CLI (Linux/macOS)
+#   - Creates Python virtual environment
+#   - Installs dependencies
+# -----------------------------------------------------------------------------
+
+echo "Starting environment setup..."
+
+# -----------------------------------------------------------------------------
+# Step 1: Install MAAS CLI based on OS
+# -----------------------------------------------------------------------------
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Detect Linux distribution
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        DISTRO=$ID
+    else
+        DISTRO="unknown"
+    fi
+
+    echo "Detected Linux distribution: $DISTRO"
+
+    case "$DISTRO" in
+        ubuntu|debian)
+            echo "Installing MAAS CLI (Debian/Ubuntu)..."
+            sudo apt update -y
+            sudo apt install -y maas-cli 
+            ;;
+        rhel|centos|fedora|rocky|almalinux)
+            echo "Installing MAAS CLI (RHEL/CentOS/Fedora)..."
+            # Ensure EPEL repo is enabled for dependencies
+            if command -v dnf >/dev/null 2>&1; then
+                sudo dnf install -y epel-release || true
+                sudo dnf install -y snapd 
+            else
+                sudo yum install -y epel-release || true
+                sudo yum install -y snapd
+            fi
+
+            # Enable and use snap to install MAAS CLI
+            sudo systemctl enable --now snapd.socket
+            sudo ln -sf /var/lib/snapd/snap /snap
+            echo "Installing MAAS CLI via snap..."
+            sudo snap install maas --classic
+            ;;
+        *)
+            echo "Unsupported Linux distribution: $DISTRO"
+            echo "Please install MAAS CLI manually."
+            exit 1
+            ;;
+    esac
+
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Installing MAAS CLI (macOS)..."
+    brew install maas || true
+else
+    echo "Unsupported OS type: $OSTYPE"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Step 2: Create and activate Python virtual environment
+# -----------------------------------------------------------------------------
+echo "Creating Python virtual environment..."
+python3 -m venv .venv
+source .venv/bin/activate
+
+echo "Installing Python dependencies..."
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# -----------------------------------------------------------------------------
+# Step 3: Check for encrypted secrets
+# -----------------------------------------------------------------------------
+if [[ ! -f "maas_api.key" || ! -f "maas_api_key.encrypted" ]]; then
+    echo "Missing 'maas_api.key' or 'maas_api_key.encrypted'. Ensure both files are present."
+    exit 1
+fi
+
+echo
+echo "Setup complete."

--- a/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/Jenkinsfile
+++ b/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'reimage' }
+    agent { label 'teuthology' }
 
     environment {
         VENV_DIR    = ".venv"

--- a/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/Jenkinsfile
+++ b/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/Jenkinsfile
@@ -176,7 +176,7 @@ pipeline {
                         ########################################################
                         # prepare_env
                         ########################################################
-                        cd "$WORKSPACE/Jenkins-job/prod-jenkins/jenkins-pipeline/build"
+                        cd "$WORKSPACE/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build"
                         bash scripts/prepare_env.sh "${TARGET_FQDN}" "${WORK_DIR}" true \
                             git@github.com:ceph/ceph-build.git \
                             git@github.com:ceph/ceph-cm-ansible.git \
@@ -185,7 +185,7 @@ pipeline {
                         ########################################################
                         # ansible_runner.sh (NOTE: VENV_DIR not VENV_PATH)
                         ########################################################
-                        cd "$WORKSPACE/Jenkins-job/prod-jenkins/jenkins-pipeline/build"
+                        cd "$WORKSPACE/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build"
                         bash scripts/ansible_runner.sh \
                             "${TARGET_FQDN}" \
                             "${WORK_DIR}" \

--- a/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/Jenkinsfile
+++ b/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/Jenkinsfile
@@ -1,0 +1,211 @@
+pipeline {
+    agent { label 'reimage' }
+
+    environment {
+        VENV_DIR    = ".venv"
+        REPO_DIR    = "${WORKSPACE}/builder-reimage/Jenkins-job/prod-jenkins"
+        VENV_PATH   = "${REPO_DIR}/${VENV_DIR}"
+        WORK_DIR    = "${WORKSPACE}/ci-work"
+        DOMAIN      = "front.sepia.ceph.com"
+    }
+
+    parameters {
+        booleanParam(name: 'SKIP_REIMAGE', defaultValue: false, description: 'Skip reimage stage and run only post-reimage tasks')
+        choice(name: 'ACTION', choices: ['reimage','reimage-all','wait_online'], description: 'Action to perform')
+        string(name: 'MACHINE', defaultValue: '', description: 'Machine shortname (e.g. irvingi08)')
+        string(name: 'OS', defaultValue: '', description: 'OS to deploy (optional). Example: jammy, focal')
+    }
+
+    stages {
+
+        /* ---------------------------------------------------------------------
+           Stage 1: Setup Python Virtual Environment
+        --------------------------------------------------------------------- */
+        stage('Setup Python Virtual Environment') {
+            steps {
+                withCredentials([string(credentialsId: 'maas-api-key', variable: 'MAAS_API_KEY')]) {
+                    sh '''#!/bin/bash
+                        set -euo pipefail
+                        cd "$REPO_DIR"
+
+                        if [ -d "$VENV_PATH" ]; then
+                            echo "Removing incompatible virtual environment..."
+                            rm -rf "$VENV_PATH"
+                        fi
+
+                        python3 -m venv "$VENV_PATH"
+                        source "$VENV_PATH/bin/activate"
+
+                        pip install --upgrade pip
+                        pip install -r requirements.txt
+                    '''
+                }
+            }
+        }
+
+        /* ---------------------------------------------------------------------
+           Stage 2: Reimage Builder
+        --------------------------------------------------------------------- */
+        stage('Reimage Builder') {
+            when { expression { return params.SKIP_REIMAGE == false } }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    withCredentials([string(credentialsId: 'maas-api-key', variable: 'MAAS_API_KEY')]) {
+
+                        sh '''#!/bin/bash
+                            set -euo pipefail
+
+                            OS="${OS:-}"
+
+                            cd "$REPO_DIR"
+                            source "$VENV_PATH/bin/activate"
+
+                            if [ -z "${MACHINE}" ]; then
+                                echo "Error: MACHINE parameter is required."
+                                exit 1
+                            fi
+
+                            CMD="python Jenkins_builder-reimage.py --action ${ACTION} --machine ${MACHINE}"
+
+                            if [ -n "${OS}" ]; then
+                                CMD="$CMD --os ${OS}"
+                            fi
+
+                            echo "Running builder command:"
+                            echo "$CMD"
+
+                            OUTPUT=$(eval $CMD | tee /tmp/reimage-output.txt)
+                            echo "$OUTPUT"
+
+                            # Extract detected machine OS (if produced by script)
+                            DETECTED_OS=$(grep -oP '^DETECTED_OS=\\K.*' /tmp/reimage-output.txt || true)
+                            echo "DETECTED_OS=${DETECTED_OS}"
+
+                            # Persist to workspace for next stages
+                            echo "DETECTED_OS=${DETECTED_OS}" > "$WORKSPACE/detected_os.env"
+                        '''
+                    }
+                }
+            }
+        }
+
+        /* ---------------------------------------------------------------------
+           Stage 3: Wait for Ready/Deployed
+        --------------------------------------------------------------------- */
+        stage('Wait for Ready/Deployed') {
+            when {
+                allOf {
+                    expression { return params.SKIP_REIMAGE == false }
+                    expression { return currentBuild.currentResult == 'SUCCESS' }
+                }
+            }
+            steps {
+                withCredentials([string(credentialsId: 'maas-api-key', variable: 'MAAS_API_KEY')]) {
+                    script {
+                        sh '''#!/bin/bash
+                            set -euo pipefail
+                            cd "$REPO_DIR"
+                            source "$VENV_PATH/bin/activate"
+
+                            python Jenkins_builder-reimage.py --action wait_online --machine ${MACHINE}
+                        '''
+                    }
+                }
+            }
+        }
+
+        /* ---------------------------------------------------------------------
+           Stage 4: Post Reimage Tasks
+        --------------------------------------------------------------------- */
+        stage('Post Reimage Tasks') {
+            when {
+                allOf {
+                    expression { return currentBuild.currentResult == 'SUCCESS' }
+                }
+            }
+            steps {
+                withCredentials([
+                    string(credentialsId: 'builder-api-token', variable: 'BUILDER_TOKEN'),
+                    string(credentialsId: 'ansible-vault-pass', variable: 'VAULT_PASS'),
+                    sshUserPrivateKey(credentialsId: 'ansible-ssh-key', keyFileVariable: 'SSH_KEY')
+                ]) {
+
+                    sh '''#!/bin/bash
+                        set -euo pipefail
+
+                        ########################################################
+                        # SAFE LOAD OF DETECTED_OS — prevents "unbound variable"
+                        ########################################################
+                        if [ -f "${WORKSPACE}/detected_os.env" ]; then
+                            source "${WORKSPACE}/detected_os.env"
+                        else
+                            echo "[WARN] detected_os.env not found — using OS parameter instead."
+                            DETECTED_OS="${OS:-}"
+                        fi
+
+                        : "${DETECTED_OS:=}"   # guarantee defined, even if empty
+                        echo "Using DETECTED_OS=${DETECTED_OS}"
+                        ########################################################
+
+                        cd "$REPO_DIR"
+
+                        # Build FQDN
+                        if [ -z "${MACHINE}" ]; then
+                            echo "Error: MACHINE parameter is required."
+                            exit 1
+                        fi
+                        TARGET_FQDN="${MACHINE}.${DOMAIN}"
+                        echo "FQDN = ${TARGET_FQDN}"
+
+                        mkdir -p "${WORK_DIR}"
+
+                        # SSH key for Git clones
+                        cp "${SSH_KEY}" /tmp/jenkins_git_key
+                        chmod 600 /tmp/jenkins_git_key
+
+                        ########################################################
+                        # Vault password file
+                        ########################################################
+                        VAULT_FILE="/home/jenkins-build/.vault_pass.txt"
+                        TMP_FILE="$(mktemp /tmp/vault.XXXXXX)"
+                        umask 077
+                        printf "%s" "${VAULT_PASS}" > "${TMP_FILE}"
+                        mv -f "${TMP_FILE}" "${VAULT_FILE}"
+                        chmod 600 "${VAULT_FILE}"
+
+                        ########################################################
+                        # prepare_env
+                        ########################################################
+                        cd "$WORKSPACE/Jenkins-job/prod-jenkins/jenkins-pipeline/build"
+                        bash scripts/prepare_env.sh "${TARGET_FQDN}" "${WORK_DIR}" true \
+                            git@github.com:ceph/ceph-build.git \
+                            git@github.com:ceph/ceph-cm-ansible.git \
+                            git@github.com:ceph/ceph-sepia-secrets.git
+
+                        ########################################################
+                        # ansible_runner.sh (NOTE: VENV_DIR not VENV_PATH)
+                        ########################################################
+                        cd "$WORKSPACE/Jenkins-job/prod-jenkins/jenkins-pipeline/build"
+                        bash scripts/ansible_runner.sh \
+                            "${TARGET_FQDN}" \
+                            "${WORK_DIR}" \
+                            "${VENV_DIR}" \
+                            "${DETECTED_OS}" \
+                            "${BUILDER_TOKEN}" \
+                            "${VAULT_PASS}"
+                    '''
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            sh 'rm -f /home/jenkins-build/.vault_pass.txt || true'
+            echo 'Build finished!'
+        }
+        failure {
+            echo 'Build failed!'
+        }
+    }
+}

--- a/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/scripts/ansible_runner.sh
+++ b/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/scripts/ansible_runner.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ansible_runner.sh
+#
+# Usage:
+#   ansible_runner.sh <target_fqdn> <work_dir> <venv_dir> <os> <builder_token>
+
+TARGET_FQDN="$1"
+WORK_DIR="$2"
+VENV_DIR="$3"
+OS_VALUE="${4,,}"        # normalize OS → lowercase (can be empty)
+BUILDER_TOKEN="$5"
+
+ANSIBLE_DIR="${WORK_DIR}/repos/ansible"
+MAIN_DIR="${WORK_DIR}/repos/main"
+LOG_DIR="${WORK_DIR}/ansible-logs"
+
+# Vault now ALWAYS comes from this file (created by Jenkinsfile)
+VAULT_FILE="/home/jenkins-build/.vault_pass.txt"
+VAULT_ARG="--vault-password-file=${VAULT_FILE}"
+
+mkdir -p "${LOG_DIR}"
+
+##############################################
+# Activate virtualenv if present
+##############################################
+if [[ -f "${WORK_DIR}/${VENV_DIR}/bin/activate" ]]; then
+    echo "[ansible_runner] Activating venv: ${WORK_DIR}/${VENV_DIR}"
+    # shellcheck disable=SC1090
+    source "${WORK_DIR}/${VENV_DIR}/bin/activate"
+else
+    echo "[ansible_runner] WARNING: venv not found at ${WORK_DIR}/${VENV_DIR}. Continuing without venv."
+fi
+
+##############################################
+# Determine SSH user based on OS
+##############################################
+if [[ "$OS_VALUE" =~ (rhel|centos|rocky|almai|9-stream|rhel10|centos70|8) ]]; then
+    SSH_USER="cloud-user"
+else
+    SSH_USER="ubuntu"
+fi
+
+echo "[ansible_runner] SSH user selected = ${SSH_USER}"
+
+##############################################
+# Admin user JSON builder
+##############################################
+ADMIN_USERS=(
+  "akraitma"
+  "dgalloway"
+  "dmick"
+  "falcocer"
+  "jitendra"
+  "zack"
+)
+
+build_admin_users_json() {
+    local json='{"managed_admin_users":['
+    for u in "${ADMIN_USERS[@]}"; do
+        json+="{\"name\":\"${u}\"},"
+    done
+    json="${json%,}]}"
+    echo "${json}"
+}
+
+##############################################
+# Playbook runner with retries (3 attempts)
+##############################################
+run_playbook() {
+    local pb_name="$1"
+    local cmd="$2"
+    local logfile="${LOG_DIR}/${TARGET_FQDN}-${pb_name}.log"
+
+    echo "[ansible_runner] Running ${pb_name} -> ${logfile}"
+
+    attempts=0
+    max_attempts=3
+
+    until [[ $attempts -ge $max_attempts ]]; do
+        attempts=$((attempts + 1))
+
+        eval "${cmd}" 2>&1 | tee "${logfile}"
+        rc=${PIPESTATUS[0]}
+
+        if [[ $rc -eq 0 ]]; then
+            echo "[ansible_runner] ${pb_name} succeeded on attempt ${attempts}"
+            return
+        fi
+
+        echo "[ansible_runner] ${pb_name} failed (rc=${rc}), attempt ${attempts}/${max_attempts}"
+
+        if [[ $attempts -lt $max_attempts ]]; then
+            sleep $((attempts * 10))
+        else
+            echo "[ansible_runner] Max attempts reached for ${pb_name}; failing"
+            exit "${rc}"
+        fi
+    done
+}
+
+##############################################
+# PLAYBOOK 1 — ansible_managed.yml
+# (NO VAULT)
+##############################################
+(
+  cd "${ANSIBLE_DIR}"
+
+  CMD="ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook ansible_managed.yml \
+        --limit='${TARGET_FQDN}' \
+        -e ansible_ssh_user='${SSH_USER}'"
+
+  run_playbook "play1-ansible_managed" "${CMD}"
+)
+
+##############################################
+# PLAYBOOK 2 — users.yml
+# (NO VAULT)
+##############################################
+(
+  cd "${ANSIBLE_DIR}"
+
+  ADMIN_USERS_JSON="$(build_admin_users_json)"
+
+  CMD="ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook users.yml -v \
+        --limit='${TARGET_FQDN}' \
+        --tags='user,pubkeys' \
+        --extra-vars='${ADMIN_USERS_JSON}'"
+
+  run_playbook "play2-users" "${CMD}"
+)
+
+##############################################
+# PLAYBOOK 3 — jenkins-builder-disk.yml
+# (NO VAULT)
+##############################################
+(
+  cd "${ANSIBLE_DIR}"
+
+  CMD="ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -vvv tools/jenkins-builder-disk.yml \
+        --limit='${TARGET_FQDN}'"
+
+  run_playbook "play3-tools-disk" "${CMD}"
+)
+
+##############################################
+# PLAYBOOK 4 — builder.yml
+# (USES VAULT)
+##############################################
+(
+  cd "${MAIN_DIR}/ansible"
+
+  CMD="ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -vvv \
+        ${VAULT_ARG} \
+        -M ./library/ \
+        examples/builder.yml \
+        -e '{\"token\":\"${BUILDER_TOKEN}\", \"jenkins_credentials_uuid\":\"jenkins-build\", \"api_uri\":\"https://jenkins.ceph.com\"}' \
+        -e permanent=true \
+        --limit='${TARGET_FQDN}'"
+
+  run_playbook "play4-main-builder" "${CMD}"
+)
+
+echo "[ansible_runner] All playbooks completed successfully for ${TARGET_FQDN}"

--- a/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/scripts/prepare_env.sh
+++ b/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/scripts/prepare_env.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# prepare_env.sh
+# Usage:
+#   prepare_env.sh <target_fqdn> <work_dir> <ssh_available> <ansible_repo> <main_repo> <secrets_repo>
+#
+# Example:
+#   prepare_env.sh irvingi04.front.sepia.ceph.com /var/lib/jenkins/ci-work true git@github.com:org/repo-ansible.git ...
+
+TARGET_FQDN="$1"
+WORK_DIR="$2"
+SSH_AVAILABLE="${3:-false}"
+MAIN_REPO="${4:-git@github.com:ceph/ceph-build.git}"  ## ceph-build
+ANSIBLE_REPO="${5:-git@github.com:ceph/ceph-cm-ansible.git}" ## ceph-ci-ansible
+SECRETS_REPO="${6:-git@github.com:ceph/ceph-sepia-secrets.git}" ## ceph-sepia-secrets
+
+SHORTNAME="${TARGET_FQDN%%.*}"
+
+REPOS_DIR="${WORK_DIR}/repos"
+ANSIBLE_DIR="${REPOS_DIR}/ansible"
+MAIN_DIR="${REPOS_DIR}/main"
+SECRETS_DIR="${REPOS_DIR}/secret-repo"
+VENV_DIR="${WORK_DIR}/.venv"
+
+mkdir -p "${REPOS_DIR}"
+cd "${REPOS_DIR}"
+
+log() { echo "[prepare_env] $*"; }
+
+adjust_url() {
+  local url="$1"
+  if [ "${SSH_AVAILABLE}" = "true" ]; then
+    echo "${url}"
+  else
+    # convert git@github.com:org/repo.git -> https://github.com/org/repo.git
+    echo "${url}" | sed 's|git@github.com:|https://github.com/|'
+  fi
+}
+
+clone_repo() {
+  local url="$1"
+  local dir="$2"
+  if [ -d "${dir}/.git" ]; then
+    log "Updating existing repo ${dir}"
+    (cd "${dir}" && git fetch --all --prune)
+  else
+    log "Cloning ${url} -> ${dir}"
+    if [ "${SSH_AVAILABLE}" = "true" ] && [ -f /tmp/jenkins_git_key ]; then
+      GIT_SSH_COMMAND='ssh -i /tmp/jenkins_git_key -o StrictHostKeyChecking=no' git clone --depth 1 "${url}" "${dir}"
+    else
+      git clone --depth 1 "${url}" "${dir}"
+    fi
+  fi
+}
+
+ANSIBLE_URL=$(adjust_url "${ANSIBLE_REPO}")
+MAIN_URL=$(adjust_url "${MAIN_REPO}")
+SECRETS_URL=$(adjust_url "${SECRETS_REPO}")
+
+clone_repo "${ANSIBLE_URL}" "${ANSIBLE_DIR}"
+clone_repo "${MAIN_URL}" "${MAIN_DIR}"
+clone_repo "${SECRETS_URL}" "${SECRETS_DIR}"
+
+# Ensure venv exists (created by Jenkinsfile in WORK_DIR). If not, create here.
+if [ ! -d "${VENV_DIR}/bin" ]; then
+  log "Virtualenv not found at ${VENV_DIR}, creating..."
+  python3 -m venv "${VENV_DIR}"
+  source "${VENV_DIR}/bin/activate"
+  pip install --upgrade pip
+  pip install -r "${ANSIBLE_DIR}/requirements.txt" 2>/dev/null || true
+else
+  source "${VENV_DIR}/bin/activate"
+fi
+
+# Check ansible installation in venv or system
+if command -v ansible-playbook >/dev/null 2>&1; then
+  log "Ansible already installed."
+else
+  log "Ansible not found, attempting to install into venv..."
+
+  # Determine package manager depending on OS
+  install_ansible_system() {
+    if command -v apt-get >/dev/null 2>&1; then
+      log "Detected apt-based system. Installing ansible..."
+      sudo apt-get update && sudo apt-get install -y ansible || true
+
+    elif command -v dnf >/dev/null 2>&1; then
+      log "Detected dnf-based system (RHEL8+/Rocky/Alma). Installing ansible-core..."
+      sudo dnf install -y ansible-core || sudo dnf install -y ansible || true
+
+    elif command -v yum >/dev/null 2>&1; then
+      log "Detected yum-based system (RHEL7/CentOS7). Installing ansible..."
+      sudo yum install -y ansible || true
+
+    else
+      log "No supported package manager found. Cannot install ansible."
+    fi
+  }
+
+  if [ -n "${VENV_DIR}" ] && [ -f "${VENV_DIR}/bin/activate" ]; then
+    pip install ansible || {
+      log "Failed to install ansible in venv; trying system install (requires sudo)"
+      install_ansible_system
+    }
+  else
+    log "No venv available; attempting system install (requires sudo)"
+    install_ansible_system
+  fi
+fi
+
+# Create idempotent symlinks for /etc/ansible/secrets and /etc/ansible/hosts
+ensure_symlink() {
+  local src="$1"
+  local dst="$2"
+  if [ -L "${dst}" ]; then
+    log "Symlink ${dst} already exists"
+    return 0
+  fi
+  if [ -e "${dst}" ]; then
+    log "Target ${dst} exists and is not a symlink — leaving it untouched"
+    return 0
+  fi
+  # ensure parent directory exists
+  sudo mkdir -p "$(dirname "${dst}")"
+  sudo ln -s "${src}" "${dst}"
+  log "Created symlink ${dst} -> ${src}"
+}
+
+# Ensure /etc/ansible exists
+sudo mkdir -p /etc/ansible || true
+
+sudo rm -f /etc/ansible/secrets
+ensure_symlink "${SECRETS_DIR}/ansible/secrets" "/etc/ansible/secrets"
+sudo rm -f /etc/ansible/hosts
+ensure_symlink "${SECRETS_DIR}/ansible/inventory" "/etc/ansible/hosts"
+
+# Optional: Warn if target FQDN is not present in inventory file
+if ! grep -q -E "^${TARGET_FQDN}\\b" /etc/ansible/hosts 2>/dev/null; then
+  log "Warning: ${TARGET_FQDN} not found in /etc/ansible/hosts. Ensure dynamic inventory or update inventory."
+fi
+
+log "prepare_env completed for ${TARGET_FQDN} (shortname=${SHORTNAME})"

--- a/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/config/definitions/builder-reimage-pipeline.yml
+++ b/builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/config/definitions/builder-reimage-pipeline.yml
@@ -1,0 +1,43 @@
+- job:
+    name: builder-reimage-job
+    project-type: pipeline
+    description: "Pipeline to reimage Jenkins builders and run post-reimage ansible tasks"
+
+    concurrent: false
+
+    parameters:
+      - choice:
+          name: ACTION
+          choices:
+            - reimage
+            - reimage-all
+          default: reimage
+          description: "Reimage action"
+      - string:
+          name: MACHINE
+          default: ""
+          description: "Machine name"
+      - string:
+          name: OS
+          default: ""
+          description: "OS to deploy (optional)"
+      - bool:
+          name: SKIP_REIMAGE
+          default: false
+          description: "Skip reimage and only run post-reimage tasks"
+
+    scm:
+      - git:
+          url: https://github.com/ceph/ceph-build.git
+          branches:
+            - builder-reimage
+          clean: true
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/ceph/ceph-build.git
+            branches:
+              - builder-reimage
+      script-path: builder-reimage/Jenkins-job/prod-jenkins/jenkins-pipeline/build/Jenkinsfile
+      lightweight-checkout: true

--- a/builder-reimage/Jenkins-job/prod-jenkins/maas.conf
+++ b/builder-reimage/Jenkins-job/prod-jenkins/maas.conf
@@ -1,0 +1,2 @@
+[maas]
+maas_url=http://soko02.front.sepia.ceph.com:5240/MAAS

--- a/builder-reimage/Jenkins-job/prod-jenkins/requirements.txt
+++ b/builder-reimage/Jenkins-job/prod-jenkins/requirements.txt
@@ -1,0 +1,8 @@
+requests>=2.31.0
+aiohttp>=3.9.0
+asyncio>=3.4.3
+python-dotenv>=1.0.1
+tabulate>=0.9.0
+cryptography>=36.0.0
+maas>=1.3.2
+python-libmaas>=0.6.8

--- a/builder-reimage/Jenkins-job/prod-jenkins/requirements.txt
+++ b/builder-reimage/Jenkins-job/prod-jenkins/requirements.txt
@@ -6,3 +6,4 @@ tabulate>=0.9.0
 cryptography>=36.0.0
 maas>=1.3.2
 python-libmaas>=0.6.8
+setuptools>=65.0.0

--- a/builder-reimage/Jenkins-job/test-2.jenkins/Jenkins_builder-reimage.py
+++ b/builder-reimage/Jenkins-job/test-2.jenkins/Jenkins_builder-reimage.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+
+"""
+MAAS Reimage Automation Script
+
+Provides:
+- Connect to MAAS
+- Query machines
+- List machines
+- Deploy a machine
+- Reimage a machine
+- Reimage all machines
+- List OS images
+"""
+
+import asyncio
+import argparse
+import configparser
+import sys
+import time
+from datetime import datetime, timezone
+from cryptography.fernet import Fernet
+import os
+
+from maas.client import connect
+from aiohttp.client_exceptions import (
+    ClientConnectorError,
+    ServerDisconnectedError,
+    ClientResponseError,
+    ClientOSError
+)
+
+# -------------------------------------------------------------------------
+# Missing minimal helper functions required by main()
+# -------------------------------------------------------------------------
+
+def load_config():
+    # Prefer Jenkins MAAS_URL env if provided, else fall back to script constant
+    return os.environ.get("MAAS_URL", MAAS_URL)
+
+def load_api_key():
+    return MAAS_API_KEY
+
+def get_machine(client, hostname):
+    """
+    Minimal helper used by wait_online(), returns dict with hostname & status_name.
+    """
+    machines = getattr(client, "_machines_cache", []) or []
+    for m in machines:
+        if m.hostname == hostname:
+            return {
+                "hostname": m.hostname,
+                "status_name": getattr(m, "status_name", None) or getattr(getattr(m, "status", None), "name", "-")
+            }
+    return {"hostname": hostname, "status_name": "Unknown"}
+
+# -------------------------------------------------------------------------
+# Global Defaults
+# -------------------------------------------------------------------------
+
+LOG_FILE_DEFAULT = "maas_reimage.log"
+STATUS_WAIT_TIMEOUT = 1800
+POLL_INTERVAL = 10
+DEFAULT_OWNER = "jitendra" # use --owner to tag manually
+
+# -------------------------------------------------------------------------
+# Small helpers
+# -------------------------------------------------------------------------
+
+def log(msg, log_file=None):
+    """Print message and optionally append to a log file with a timestamp."""
+    print(msg)
+    if log_file:
+        try:
+            with open(log_file, "a") as f:
+                f.write(f"{datetime.now().isoformat()} - {msg}\n")
+        except Exception:
+            print(f"(warning) Unable to write to log file: {log_file}")
+
+def sanitize_owner(name):
+    return name.replace(" ", "_").replace("@", "_")
+
+async def safe_list_tags_for_machine(machine):
+    """
+    Return list of tag objects applied to the machine.
+    Some MAAS clients expose machine.tags as a proxy; the reliable way is:
+    await machine.tags.list()
+    """
+    try:
+        return await machine.tags.list()
+    except Exception:
+        # fallback: try to read machine.tags attribute (may not be useful)
+        mt = getattr(machine, "tags", None)
+        if isinstance(mt, list):
+            return mt
+        return []
+
+def get_normalized_status(machine):
+    """
+    Return lowercased status name using the most reliable available attribute.
+    Handles both `status_name` and `status.name` forms.
+    """
+    status_name = getattr(machine, "status_name", None)
+    if status_name:
+        return str(status_name).lower()
+    status_obj = getattr(machine, "status", None)
+    if status_obj is not None:
+        name = getattr(status_obj, "name", None)
+        if name:
+            return str(name).lower()
+    return ""
+
+# -------------------------------------------------------------------------
+# Configuration (use Jenkins credential via env)
+# -------------------------------------------------------------------------
+MAAS_URL = "http://sepia-maas.front.sepia.ceph.com:5240/MAAS"
+
+# MAAS API key must be supplied by Jenkins as an environment variable named MAAS_API_KEY
+MAAS_API_KEY = os.environ.get("MAAS_API_KEY")
+if not MAAS_API_KEY:
+    print("Error: MAAS_API_KEY environment variable not set. Please configure your Jenkins job to pass the API key as an env var 'MAAS_API_KEY'.")
+    sys.exit(1)
+
+# -------------------------------------------------------------------------
+# MAAS connect with retries
+# -------------------------------------------------------------------------
+
+async def connect_maas(maas_url, api_key, retries=3):
+    """Connect to MAAS with retries and clear error handling."""
+    for attempt in range(1, retries + 1):
+        try:
+            client = await connect(maas_url, apikey=api_key)
+            return client
+        except (ClientConnectorError, ClientOSError) as e:
+            print(f"Connection attempt {attempt} failed: {e}")
+        except ClientResponseError as e:
+            print(f"MAAS server responded with error: {e.status} {e.message}")
+        except asyncio.TimeoutError:
+            print(f"Connection timed out on attempt {attempt}")
+        except ServerDisconnectedError:
+            print(f"Server disconnected unexpectedly (attempt {attempt})")
+        if attempt < retries:
+            print("Retrying in 2 seconds...")
+            await asyncio.sleep(2)
+    print("Error: Unable to connect to MAAS after several attempts.")
+    print("Please check:")
+    print("  • Network or VPN connection")
+    print("  • MAAS server hostname and port")
+    print("  • MAAS service availability")
+    sys.exit(1)
+
+# -------------------------------------------------------------------------
+# Cache + refresh helpers
+# -------------------------------------------------------------------------
+
+async def get_cached_machines(client):
+    """Return a cached copy of client.machines.list() for script lifetime."""
+    if getattr(client, "_machines_cache", None) is None:
+        log("Fetching machines list...")
+        client._machines_cache = await client.machines.list()
+    return client._machines_cache
+
+async def refresh_machine(client, machine):
+    """
+    Refresh machine object. Prefer machine.refresh() if available.
+    """
+    try:
+        ref = getattr(machine, "refresh", None)
+        if callable(ref):
+            maybe = ref()
+            if asyncio.iscoroutine(maybe):
+                await maybe
+            return machine
+    except Exception:
+        pass
+
+    try:
+        return await client.machines.get(system_id=machine.system_id)
+    except Exception:
+        return machine
+
+# -------------------------------------------------------------------------
+# Tag-based ownership helpers
+# -------------------------------------------------------------------------
+
+async def ensure_tag_exists(client, tag_name, log_file=None):
+    """Ensure a tag with `tag_name` exists in MAAS; create it if not."""
+    try:
+        tags = await client.tags.list()
+        if not any(getattr(t, "name", t) == tag_name for t in tags):
+            log(f"Creating tag '{tag_name}'...", log_file)
+            await client.tags.create(name=tag_name)
+        return True
+    except Exception as e:
+        log(f"[ERROR] Unable to ensure tag exists '{tag_name}': {e}", log_file)
+        return False
+
+async def assign_owner_tag(client, machine, owner_name, log_file=None):
+    """
+    Assign owner tag to machine using client.tags.get() and machine.tags.add(tag).
+    Refresh machine after applying tag so later reads see it.
+    """
+    sanitized = sanitize_owner(owner_name)
+    if not await ensure_tag_exists(client, sanitized, log_file):
+        return False
+
+    try:
+        tag = await client.tags.get(name=sanitized)
+        applied = await safe_list_tags_for_machine(machine)
+        applied_names = [getattr(t, "name", None) for t in applied]
+        if sanitized in applied_names:
+            return True
+
+        log(f"Assigning tag '{sanitized}' to {machine.hostname}...", log_file)
+        await machine.tags.add(tag)
+        # Refresh so tag is visible
+        await refresh_machine(client, machine)
+        return True
+    except Exception as e:
+        log(f"[ERROR] Failed to assign tag '{sanitized}' to {getattr(machine, 'hostname', machine)}: {e}", log_file)
+        return False
+
+async def get_owner_from_tags(client, machine, owner_pattern):
+    """
+    Determine owner by checking machine's applied tags.
+    owner_pattern should be sanitized (e.g., DEFAULT_OWNER sanitized).
+    Returns the matching tag name or '-' if none.
+    """
+    try:
+        applied = await safe_list_tags_for_machine(machine)
+        applied_names = [getattr(t, "name", None) for t in applied]
+        if owner_pattern in applied_names:
+            return owner_pattern
+        # try prefix match too
+        for n in applied_names:
+            if n and n.startswith(owner_pattern):
+                return n
+    except Exception:
+        pass
+    return "-"
+
+# -------------------------------------------------------------------------
+# Query Machine
+# -------------------------------------------------------------------------
+
+async def query_machine(client, hostname, log_file=None, quiet=False):
+    """
+    Query machine details and print them.
+    Owner detection is tag-based (matches sanitized DEFAULT_OWNER).
+    """
+    owner_tag = "-"  # initialize to avoid undefined variable on errors
+
+    try:
+        machines = await get_cached_machines(client)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machines list: {e}", log_file)
+        return None
+
+    system_id = None
+    for m in machines:
+        if m.hostname == hostname:
+            system_id = m.system_id
+            break
+
+    if not system_id:
+        log(f"[ERROR] Machine '{hostname}' not found.", log_file)
+        return None
+
+    try:
+        log(f"Fetching details for {hostname}...", log_file)
+        machine = await client.machines.get(system_id=system_id)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machine details: {e}", log_file)
+        return None
+
+    if not quiet:
+        sanitized = sanitize_owner(DEFAULT_OWNER)
+        owner_tag = await get_owner_from_tags(client, machine, sanitized)
+
+        # Fetch all tags applied to this machine for display
+        try:
+            applied = await safe_list_tags_for_machine(machine)
+            tag_names = [getattr(t, "name", None) for t in applied if getattr(t, "name", None)]
+            tags_display = ", ".join(tag_names) if tag_names else "-"
+        except Exception:
+            tags_display = "-"
+
+        # resolve status display
+        status_display = getattr(machine, "status_name", None)
+        if not status_display:
+            st = getattr(machine, "status", None)
+            status_display = getattr(st, "name", "-") if st else "-"
+
+        log("\nMachine Details\n" + "-" * 60, log_file)
+        log(
+            f"Name:             {machine.hostname}\n"
+            f"System ID:        {machine.system_id}\n"
+            f"Status:           {status_display}\n"
+            f"OS Distro:        {getattr(machine, 'distro_series', '-')}\n"
+            f"OS Type:          {getattr(machine, 'osystem', '-')}\n"
+           # f"Owner:            {owner_tag}\n"
+           # f"Tags:             {tags_display}\n"
+            f"Power Type:       {getattr(machine, 'power_type', '-')}\n"
+            f"Power Status:     {getattr(machine, 'power_state', '-')}",
+            log_file
+        )
+
+    return machine
+
+# -------------------------------------------------------------------------
+# List machines / distros
+# -------------------------------------------------------------------------
+
+async def list_machines(client, log_file=None):
+    machines = await get_cached_machines(client)
+    log(f"{'Hostname':20} | {'System ID':10} | {'Status':10} | {'OS':10}", log_file)
+    log("-" * 65, log_file)
+    for m in machines:
+        status_display = getattr(m, "status_name", None) or getattr(getattr(m, "status", None), "name", "-")
+        osname = getattr(m, "distro_series", "-")
+        log(f"{m.hostname:20} | {m.system_id:10} | {status_display:10} | {osname:10}", log_file)
+
+async def list_distros(client, log_file=None):
+    try:
+        log("Fetching available OS images...", log_file)
+        resources = await client.boot_resources.list()
+    except Exception as e:
+        log(f"[ERROR] Unable to list boot resources: {e}", log_file)
+        return
+
+    log(f"{'ID':<5} | {'OS Type':<15} | {'Release':<15} | {'Architecture':<12}", log_file)
+    log("-" * 60, log_file)
+    for r in resources:
+        name = getattr(r, "name", "-")
+        os_type, release = "-", "-"
+        if "/" in name:
+            os_type, release = name.split("/", 1)
+        log(f"{r.id:<5} | {os_type:<15} | {release:<15} | {r.architecture:<12}", log_file)
+
+# -------------------------------------------------------------------------
+# Status polling helper
+# -------------------------------------------------------------------------
+
+async def wait_for_status(client, system_id, expected, timeout=STATUS_WAIT_TIMEOUT):
+    """
+    Wait for a machine to reach the expected state (case-insensitive).
+    """
+    log(f"Waiting for machine {system_id} to reach '{expected}'...", None)
+    start = time.time()
+    poll = 2
+    max_poll = 8
+    expected_l = expected.lower()
+
+    while time.time() - start < timeout:
+        try:
+            m = await client.machines.get(system_id=system_id)
+        except Exception as e:
+            print(f"Error fetching machine {system_id}: {e}")
+            await asyncio.sleep(poll)
+            poll = min(max_poll, poll + 1)
+            continue
+
+        current = get_normalized_status(m)
+        if current == expected_l:
+            log(f"{getattr(m, 'hostname', system_id)} reached expected status: {expected}", None)
+            return True
+
+        await asyncio.sleep(poll)
+        poll = min(max_poll, poll + 1)
+
+    print(f"Timeout waiting for {system_id} to reach {expected}.")
+    return False
+
+# -------------------------------------------------------------------------
+# Deploy machine
+# -------------------------------------------------------------------------
+
+async def deploy_machine(client, machine_ref, os_release=None, log_file=None):
+    """
+    Deploy (reimage) a machine. Accepts hostname (str) or machine object.
+    NOTE: this function assumes owner tag is already applied when called from reimage flow.
+    If user invokes deploy action directly, main() will ensure tag is applied before calling this.
+    """
+    if isinstance(machine_ref, str):
+        # Avoid calling query_machine() (which prints full details) to prevent duplicate fetches.
+        machines = await get_cached_machines(client)
+        found = next((m for m in machines if m.hostname == machine_ref), None)
+        if not found:
+            log(f"[ERROR] Machine '{machine_ref}' not found.", log_file)
+            return False
+        machine = await client.machines.get(system_id=found.system_id)
+    else:
+        machine = machine_ref
+
+    machine = await refresh_machine(client, machine)
+
+    hostname = machine.hostname
+    system_id = machine.system_id
+    status = get_normalized_status(machine)
+
+    if status == "deployed":
+        log(f"[INFO] {hostname} is already deployed.", log_file)
+        return True
+
+    if status in ["failed", "broken", "error", "unknown"]:
+        log(f"[ERROR] {hostname} cannot be reimaged (state: {status}).", log_file)
+        return False
+
+    os_to_use = os_release or getattr(machine, "distro_series", None) or "focal"
+    log(f"[ACTION] Reimaging {hostname} using OS '{os_to_use}'...", log_file)
+
+    try:
+        await machine.deploy(distro_series=os_to_use)
+    except Exception as e:
+        log(f"[ERROR] Failed to trigger reimage for {hostname}: {e}", log_file)
+        return False
+
+    if not await wait_for_status(client, system_id, "deployed"):
+        log(f"[ERROR] Reimage timeout for {hostname}.", log_file)
+        return False
+
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    log(f"[SUCCESS] Reimage completed for {hostname}.", log_file)
+    log(f"[INFO] Deployment timestamp for {hostname}: {ts} IST", log_file)
+    return True
+
+# -------------------------------------------------------------------------
+# Release machine
+# -------------------------------------------------------------------------
+
+async def release_machine(client, machine, log_file=None):
+    status = get_normalized_status(machine)
+    if status != "deployed":
+        return True
+
+    log(f"[ACTION] Releasing {machine.hostname}...", log_file)
+    try:
+        await machine.release()
+        return True
+    except Exception as e:
+        log(f"[ERROR] Failed to release: {e}", log_file)
+        return False
+
+# -------------------------------------------------------------------------
+# Reimage machine
+# -------------------------------------------------------------------------
+
+async def reimage_machine(client, hostname, os_release=None, log_file=None):
+    # First, fetch machine (and print its details)
+    machine = await query_machine(client, hostname, log_file)
+    if not machine:
+        return
+
+    force_flag = getattr(args, "force", False)
+    status = get_normalized_status(machine)
+
+    if force_flag and status == "deploying":
+        log(f"[FORCE] Aborting active deployment for {hostname}...", log_file)
+        try:
+            await machine.abort()
+        except Exception as e:
+            log(f"[ERROR] Unable to abort deployment for {hostname}: {e}", log_file)
+            return
+
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after abort.", log_file)
+            return
+
+        log(f"[FORCE] Deployment aborted. Releasing {hostname}...", log_file)
+        try:
+            await machine.release()
+        except Exception:
+            pass
+
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after forced release.", log_file)
+            return
+
+        machine = await refresh_machine(client, machine)
+
+    # Ensure owner tag is applied (only once here)
+    if not await assign_owner_tag(client, machine, DEFAULT_OWNER, log_file):
+        return
+
+    # choose OS
+    current_os = getattr(machine, "distro_series", None)
+    if os_release:
+        os_to_use = os_release
+    elif current_os:
+        os_to_use = current_os
+    else:
+        log(f"[ERROR] No OS detected for machine '{hostname}'. Provide --os.", log_file)
+        return
+
+    # if deployed -> release then wait for Ready
+    status = get_normalized_status(machine)
+    if status == "deployed":
+        log(f"[ACTION] Releasing {machine.hostname} for reimage...", log_file)
+        if not await release_machine(client, machine, log_file):
+            return
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after release.", log_file)
+            return
+        machine = await refresh_machine(client, machine)
+
+    # trigger deploy (deploy_machine will not re-assign tag)
+    if await deploy_machine(client, hostname, os_to_use, log_file):
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        log(f"[SUCCESS] Reimage completed for {hostname}.", log_file)
+        log(f"[INFO] Reimage timestamp for {hostname}: {ts} IST", log_file)
+        # print detected OS for downstream consumption (simple marker)
+        print(f"DETECTED_OS={os_to_use}")
+
+# -------------------------------------------------------------------------
+# Reimage all machines
+# -------------------------------------------------------------------------
+
+async def reimage_all(client, os_release=None, log_file=None):
+    try:
+        machines = await get_cached_machines(client)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machines list: {e}", log_file)
+        return
+
+    for m in machines:
+        hostname = m.hostname
+        target_os = os_release or getattr(m, "distro_series", "focal")
+        log(f"[INFO] Starting reimage for {hostname}", log_file)
+        try:
+            await reimage_machine(client, hostname, target_os, log_file)
+        except Exception as e:
+            log(f"[ERROR] Reimage error for {hostname}: {e}", log_file)
+
+# -------------------------------------------------------------------------
+# Find last deployed
+# -------------------------------------------------------------------------
+
+async def find_last_deployed_machine(client):
+    try:
+        machines = await get_cached_machines(client)
+    except Exception:
+        return None
+
+    time_fields = [
+        "deployed_at", "deployment_finished_at", "deployment_completed",
+        "deployment_started", "deployment_started_at"
+    ]
+
+    candidates = []
+    for m in machines:
+        status = get_normalized_status(m)
+        if status != "deployed":
+            continue
+
+        timestamp = None
+        for field in time_fields:
+            val = getattr(m, field, None)
+            if val:
+                try:
+                    if isinstance(val, str):
+                        val = val.replace("Z", "+00:00")
+                        timestamp = datetime.fromisoformat(val)
+                    elif isinstance(val, datetime):
+                        timestamp = val
+                except Exception:
+                    continue
+        if timestamp:
+            candidates.append((timestamp, m))
+
+    if candidates:
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        return candidates[0][1]
+
+    for m in machines:
+        if get_normalized_status(m) == "deployed":
+            return m
+
+    return None
+
+# -------------------------------------------------------------------------
+# wait_online
+#
+# This feature is dedicately added for Jenkins job only
+# because:
+#    After triggering MAAS reimage, machines enter deploying or rebooting state.
+#    Jenkins or MAAS does not guarantee immediate readiness.
+#    So a wait/poll function is required to safely run ansible afterwards. 
+# -------------------------------------------------------------------------
+
+def wait_online(client, machine_name, timeout=1800, interval=20):
+    """
+    Poll MAAS for machine status until it's Deploying / Running / Ready.
+    """
+    import time
+
+    allowed_statuses = ["Deployed", "Ready", "Running"]
+
+    start = time.time()
+    while True:
+        machine = get_machine(client, machine_name)
+        status_name = machine.get("status_name", "")
+
+        print(f"[wait_online] {machine_name} status: {status_name}")
+
+        if status_name in allowed_statuses:
+            print(f"[wait_online] Machine {machine_name} is online and ready.")
+            return
+
+        if time.time() - start > timeout:
+            print(f"[wait_online] Timeout reached ({timeout}s). Machine not ready.")
+            sys.exit(1)
+
+        time.sleep(interval)
+
+
+# -------------------------------------------------------------------------
+# Main
+# -------------------------------------------------------------------------
+
+async def main():
+    global args
+    global DEFAULT_OWNER
+
+    parser = argparse.ArgumentParser(description="MAAS Reimage Automation Script")
+    parser.add_argument("--action", required=True,
+                        choices=[
+                            "list", "list-distros", "query", "status",
+                            "deploy", "reimage", "reimage-all", "last-deployed", "wait_online"
+                        ])
+    parser.add_argument("--machine", help="Hostname for query, deploy, or reimage")
+    parser.add_argument("--os", help="Target OS release")
+    parser.add_argument("--log-file", help="Path to log file")
+    parser.add_argument("--force", action="store_true",
+                        help="Force reimage even if machine is deploying")
+    parser.add_argument("--owner", help="Owner username (fallback: DEFAULT_OWNER)")
+
+    args = parser.parse_args()
+
+    if args.owner:
+        DEFAULT_OWNER = args.owner
+
+    maas_url = load_config()
+    api_key = load_api_key()
+
+    client = await connect_maas(maas_url, api_key)
+
+    # initialize cache immediately
+    try:
+        client._machines_cache = await client.machines.list()
+    except Exception:
+        client._machines_cache = None
+
+    log_file = args.log_file or LOG_FILE_DEFAULT
+
+    if args.action == "list":
+        await list_machines(client, log_file)
+
+    elif args.action == "query":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await query_machine(client, args.machine, log_file)
+
+    elif args.action == "status":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await query_machine(client, args.machine, log_file)
+
+    elif args.action == "list-distros":
+        await list_distros(client, log_file)
+
+    elif args.action == "deploy":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            # ensure owner tag when user runs deploy directly
+            # fetch machine object (no extra printed details)
+            machines = await get_cached_machines(client)
+            found = next((m for m in machines if m.hostname == args.machine), None)
+            if not found:
+                log(f"[ERROR] Machine '{args.machine}' not found.", log_file)
+            else:
+                machine_obj = await client.machines.get(system_id=found.system_id)
+                await assign_owner_tag(client, machine_obj, DEFAULT_OWNER, log_file)
+                await deploy_machine(client, args.machine, args.os, log_file)
+
+    elif args.action == "reimage":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await reimage_machine(client, args.machine, args.os, log_file)
+
+    elif args.action == "reimage-all":
+        await reimage_all(client, args.os, log_file)
+    
+    elif args.action == "wait_online":
+        wait_online(client, args.machine)
+
+    elif args.action == "last-deployed":
+        machine = await find_last_deployed_machine(client)
+        if machine:
+            log(f"Last deployed machine: {machine.hostname} ({machine.system_id})", log_file)
+        else:
+            log("No deployed machines found.", log_file)
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("Interrupted by user.")
+    except Exception as e:
+        print(f"Fatal error: {e}")

--- a/builder-reimage/Jenkins-job/test-2.jenkins/bootstrap_env.sh
+++ b/builder-reimage/Jenkins-job/test-2.jenkins/bootstrap_env.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -e
+
+# -----------------------------------------------------------------------------
+# Script Name: bootstrap_env.sh
+# Description:
+#   Bootstraps the local Python environment for running the MAAS reimage script.
+#   - Installs MAAS CLI (Linux/macOS)
+#   - Creates Python virtual environment
+#   - Installs dependencies
+# -----------------------------------------------------------------------------
+
+echo "Starting environment setup..."
+
+# -----------------------------------------------------------------------------
+# Step 1: Install MAAS CLI based on OS
+# -----------------------------------------------------------------------------
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Detect Linux distribution
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        DISTRO=$ID
+    else
+        DISTRO="unknown"
+    fi
+
+    echo "Detected Linux distribution: $DISTRO"
+
+    case "$DISTRO" in
+        ubuntu|debian)
+            echo "Installing MAAS CLI (Debian/Ubuntu)..."
+            sudo apt update -y
+            sudo apt install -y maas-cli 
+            ;;
+        rhel|centos|fedora|rocky|almalinux)
+            echo "Installing MAAS CLI (RHEL/CentOS/Fedora)..."
+            # Ensure EPEL repo is enabled for dependencies
+            if command -v dnf >/dev/null 2>&1; then
+                sudo dnf install -y epel-release || true
+                sudo dnf install -y snapd 
+            else
+                sudo yum install -y epel-release || true
+                sudo yum install -y snapd
+            fi
+
+            # Enable and use snap to install MAAS CLI
+            sudo systemctl enable --now snapd.socket
+            sudo ln -sf /var/lib/snapd/snap /snap
+            echo "Installing MAAS CLI via snap..."
+            sudo snap install maas --classic
+            ;;
+        *)
+            echo "Unsupported Linux distribution: $DISTRO"
+            echo "Please install MAAS CLI manually."
+            exit 1
+            ;;
+    esac
+
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Installing MAAS CLI (macOS)..."
+    brew install maas || true
+else
+    echo "Unsupported OS type: $OSTYPE"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Step 2: Create and activate Python virtual environment
+# -----------------------------------------------------------------------------
+echo "Creating Python virtual environment..."
+python3 -m venv .venv
+source .venv/bin/activate
+
+echo "Installing Python dependencies..."
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# -----------------------------------------------------------------------------
+# Step 3: Check for encrypted secrets
+# -----------------------------------------------------------------------------
+if [[ ! -f "maas_api.key" || ! -f "maas_api_key.encrypted" ]]; then
+    echo "Missing 'maas_api.key' or 'maas_api_key.encrypted'. Ensure both files are present."
+    exit 1
+fi
+
+echo
+echo "Setup complete."

--- a/builder-reimage/Jenkins-job/test-2.jenkins/jenkins-pipeline/build/Jenkinsfile
+++ b/builder-reimage/Jenkins-job/test-2.jenkins/jenkins-pipeline/build/Jenkinsfile
@@ -1,0 +1,211 @@
+pipeline {
+    agent { label 'sepia' }
+
+    environment {
+        VENV_DIR    = ".venv"
+        REPO_DIR    = "${WORKSPACE}/Jenkins-job/test-2.jenkins"
+        VENV_PATH   = "${REPO_DIR}/${VENV_DIR}"
+        WORK_DIR    = "${WORKSPACE}/ci-work"
+        DOMAIN      = "front.sepia.ceph.com"
+    }
+
+    parameters {
+        booleanParam(name: 'SKIP_REIMAGE', defaultValue: false, description: 'Skip reimage stage and run only post-reimage tasks')
+        choice(name: 'ACTION', choices: ['reimage','reimage-all','wait_online'], description: 'Action to perform')
+        string(name: 'MACHINE', defaultValue: '', description: 'Machine shortname (e.g. irvingi08)')
+        string(name: 'OS', defaultValue: '', description: 'OS to deploy (optional). Example: jammy, focal')
+    }
+
+    stages {
+
+        /* ---------------------------------------------------------------------
+           Stage 1: Setup Python Virtual Environment
+        --------------------------------------------------------------------- */
+        stage('Setup Python Virtual Environment') {
+            steps {
+                withCredentials([string(credentialsId: 'maas-api-key', variable: 'MAAS_API_KEY')]) {
+                    sh '''#!/bin/bash
+                        set -euo pipefail
+                        cd "$REPO_DIR"
+
+                        if [ -d "$VENV_PATH" ]; then
+                            echo "Removing incompatible virtual environment..."
+                            rm -rf "$VENV_PATH"
+                        fi
+
+                        python3 -m venv "$VENV_PATH"
+                        source "$VENV_PATH/bin/activate"
+
+                        pip install --upgrade pip
+                        pip install -r requirements.txt
+                    '''
+                }
+            }
+        }
+
+        /* ---------------------------------------------------------------------
+           Stage 2: Reimage Builder
+        --------------------------------------------------------------------- */
+        stage('Reimage Builder') {
+            when { expression { return params.SKIP_REIMAGE == false } }
+            steps {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    withCredentials([string(credentialsId: 'maas-api-key', variable: 'MAAS_API_KEY')]) {
+
+                        sh '''#!/bin/bash
+                            set -euo pipefail
+
+                            OS="${OS:-}"
+
+                            cd "$REPO_DIR"
+                            source "$VENV_PATH/bin/activate"
+
+                            if [ -z "${MACHINE}" ]; then
+                                echo "Error: MACHINE parameter is required."
+                                exit 1
+                            fi
+
+                            CMD="python Jenkins_builder-reimage.py --action ${ACTION} --machine ${MACHINE}"
+
+                            if [ -n "${OS}" ]; then
+                                CMD="$CMD --os ${OS}"
+                            fi
+
+                            echo "Running builder command:"
+                            echo "$CMD"
+
+                            OUTPUT=$(eval $CMD | tee /tmp/reimage-output.txt)
+                            echo "$OUTPUT"
+
+                            # Extract detected machine OS (if produced by script)
+                            DETECTED_OS=$(grep -oP '^DETECTED_OS=\\K.*' /tmp/reimage-output.txt || true)
+                            echo "DETECTED_OS=${DETECTED_OS}"
+
+                            # Persist to workspace for next stages
+                            echo "DETECTED_OS=${DETECTED_OS}" > "$WORKSPACE/detected_os.env"
+                        '''
+                    }
+                }
+            }
+        }
+
+        /* ---------------------------------------------------------------------
+           Stage 3: Wait for Ready/Deployed
+        --------------------------------------------------------------------- */
+        stage('Wait for Ready/Deployed') {
+            when {
+                allOf {
+                    expression { return params.SKIP_REIMAGE == false }
+                    expression { return currentBuild.currentResult == 'SUCCESS' }
+                }
+            }
+            steps {
+                withCredentials([string(credentialsId: 'maas-api-key', variable: 'MAAS_API_KEY')]) {
+                    script {
+                        sh '''#!/bin/bash
+                            set -euo pipefail
+                            cd "$REPO_DIR"
+                            source "$VENV_PATH/bin/activate"
+
+                            python Jenkins_builder-reimage.py --action wait_online --machine ${MACHINE}
+                        '''
+                    }
+                }
+            }
+        }
+
+        /* ---------------------------------------------------------------------
+           Stage 4: Post Reimage Tasks
+        --------------------------------------------------------------------- */
+        stage('Post Reimage Tasks') {
+            when {
+                allOf {
+                    expression { return currentBuild.currentResult == 'SUCCESS' }
+                }
+            }
+            steps {
+                withCredentials([
+                    string(credentialsId: 'builder-api-token', variable: 'BUILDER_TOKEN'),
+                    string(credentialsId: 'ansible-vault-pass', variable: 'VAULT_PASS'),
+                    sshUserPrivateKey(credentialsId: 'ansible-ssh-key', keyFileVariable: 'SSH_KEY')
+                ]) {
+
+                    sh '''#!/bin/bash
+                        set -euo pipefail
+
+                        ########################################################
+                        # SAFE LOAD OF DETECTED_OS — prevents "unbound variable"
+                        ########################################################
+                        if [ -f "${WORKSPACE}/detected_os.env" ]; then
+                            source "${WORKSPACE}/detected_os.env"
+                        else
+                            echo "[WARN] detected_os.env not found — using OS parameter instead."
+                            DETECTED_OS="${OS:-}"
+                        fi
+
+                        : "${DETECTED_OS:=}"   # guarantee defined, even if empty
+                        echo "Using DETECTED_OS=${DETECTED_OS}"
+                        ########################################################
+
+                        cd "$REPO_DIR"
+
+                        # Build FQDN
+                        if [ -z "${MACHINE}" ]; then
+                            echo "Error: MACHINE parameter is required."
+                            exit 1
+                        fi
+                        TARGET_FQDN="${MACHINE}.${DOMAIN}"
+                        echo "FQDN = ${TARGET_FQDN}"
+
+                        mkdir -p "${WORK_DIR}"
+
+                        # SSH key for Git clones
+                        cp "${SSH_KEY}" /tmp/jenkins_git_key
+                        chmod 600 /tmp/jenkins_git_key
+
+                        ########################################################
+                        # Vault password file
+                        ########################################################
+                        VAULT_FILE="/home/jenkins-build/.vault_pass.txt"
+                        TMP_FILE="$(mktemp /tmp/vault.XXXXXX)"
+                        umask 077
+                        printf "%s" "${VAULT_PASS}" > "${TMP_FILE}"
+                        mv -f "${TMP_FILE}" "${VAULT_FILE}"
+                        chmod 600 "${VAULT_FILE}"
+
+                        ########################################################
+                        # prepare_env
+                        ########################################################
+                        cd "$WORKSPACE/Jenkins-job/test-2.jenkins/jenkins-pipeline/build"
+                        bash scripts/prepare_env.sh "${TARGET_FQDN}" "${WORK_DIR}" true \
+                            git@github.com:ceph/ceph-build.git \
+                            git@github.com:ceph/ceph-cm-ansible.git \
+                            git@github.com:ceph/ceph-sepia-secrets.git
+
+                        ########################################################
+                        # ansible_runner.sh (NOTE: VENV_DIR not VENV_PATH)
+                        ########################################################
+                        cd "$WORKSPACE/Jenkins-job/test-2.jenkins/jenkins-pipeline/build"
+                        bash scripts/ansible_runner.sh \
+                            "${TARGET_FQDN}" \
+                            "${WORK_DIR}" \
+                            "${VENV_DIR}" \
+                            "${DETECTED_OS}" \
+                            "${BUILDER_TOKEN}" \
+                            "${VAULT_PASS}"
+                    '''
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            sh 'rm -f /home/jenkins-build/.vault_pass.txt || true'
+            echo 'Build finished!'
+        }
+        failure {
+            echo 'Build failed!'
+        }
+    }
+}

--- a/builder-reimage/Jenkins-job/test-2.jenkins/jenkins-pipeline/build/scripts/ansible_runner.sh
+++ b/builder-reimage/Jenkins-job/test-2.jenkins/jenkins-pipeline/build/scripts/ansible_runner.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ansible_runner.sh
+#
+# Usage:
+#   ansible_runner.sh <target_fqdn> <work_dir> <venv_dir> <os> <builder_token>
+
+TARGET_FQDN="$1"
+WORK_DIR="$2"
+VENV_DIR="$3"
+OS_VALUE="${4,,}"        # normalize OS → lowercase (can be empty)
+BUILDER_TOKEN="$5"
+
+ANSIBLE_DIR="${WORK_DIR}/repos/ansible"
+MAIN_DIR="${WORK_DIR}/repos/main"
+LOG_DIR="${WORK_DIR}/ansible-logs"
+
+# Vault now ALWAYS comes from this file (created by Jenkinsfile)
+VAULT_FILE="/home/jenkins-build/.vault_pass.txt"
+VAULT_ARG="--vault-password-file=${VAULT_FILE}"
+
+mkdir -p "${LOG_DIR}"
+
+##############################################
+# Activate virtualenv if present
+##############################################
+if [[ -f "${WORK_DIR}/${VENV_DIR}/bin/activate" ]]; then
+    echo "[ansible_runner] Activating venv: ${WORK_DIR}/${VENV_DIR}"
+    # shellcheck disable=SC1090
+    source "${WORK_DIR}/${VENV_DIR}/bin/activate"
+else
+    echo "[ansible_runner] WARNING: venv not found at ${WORK_DIR}/${VENV_DIR}. Continuing without venv."
+fi
+
+##############################################
+# Determine SSH user based on OS
+##############################################
+if [[ "$OS_VALUE" =~ (rhel|centos|rocky|almai|9-stream|rhel10|centos70|8) ]]; then
+    SSH_USER="cloud-user"
+else
+    SSH_USER="ubuntu"
+fi
+
+echo "[ansible_runner] SSH user selected = ${SSH_USER}"
+
+##############################################
+# Admin user JSON builder
+##############################################
+ADMIN_USERS=(
+  "akraitma"
+  "dgalloway"
+  "dmick"
+  "falcocer"
+  "jitendra"
+  "zack"
+)
+
+build_admin_users_json() {
+    local json='{"managed_admin_users":['
+    for u in "${ADMIN_USERS[@]}"; do
+        json+="{\"name\":\"${u}\"},"
+    done
+    json="${json%,}]}"
+    echo "${json}"
+}
+
+##############################################
+# Playbook runner with retries (3 attempts)
+##############################################
+run_playbook() {
+    local pb_name="$1"
+    local cmd="$2"
+    local logfile="${LOG_DIR}/${TARGET_FQDN}-${pb_name}.log"
+
+    echo "[ansible_runner] Running ${pb_name} -> ${logfile}"
+
+    attempts=0
+    max_attempts=3
+
+    until [[ $attempts -ge $max_attempts ]]; do
+        attempts=$((attempts + 1))
+
+        eval "${cmd}" 2>&1 | tee "${logfile}"
+        rc=${PIPESTATUS[0]}
+
+        if [[ $rc -eq 0 ]]; then
+            echo "[ansible_runner] ${pb_name} succeeded on attempt ${attempts}"
+            return
+        fi
+
+        echo "[ansible_runner] ${pb_name} failed (rc=${rc}), attempt ${attempts}/${max_attempts}"
+
+        if [[ $attempts -lt $max_attempts ]]; then
+            sleep $((attempts * 10))
+        else
+            echo "[ansible_runner] Max attempts reached for ${pb_name}; failing"
+            exit "${rc}"
+        fi
+    done
+}
+
+##############################################
+# PLAYBOOK 1 — ansible_managed.yml
+# (NO VAULT)
+##############################################
+(
+  cd "${ANSIBLE_DIR}"
+
+  CMD="ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook ansible_managed.yml \
+        --limit='${TARGET_FQDN}' \
+        -e ansible_ssh_user='${SSH_USER}'"
+
+  run_playbook "play1-ansible_managed" "${CMD}"
+)
+
+##############################################
+# PLAYBOOK 2 — users.yml
+# (NO VAULT)
+##############################################
+(
+  cd "${ANSIBLE_DIR}"
+
+  ADMIN_USERS_JSON="$(build_admin_users_json)"
+
+  CMD="ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook users.yml -v \
+        --limit='${TARGET_FQDN}' \
+        --tags='user,pubkeys' \
+        --extra-vars='${ADMIN_USERS_JSON}'"
+
+  run_playbook "play2-users" "${CMD}"
+)
+
+##############################################
+# PLAYBOOK 3 — jenkins-builder-disk.yml
+# (NO VAULT)
+##############################################
+(
+  cd "${ANSIBLE_DIR}"
+
+  CMD="ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -vvv tools/jenkins-builder-disk.yml \
+        --limit='${TARGET_FQDN}'"
+
+  run_playbook "play3-tools-disk" "${CMD}"
+)
+
+##############################################
+# PLAYBOOK 4 — builder.yml
+# (USES VAULT)
+##############################################
+(
+  cd "${MAIN_DIR}/ansible"
+
+  CMD="ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -vvv \
+        ${VAULT_ARG} \
+        -M ./library/ \
+        examples/builder.yml \
+        -e '{\"token\":\"${BUILDER_TOKEN}\", \"jenkins_credentials_uuid\":\"jenkins-build\", \"api_uri\":\"https://jenkins.ceph.com\"}' \
+        -e permanent=true \
+        --limit='${TARGET_FQDN}'"
+
+  run_playbook "play4-main-builder" "${CMD}"
+)
+
+##############################################
+# PLAYBOOK 5 — grafana_agent.yml
+# (NO VAULT)
+##############################################
+#(
+#  cd "${ANSIBLE_DIR}"
+#
+#  CMD="ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -vvv \
+#        grafana_agent.yml \
+#        --limit='${TARGET_FQDN}'"
+#
+#  run_playbook "play5-grafana" "${CMD}"
+#)
+echo "[ansible_runner] All playbooks completed successfully for ${TARGET_FQDN}"

--- a/builder-reimage/Jenkins-job/test-2.jenkins/jenkins-pipeline/build/scripts/prepare_env.sh
+++ b/builder-reimage/Jenkins-job/test-2.jenkins/jenkins-pipeline/build/scripts/prepare_env.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# prepare_env.sh
+# Usage:
+#   prepare_env.sh <target_fqdn> <work_dir> <ssh_available> <ansible_repo> <main_repo> <secrets_repo>
+#
+# Example:
+#   prepare_env.sh irvingi04.front.sepia.ceph.com /var/lib/jenkins/ci-work true git@github.com:org/repo-ansible.git ...
+
+TARGET_FQDN="$1"
+WORK_DIR="$2"
+SSH_AVAILABLE="${3:-false}"
+MAIN_REPO="${4:-git@github.com:ceph/ceph-build.git}"  ## ceph-build
+ANSIBLE_REPO="${5:-git@github.com:ceph/ceph-cm-ansible.git}" ## ceph-ci-ansible
+SECRETS_REPO="${6:-git@github.com:ceph/ceph-sepia-secrets.git}" ## ceph-sepia-secrets
+
+SHORTNAME="${TARGET_FQDN%%.*}"
+
+REPOS_DIR="${WORK_DIR}/repos"
+ANSIBLE_DIR="${REPOS_DIR}/ansible"
+MAIN_DIR="${REPOS_DIR}/main"
+SECRETS_DIR="${REPOS_DIR}/secret-repo"
+VENV_DIR="${WORK_DIR}/.venv"
+
+mkdir -p "${REPOS_DIR}"
+cd "${REPOS_DIR}"
+
+log() { echo "[prepare_env] $*"; }
+
+adjust_url() {
+  local url="$1"
+  if [ "${SSH_AVAILABLE}" = "true" ]; then
+    echo "${url}"
+  else
+    # convert git@github.com:org/repo.git -> https://github.com/org/repo.git
+    echo "${url}" | sed 's|git@github.com:|https://github.com/|'
+  fi
+}
+
+clone_repo() {
+  local url="$1"
+  local dir="$2"
+  if [ -d "${dir}/.git" ]; then
+    log "Updating existing repo ${dir}"
+    (cd "${dir}" && git fetch --all --prune)
+  else
+    log "Cloning ${url} -> ${dir}"
+    if [ "${SSH_AVAILABLE}" = "true" ] && [ -f /tmp/jenkins_git_key ]; then
+      GIT_SSH_COMMAND='ssh -i /tmp/jenkins_git_key -o StrictHostKeyChecking=no' git clone --depth 1 "${url}" "${dir}"
+    else
+      git clone --depth 1 "${url}" "${dir}"
+    fi
+  fi
+}
+
+ANSIBLE_URL=$(adjust_url "${ANSIBLE_REPO}")
+MAIN_URL=$(adjust_url "${MAIN_REPO}")
+SECRETS_URL=$(adjust_url "${SECRETS_REPO}")
+
+clone_repo "${ANSIBLE_URL}" "${ANSIBLE_DIR}"
+clone_repo "${MAIN_URL}" "${MAIN_DIR}"
+clone_repo "${SECRETS_URL}" "${SECRETS_DIR}"
+
+# Ensure venv exists (created by Jenkinsfile in WORK_DIR). If not, create here.
+if [ ! -d "${VENV_DIR}/bin" ]; then
+  log "Virtualenv not found at ${VENV_DIR}, creating..."
+  python3 -m venv "${VENV_DIR}"
+  source "${VENV_DIR}/bin/activate"
+  pip install --upgrade pip
+  pip install -r "${ANSIBLE_DIR}/requirements.txt" 2>/dev/null || true
+else
+  source "${VENV_DIR}/bin/activate"
+fi
+
+# Check ansible installation in venv or system
+if command -v ansible-playbook >/dev/null 2>&1; then
+  log "Ansible already installed."
+else
+  log "Ansible not found, attempting to install into venv..."
+
+  # Determine package manager depending on OS
+  install_ansible_system() {
+    if command -v apt-get >/dev/null 2>&1; then
+      log "Detected apt-based system. Installing ansible..."
+      sudo apt-get update && sudo apt-get install -y ansible || true
+
+    elif command -v dnf >/dev/null 2>&1; then
+      log "Detected dnf-based system (RHEL8+/Rocky/Alma). Installing ansible-core..."
+      sudo dnf install -y ansible-core || sudo dnf install -y ansible || true
+
+    elif command -v yum >/dev/null 2>&1; then
+      log "Detected yum-based system (RHEL7/CentOS7). Installing ansible..."
+      sudo yum install -y ansible || true
+
+    else
+      log "No supported package manager found. Cannot install ansible."
+    fi
+  }
+
+  if [ -n "${VENV_DIR}" ] && [ -f "${VENV_DIR}/bin/activate" ]; then
+    pip install ansible || {
+      log "Failed to install ansible in venv; trying system install (requires sudo)"
+      install_ansible_system
+    }
+  else
+    log "No venv available; attempting system install (requires sudo)"
+    install_ansible_system
+  fi
+fi
+
+# Create idempotent symlinks for /etc/ansible/secrets and /etc/ansible/hosts
+ensure_symlink() {
+  local src="$1"
+  local dst="$2"
+  if [ -L "${dst}" ]; then
+    log "Symlink ${dst} already exists"
+    return 0
+  fi
+  if [ -e "${dst}" ]; then
+    log "Target ${dst} exists and is not a symlink — leaving it untouched"
+    return 0
+  fi
+  # ensure parent directory exists
+  sudo mkdir -p "$(dirname "${dst}")"
+  sudo ln -s "${src}" "${dst}"
+  log "Created symlink ${dst} -> ${src}"
+}
+
+# Ensure /etc/ansible exists
+sudo mkdir -p /etc/ansible || true
+
+sudo rm -f /etc/ansible/secrets
+ensure_symlink "${SECRETS_DIR}/ansible/secrets" "/etc/ansible/secrets"
+sudo rm -f /etc/ansible/hosts
+ensure_symlink "${SECRETS_DIR}/ansible/inventory" "/etc/ansible/hosts"
+
+# Optional: Warn if target FQDN is not present in inventory file
+if ! grep -q -E "^${TARGET_FQDN}\\b" /etc/ansible/hosts 2>/dev/null; then
+  log "Warning: ${TARGET_FQDN} not found in /etc/ansible/hosts. Ensure dynamic inventory or update inventory."
+fi
+
+log "prepare_env completed for ${TARGET_FQDN} (shortname=${SHORTNAME})"

--- a/builder-reimage/Jenkins-job/test-2.jenkins/jenkins-pipeline/config/definitions/builder-reimage-pipeline.yml
+++ b/builder-reimage/Jenkins-job/test-2.jenkins/jenkins-pipeline/config/definitions/builder-reimage-pipeline.yml
@@ -1,0 +1,43 @@
+- job:
+    name: builder-reimage-job
+    project-type: pipeline
+    description: "Pipeline to reimage Jenkins builders and run post-reimage ansible tasks"
+
+    concurrent: false
+
+    parameters:
+      - choice:
+          name: ACTION
+          choices:
+            - reimage
+            - reimage-all
+          default: reimage
+          description: "Reimage action"
+      - string:
+          name: MACHINE
+          default: ""
+          description: "Machine name"
+      - string:
+          name: OS
+          default: ""
+          description: "OS to deploy (optional)"
+      - bool:
+          name: SKIP_REIMAGE
+          default: false
+          description: "Skip reimage and only run post-reimage tasks"
+
+    scm:
+      - git:
+          url: https://github.com/jitendrasahu1803/builder-reimage.git
+          branches:
+            - main
+          clean: true
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/jitendrasahu1803/builder-reimage.git
+            branches:
+              - main
+      script-path: Jenkins-job/test-2.jenkins/jenkins-pipeline/build/Jenkinsfile
+      lightweight-checkout: true

--- a/builder-reimage/Jenkins-job/test-2.jenkins/maas.conf
+++ b/builder-reimage/Jenkins-job/test-2.jenkins/maas.conf
@@ -1,0 +1,2 @@
+[maas]
+maas_url=http://sepia-maas.front.sepia.ceph.com:5240/MAAS

--- a/builder-reimage/Jenkins-job/test-2.jenkins/requirements.txt
+++ b/builder-reimage/Jenkins-job/test-2.jenkins/requirements.txt
@@ -1,0 +1,8 @@
+requests>=2.31.0
+aiohttp>=3.9.0
+asyncio>=3.4.3
+python-dotenv>=1.0.1
+tabulate>=0.9.0
+cryptography>=36.0.0
+maas>=1.3.2
+python-libmaas>=0.6.8

--- a/builder-reimage/README.md
+++ b/builder-reimage/README.md
@@ -1,0 +1,123 @@
+# Builder Reimage
+
+Builder Reimage is a lightweight automation utility for interacting with **MAAS (Metal as a Service)**.  
+It allows you to list, query, check status, and redeploy machines efficiently, with or without specifying an operating system.
+
+This script simplifies MAAS machine management tasks and helps maintain consistent environment setups through a command-line interface.
+
+---
+
+## Features
+- List all managed MAAS machines  
+- Query machine details  
+- Check deployment or power status  
+- Redeploy single or multiple machines  
+- Redeploy with or without specifying an OS version  
+
+---
+
+## Requirements
+- Python 3.8 or higher  
+- MAAS CLI installed and configured  
+- Valid MAAS API credentials
+
+---
+
+## Cloning the Repository
+
+To get started, clone the repository and navigate into the project directory:
+
+```bash
+git clone https://github.com/jitendrasahu1803/builder-reimage.git
+
+cd builder-reimage
+```
+
+## Setup your environment to use the tool
+
+Run bootstrap script:
+```bash
+bash bootstrap_env.sh
+```
+Active your virtual environment:
+```bash
+source .venv/bin/activate
+```
+Edit ```bash maas.conf``` file and update it with the correct MAAS URL (Sepia/Tucson):
+```bash
+cat maas.conf
+[maas]
+maas_url=http://<Enter_MAAS_URL>/MAAS
+```
+To setup your credential to connect with MAAS API, run (Replace <YOUR_MAAS_API_KEY> with your actual MAAS API key):
+```bash
+echo -n "<YOUR_MAAS_API_KEY>" | python3 -c 'import sys; from cryptography.fernet import Fernet; key=Fernet.generate_key(); open("maas_api.key","wb").write(key); data=sys.stdin.buffer.read(); open("maas_api_key.encrypted","wb").write(Fernet(key).encrypt(data)); print("wrote: maas_api.key and maas_api_key.encrypted")'
+```
+---
+
+## Usage
+Activate your virtual environment (if not already active), then run:
+```bash
+python3 maas-reimage.py [OPTIONS]
+```
+
+## Examples
+List all machines
+```bash
+--action list
+```
+Query details for one machine
+```bash
+--action query --machine node01
+```
+Check machine status
+```bash
+--action status --machine node01
+```
+Deploy a machine with a specific OS:
+```bash
+--action deploy --machine node01 --os 9.6
+```
+Reimage one machine (same OS)
+```bash
+--action reimage --machine node01
+```
+Reimage one machine with a specific OS
+```bash
+--action reimage --machine node01 --os jammy
+```
+Redeploy all machines
+```bash
+--action reimage-all
+```
+Redeploy all machines with a specific OS
+```bash
+--action reimage-all --os jammy
+```
+Find last deployed machine
+```bash
+--action last-deployed
+```
+
+## Additional option of (--owner)
+
+When you deploy or reimage a machine, it is automatically tagged with the default owner ```jitendra```. If you want to assign a different owner, you can specify it using the option shown below.
+
+Reimage a machine with a custom owner tag:
+```bash
+--action reimage --machine node01 --owner "<owner_name>"
+```
+
+This option works for deploy, reimage, reimage_all, and all other relevant commands.
+
+---
+
+## Author
+
+Jitendra Sahu
+
+GitHub: jitendrasahu1803
+
+## License
+
+This project is licensed under the MIT License.

--- a/builder-reimage/bootstrap_env.sh
+++ b/builder-reimage/bootstrap_env.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -e
+
+# -----------------------------------------------------------------------------
+# Script Name: bootstrap_env.sh
+# Description:
+#   Bootstraps the local Python environment for running the MAAS reimage script.
+#   - Installs MAAS CLI (Linux/macOS)
+#   - Creates Python virtual environment
+#   - Installs dependencies
+# -----------------------------------------------------------------------------
+
+echo "Starting environment setup..."
+
+# -----------------------------------------------------------------------------
+# Step 1: Install MAAS CLI based on OS
+# -----------------------------------------------------------------------------
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Detect Linux distribution
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        DISTRO=$ID
+    else
+        DISTRO="unknown"
+    fi
+
+    echo "Detected Linux distribution: $DISTRO"
+
+    case "$DISTRO" in
+        ubuntu|debian)
+            echo "Installing MAAS CLI (Debian/Ubuntu)..."
+            sudo apt update -y
+            sudo apt install -y maas-cli 
+            ;;
+        rhel|centos|fedora|rocky|almalinux)
+            echo "Installing MAAS CLI (RHEL/CentOS/Fedora)..."
+            # Ensure EPEL repo is enabled for dependencies
+            if command -v dnf >/dev/null 2>&1; then
+                sudo dnf install -y epel-release || true
+                sudo dnf install -y snapd 
+            else
+                sudo yum install -y epel-release || true
+                sudo yum install -y snapd
+            fi
+
+            # Enable and use snap to install MAAS CLI
+            sudo systemctl enable --now snapd.socket
+            sudo ln -sf /var/lib/snapd/snap /snap
+            echo "Installing MAAS CLI via snap..."
+            sudo snap install maas --classic
+            ;;
+        *)
+            echo "Unsupported Linux distribution: $DISTRO"
+            echo "Please install MAAS CLI manually."
+            exit 1
+            ;;
+    esac
+
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Installing MAAS CLI (macOS)..."
+    brew install maas || true
+else
+    echo "Unsupported OS type: $OSTYPE"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Step 2: Create and activate Python virtual environment
+# -----------------------------------------------------------------------------
+echo "Creating Python virtual environment..."
+python3 -m venv .venv
+source .venv/bin/activate
+
+echo "Installing Python dependencies..."
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo
+echo "Setup complete."

--- a/builder-reimage/maas-reimage.py
+++ b/builder-reimage/maas-reimage.py
@@ -1,0 +1,666 @@
+#!.venv/bin/python3
+"""
+MAAS Reimage Automation Script
+
+Provides:
+- Connect to MAAS
+- Query machines
+- List machines
+- Deploy a machine
+- Reimage a machine
+- Reimage all machines
+- List OS images
+"""
+
+import asyncio
+import argparse
+import configparser
+import sys
+import time
+from datetime import datetime, timezone
+from cryptography.fernet import Fernet
+
+from maas.client import connect
+from aiohttp.client_exceptions import (
+    ClientConnectorError,
+    ServerDisconnectedError,
+    ClientResponseError,
+    ClientOSError
+)
+
+# -------------------------------------------------------------------------
+# Global Defaults
+# -------------------------------------------------------------------------
+
+LOG_FILE_DEFAULT = "maas_reimage.log"
+STATUS_WAIT_TIMEOUT = 600
+POLL_INTERVAL = 10
+DEFAULT_OWNER = "jitendra" # use --owner to tag manually
+
+# -------------------------------------------------------------------------
+# Small helpers
+# -------------------------------------------------------------------------
+
+def log(msg, log_file=None):
+    """Print message and optionally append to a log file with a timestamp."""
+    print(msg)
+    if log_file:
+        try:
+            with open(log_file, "a") as f:
+                f.write(f"{datetime.now().isoformat()} - {msg}\n")
+        except Exception:
+            print(f"(warning) Unable to write to log file: {log_file}")
+
+def sanitize_owner(name):
+    return name.replace(" ", "_").replace("@", "_")
+
+async def safe_list_tags_for_machine(machine):
+    """
+    Return list of tag objects applied to the machine.
+    Some MAAS clients expose machine.tags as a proxy; the reliable way is:
+    await machine.tags.list()
+    """
+    try:
+        return await machine.tags.list()
+    except Exception:
+        # fallback: try to read machine.tags attribute (may not be useful)
+        mt = getattr(machine, "tags", None)
+        if isinstance(mt, list):
+            return mt
+        return []
+
+def get_normalized_status(machine):
+    """
+    Return lowercased status name using the most reliable available attribute.
+    Handles both `status_name` and `status.name` forms.
+    """
+    status_name = getattr(machine, "status_name", None)
+    if status_name:
+        return str(status_name).lower()
+    status_obj = getattr(machine, "status", None)
+    if status_obj is not None:
+        name = getattr(status_obj, "name", None)
+        if name:
+            return str(name).lower()
+    return ""
+
+# -------------------------------------------------------------------------
+# Config + API key
+# -------------------------------------------------------------------------
+
+def load_config():
+    """Load MAAS URL from maas.conf."""
+    config = configparser.ConfigParser()
+    config.read("maas.conf")
+    try:
+        return config.get("maas", "maas_url")
+    except Exception:
+        print("Error: Invalid maas.conf. Expected:\n\n[maas]\nmaas_url=http://<MAAS>/MAAS\n")
+        sys.exit(1)
+
+def load_api_key():
+    """Decrypt and return the MAAS API key from local files."""
+    try:
+        with open("maas_api.key", "rb") as key_file:
+            key = key_file.read()
+        with open("maas_api_key.encrypted", "rb") as enc_file:
+            encrypted = enc_file.read()
+    except FileNotFoundError:
+        print("Missing key files: maas_api.key or maas_api_key.encrypted")
+        sys.exit(1)
+
+    fernet = Fernet(key)
+    return fernet.decrypt(encrypted).decode().strip()
+
+# -------------------------------------------------------------------------
+# MAAS connect with retries
+# -------------------------------------------------------------------------
+
+async def connect_maas(maas_url, api_key, retries=3):
+    """Connect to MAAS and return client; show progress messages."""
+    for attempt in range(1, retries + 1):
+        try:
+            log("Connecting to MAAS...")
+            client = await connect(maas_url, apikey=api_key)
+            log("Connected to MAAS.")
+            return client
+        except (ClientConnectorError, ClientOSError) as e:
+            print(f"Connection attempt {attempt} failed: {e}")
+        except ClientResponseError as e:
+            print(f"MAAS error {e.status}: {e.message}")
+        except (ServerDisconnectedError, asyncio.TimeoutError):
+            print(f"MAAS connection dropped (attempt {attempt})")
+
+        if attempt < retries:
+            log("Retrying in 2 seconds...")
+            await asyncio.sleep(2)
+
+    print("Error: Unable to connect to MAAS after several attempts.")
+    print("Please check:")
+    print("  • Network or VPN connection")
+    print("  • MAAS server hostname and port")
+    print("  • MAAS service availability")
+    sys.exit(1)
+
+# -------------------------------------------------------------------------
+# Cache + refresh helpers
+# -------------------------------------------------------------------------
+
+async def get_cached_machines(client):
+    """Return a cached copy of client.machines.list() for script lifetime."""
+    if getattr(client, "_machines_cache", None) is None:
+        log("Fetching machines list...")
+        client._machines_cache = await client.machines.list()
+    return client._machines_cache
+
+async def refresh_machine(client, machine):
+    """
+    Refresh machine object. Prefer machine.refresh() if available.
+    """
+    try:
+        ref = getattr(machine, "refresh", None)
+        if callable(ref):
+            maybe = ref()
+            if asyncio.iscoroutine(maybe):
+                await maybe
+            return machine
+    except Exception:
+        pass
+
+    try:
+        return await client.machines.get(system_id=machine.system_id)
+    except Exception:
+        return machine
+
+# -------------------------------------------------------------------------
+# Tag-based ownership helpers
+# -------------------------------------------------------------------------
+
+async def ensure_tag_exists(client, tag_name, log_file=None):
+    """Ensure a tag with `tag_name` exists in MAAS; create it if not."""
+    try:
+        tags = await client.tags.list()
+        if not any(getattr(t, "name", t) == tag_name for t in tags):
+            log(f"Creating tag '{tag_name}'...", log_file)
+            await client.tags.create(name=tag_name)
+        return True
+    except Exception as e:
+        log(f"[ERROR] Unable to ensure tag exists '{tag_name}': {e}", log_file)
+        return False
+
+async def assign_owner_tag(client, machine, owner_name, log_file=None):
+    """
+    Assign owner tag to machine using client.tags.get() and machine.tags.add(tag).
+    Refresh machine after applying tag so later reads see it.
+    """
+    sanitized = sanitize_owner(owner_name)
+    if not await ensure_tag_exists(client, sanitized, log_file):
+        return False
+
+    try:
+        tag = await client.tags.get(name=sanitized)
+        applied = await safe_list_tags_for_machine(machine)
+        applied_names = [getattr(t, "name", None) for t in applied]
+        if sanitized in applied_names:
+            return True
+
+        log(f"Assigning tag '{sanitized}' to {machine.hostname}...", log_file)
+        await machine.tags.add(tag)
+        # Refresh so tag is visible
+        await refresh_machine(client, machine)
+        return True
+    except Exception as e:
+        log(f"[ERROR] Failed to assign tag '{sanitized}' to {getattr(machine, 'hostname', machine)}: {e}", log_file)
+        return False
+
+async def get_owner_from_tags(client, machine, owner_pattern):
+    """
+    Determine owner by checking machine's applied tags.
+    owner_pattern should be sanitized (e.g., DEFAULT_OWNER sanitized).
+    Returns the matching tag name or '-' if none.
+    """
+    try:
+        applied = await safe_list_tags_for_machine(machine)
+        applied_names = [getattr(t, "name", None) for t in applied]
+        if owner_pattern in applied_names:
+            return owner_pattern
+        # try prefix match too
+        for n in applied_names:
+            if n and n.startswith(owner_pattern):
+                return n
+    except Exception:
+        pass
+    return "-"
+
+# -------------------------------------------------------------------------
+# Query Machine
+# -------------------------------------------------------------------------
+
+async def query_machine(client, hostname, log_file=None, quiet=False):
+    """
+    Query machine details and print them.
+    Owner detection is tag-based (matches sanitized DEFAULT_OWNER).
+    """
+    owner_tag = "-"  # initialize to avoid undefined variable on errors
+
+    try:
+        machines = await get_cached_machines(client)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machines list: {e}", log_file)
+        return None
+
+    system_id = None
+    for m in machines:
+        if m.hostname == hostname:
+            system_id = m.system_id
+            break
+
+    if not system_id:
+        log(f"[ERROR] Machine '{hostname}' not found.", log_file)
+        return None
+
+    try:
+        log(f"Fetching details for {hostname}...", log_file)
+        machine = await client.machines.get(system_id=system_id)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machine details: {e}", log_file)
+        return None
+
+    if not quiet:
+        sanitized = sanitize_owner(DEFAULT_OWNER)
+        owner_tag = await get_owner_from_tags(client, machine, sanitized)
+
+        # Fetch all tags applied to this machine for display
+        try:
+            applied = await safe_list_tags_for_machine(machine)
+            tag_names = [getattr(t, "name", None) for t in applied if getattr(t, "name", None)]
+            tags_display = ", ".join(tag_names) if tag_names else "-"
+        except Exception:
+            tags_display = "-"
+
+        # resolve status display
+        status_display = getattr(machine, "status_name", None)
+        if not status_display:
+            st = getattr(machine, "status", None)
+            status_display = getattr(st, "name", "-") if st else "-"
+
+        log("\nMachine Details\n" + "-" * 60, log_file)
+        log(
+            f"Name:             {machine.hostname}\n"
+            f"System ID:        {machine.system_id}\n"
+            f"Status:           {status_display}\n"
+            f"OS Distro:        {getattr(machine, 'distro_series', '-')}\n"
+            f"OS Type:          {getattr(machine, 'osystem', '-')}\n"
+           # f"Owner:            {owner_tag}\n"
+           # f"Tags:             {tags_display}\n"
+            f"Power Type:       {getattr(machine, 'power_type', '-')}\n"
+            f"Power Status:     {getattr(machine, 'power_state', '-')}",
+            log_file
+        )
+
+    return machine
+
+# -------------------------------------------------------------------------
+# List machines / distros
+# -------------------------------------------------------------------------
+
+async def list_machines(client, log_file=None):
+    machines = await get_cached_machines(client)
+    log(f"{'Hostname':20} | {'System ID':10} | {'Status':10} | {'OS':10}", log_file)
+    log("-" * 65, log_file)
+    for m in machines:
+        status_display = getattr(m, "status_name", None) or getattr(getattr(m, "status", None), "name", "-")
+        osname = getattr(m, "distro_series", "-")
+        log(f"{m.hostname:20} | {m.system_id:10} | {status_display:10} | {osname:10}", log_file)
+
+async def list_distros(client, log_file=None):
+    try:
+        log("Fetching available OS images...", log_file)
+        resources = await client.boot_resources.list()
+    except Exception as e:
+        log(f"[ERROR] Unable to list boot resources: {e}", log_file)
+        return
+
+    log(f"{'ID':<5} | {'OS Type':<15} | {'Release':<15} | {'Architecture':<12}", log_file)
+    log("-" * 60, log_file)
+    for r in resources:
+        name = getattr(r, "name", "-")
+        os_type, release = "-", "-"
+        if "/" in name:
+            os_type, release = name.split("/", 1)
+        log(f"{r.id:<5} | {os_type:<15} | {release:<15} | {r.architecture:<12}", log_file)
+
+# -------------------------------------------------------------------------
+# Status polling helper
+# -------------------------------------------------------------------------
+
+async def wait_for_status(client, system_id, expected, timeout=STATUS_WAIT_TIMEOUT):
+    """
+    Wait for a machine to reach the expected state (case-insensitive).
+    """
+    log(f"Waiting for machine {system_id} to reach '{expected}'...", None)
+    start = time.time()
+    poll = 2
+    max_poll = 8
+    expected_l = expected.lower()
+
+    while time.time() - start < timeout:
+        try:
+            m = await client.machines.get(system_id=system_id)
+        except Exception as e:
+            print(f"Error fetching machine {system_id}: {e}")
+            await asyncio.sleep(poll)
+            poll = min(max_poll, poll + 1)
+            continue
+
+        current = get_normalized_status(m)
+        if current == expected_l:
+            log(f"{getattr(m, 'hostname', system_id)} reached expected status: {expected}", None)
+            return True
+
+        await asyncio.sleep(poll)
+        poll = min(max_poll, poll + 1)
+
+    print(f"Timeout waiting for {system_id} to reach {expected}.")
+    return False
+
+# -------------------------------------------------------------------------
+# Deploy machine
+# -------------------------------------------------------------------------
+
+async def deploy_machine(client, machine_ref, os_release=None, log_file=None):
+    """
+    Deploy (reimage) a machine. Accepts hostname (str) or machine object.
+    NOTE: this function assumes owner tag is already applied when called from reimage flow.
+    If user invokes deploy action directly, main() will ensure tag is applied before calling this.
+    """
+    if isinstance(machine_ref, str):
+        # Avoid calling query_machine() (which prints full details) to prevent duplicate fetches.
+        machines = await get_cached_machines(client)
+        found = next((m for m in machines if m.hostname == machine_ref), None)
+        if not found:
+            log(f"[ERROR] Machine '{machine_ref}' not found.", log_file)
+            return False
+        machine = await client.machines.get(system_id=found.system_id)
+    else:
+        machine = machine_ref
+
+    machine = await refresh_machine(client, machine)
+
+    hostname = machine.hostname
+    system_id = machine.system_id
+    status = get_normalized_status(machine)
+
+    if status == "deployed":
+        log(f"[INFO] {hostname} is already deployed.", log_file)
+        return True
+
+    if status in ["failed", "broken", "error", "unknown"]:
+        log(f"[ERROR] {hostname} cannot be reimaged (state: {status}).", log_file)
+        return False
+
+    os_to_use = os_release or getattr(machine, "distro_series", None) or "focal"
+    log(f"[ACTION] Reimaging {hostname} using OS '{os_to_use}'...", log_file)
+
+    try:
+        await machine.deploy(distro_series=os_to_use)
+    except Exception as e:
+        log(f"[ERROR] Failed to trigger reimage for {hostname}: {e}", log_file)
+        return False
+
+    if not await wait_for_status(client, system_id, "deployed"):
+        log(f"[ERROR] Reimage timeout for {hostname}.", log_file)
+        return False
+
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    log(f"[SUCCESS] Reimage completed for {hostname}.", log_file)
+    log(f"[INFO] Deployment timestamp for {hostname}: {ts} IST", log_file)
+    return True
+
+# -------------------------------------------------------------------------
+# Release machine
+# -------------------------------------------------------------------------
+
+async def release_machine(client, machine, log_file=None):
+    status = get_normalized_status(machine)
+    if status != "deployed":
+        return True
+
+    log(f"[ACTION] Releasing {machine.hostname}...", log_file)
+    try:
+        await machine.release()
+        return True
+    except Exception as e:
+        log(f"[ERROR] Failed to release: {e}", log_file)
+        return False
+
+# -------------------------------------------------------------------------
+# Reimage machine
+# -------------------------------------------------------------------------
+
+async def reimage_machine(client, hostname, os_release=None, log_file=None):
+    # First, fetch machine (and print its details)
+    machine = await query_machine(client, hostname, log_file)
+    if not machine:
+        return
+
+    force_flag = getattr(args, "force", False)
+    status = get_normalized_status(machine)
+
+    if force_flag and status == "deploying":
+        log(f"[FORCE] Aborting active deployment for {hostname}...", log_file)
+        try:
+            await machine.abort()
+        except Exception as e:
+            log(f"[ERROR] Unable to abort deployment for {hostname}: {e}", log_file)
+            return
+
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after abort.", log_file)
+            return
+
+        log(f"[FORCE] Deployment aborted. Releasing {hostname}...", log_file)
+        try:
+            await machine.release()
+        except Exception:
+            pass
+
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after forced release.", log_file)
+            return
+
+        machine = await refresh_machine(client, machine)
+
+    # Ensure owner tag is applied (only once here)
+    if not await assign_owner_tag(client, machine, DEFAULT_OWNER, log_file):
+        return
+
+    # choose OS
+    current_os = getattr(machine, "distro_series", None)
+    if os_release:
+        os_to_use = os_release
+    elif current_os:
+        os_to_use = current_os
+    else:
+        log(f"[ERROR] No OS detected for machine '{hostname}'. Provide --os.", log_file)
+        return
+
+    # if deployed -> release then wait for Ready
+    status = get_normalized_status(machine)
+    if status == "deployed":
+        log(f"[ACTION] Releasing {machine.hostname} for reimage...", log_file)
+        if not await release_machine(client, machine, log_file):
+            return
+        if not await wait_for_status(client, machine.system_id, "ready"):
+            log("[ERROR] Machine did not reach Ready state after release.", log_file)
+            return
+        machine = await refresh_machine(client, machine)
+
+    # trigger deploy (deploy_machine will not re-assign tag)
+    if await deploy_machine(client, hostname, os_to_use, log_file):
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        log(f"[SUCCESS] Reimage completed for {hostname}.", log_file)
+        log(f"[INFO] Reimage timestamp for {hostname}: {ts} IST", log_file)
+
+# -------------------------------------------------------------------------
+# Reimage all machines
+# -------------------------------------------------------------------------
+
+async def reimage_all(client, os_release=None, log_file=None):
+    try:
+        machines = await get_cached_machines(client)
+    except Exception as e:
+        log(f"[ERROR] Unable to fetch machines list: {e}", log_file)
+        return
+
+    for m in machines:
+        hostname = m.hostname
+        target_os = os_release or getattr(m, "distro_series", "focal")
+        log(f"[INFO] Starting reimage for {hostname}", log_file)
+        try:
+            await reimage_machine(client, hostname, target_os, log_file)
+        except Exception as e:
+            log(f"[ERROR] Reimage error for {hostname}: {e}", log_file)
+
+# -------------------------------------------------------------------------
+# Find last deployed
+# -------------------------------------------------------------------------
+
+async def find_last_deployed_machine(client):
+    try:
+        machines = await get_cached_machines(client)
+    except Exception:
+        return None
+
+    time_fields = [
+        "deployed_at", "deployment_finished_at", "deployment_completed",
+        "deployment_started", "deployment_started_at"
+    ]
+
+    candidates = []
+    for m in machines:
+        status = get_normalized_status(m)
+        if status != "deployed":
+            continue
+
+        timestamp = None
+        for field in time_fields:
+            val = getattr(m, field, None)
+            if val:
+                try:
+                    if isinstance(val, str):
+                        val = val.replace("Z", "+00:00")
+                        timestamp = datetime.fromisoformat(val)
+                    elif isinstance(val, datetime):
+                        timestamp = val
+                except Exception:
+                    continue
+        if timestamp:
+            candidates.append((timestamp, m))
+
+    if candidates:
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        return candidates[0][1]
+
+    for m in machines:
+        if get_normalized_status(m) == "deployed":
+            return m
+
+    return None
+
+# -------------------------------------------------------------------------
+# Main
+# -------------------------------------------------------------------------
+
+async def main():
+    global args
+    global DEFAULT_OWNER
+
+    parser = argparse.ArgumentParser(description="MAAS Reimage Automation Script")
+    parser.add_argument("--action", required=True,
+                        choices=[
+                            "list", "list-distros", "query", "status",
+                            "deploy", "reimage", "reimage-all", "last-deployed"
+                        ])
+    parser.add_argument("--machine", help="Hostname for query, deploy, or reimage")
+    parser.add_argument("--os", help="Target OS release")
+    parser.add_argument("--log-file", help="Path to log file")
+    parser.add_argument("--force", action="store_true",
+                        help="Force reimage even if machine is deploying")
+    parser.add_argument("--owner", help="Owner username (fallback: DEFAULT_OWNER)")
+
+    args = parser.parse_args()
+
+    if args.owner:
+        DEFAULT_OWNER = args.owner
+
+    maas_url = load_config()
+    api_key = load_api_key()
+
+    client = await connect_maas(maas_url, api_key)
+
+    # initialize cache immediately
+    try:
+        client._machines_cache = await client.machines.list()
+    except Exception:
+        client._machines_cache = None
+
+    log_file = args.log_file or LOG_FILE_DEFAULT
+
+    if args.action == "list":
+        await list_machines(client, log_file)
+
+    elif args.action == "query":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await query_machine(client, args.machine, log_file)
+
+    elif args.action == "status":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await query_machine(client, args.machine, log_file)
+
+    elif args.action == "list-distros":
+        await list_distros(client, log_file)
+
+    elif args.action == "deploy":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            # ensure owner tag when user runs deploy directly
+            # fetch machine object (no extra printed details)
+            machines = await get_cached_machines(client)
+            found = next((m for m in machines if m.hostname == args.machine), None)
+            if not found:
+                log(f"[ERROR] Machine '{args.machine}' not found.", log_file)
+            else:
+                machine_obj = await client.machines.get(system_id=found.system_id)
+                await assign_owner_tag(client, machine_obj, DEFAULT_OWNER, log_file)
+                await deploy_machine(client, args.machine, args.os, log_file)
+
+    elif args.action == "reimage":
+        if not args.machine:
+            print("Missing --machine")
+        else:
+            await reimage_machine(client, args.machine, args.os, log_file)
+
+    elif args.action == "reimage-all":
+        await reimage_all(client, args.os, log_file)
+
+    elif args.action == "last-deployed":
+        machine = await find_last_deployed_machine(client)
+        if machine:
+            log(f"Last deployed machine: {machine.hostname} ({machine.system_id})", log_file)
+        else:
+            log("No deployed machines found.", log_file)
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("Interrupted by user.")
+    except Exception as e:
+        print(f"Fatal error: {e}")

--- a/builder-reimage/maas.conf
+++ b/builder-reimage/maas.conf
@@ -1,0 +1,2 @@
+[maas]
+maas_url=http://sepia-maas.front.sepia.ceph.com:5240/MAAS

--- a/builder-reimage/maas_redeploy.log
+++ b/builder-reimage/maas_redeploy.log
@@ -1,0 +1,870 @@
+2025-11-17T15:17:40.052760 - Last deployed machine: omani002 (bqk3ge)
+2025-11-17T15:18:06.298334 - Hostname             | System ID  | Status     | OS        
+2025-11-17T15:18:06.298595 - -----------------------------------------------------------------
+2025-11-17T15:18:06.299239 - confusa01            | erwppa     | Allocated  | -         
+2025-11-17T15:18:06.299515 - incerta08            | e3hbwr     | New        | -         
+2025-11-17T15:18:06.299828 - omani002             | bqk3ge     | Deployed   | -         
+2025-11-17T15:18:06.300129 - smithi004            | 6kqcxb     | Deployed   | jammy     
+2025-11-17T15:18:06.300377 - smithi015            | h8eaq4     | Ready      | -         
+2025-11-17T15:18:06.300618 - smithi034            | rnhtk4     | Allocated  | -         
+2025-11-17T15:18:06.300900 - smithi108            | x7et47     | Deployed   | 9-stream  
+2025-11-17T15:18:06.301181 - smithi147            | p4f766     | Deployed   | 9-stream  
+2025-11-17T15:18:06.301427 - incerta02            | 664qmy     | New        | -         
+2025-11-17T15:18:06.301657 - incerta03            | kqaxm3     | New        | -         
+2025-11-17T15:18:06.301871 - incerta04            | cm8a46     | New        | -         
+2025-11-17T15:18:06.302118 - adami01              | f3tqfp     | Deployed   | jammy     
+2025-11-17T15:18:06.302332 - adami02              | 8k73pr     | Allocated  | -         
+2025-11-17T15:18:06.302541 - adami03              | rayt3b     | Allocated  | -         
+2025-11-17T15:18:06.302750 - adami04              | k48a4y     | Allocated  | -         
+2025-11-17T15:18:06.303000 - adami05              | 6tttwd     | Deployed   | jammy     
+2025-11-17T15:18:06.303214 - adami06              | hsab36     | Allocated  | -         
+2025-11-17T15:18:06.303459 - adami07              | gnmttw     | Deployed   | jammy     
+2025-11-17T15:18:06.303709 - adami08              | eant8f     | Deployed   | 9-stream  
+2025-11-17T15:18:06.303952 - adami09              | a4dae7     | Deploying  | jammy     
+2025-11-17T15:18:06.304199 - adami10              | m8hpw6     | Deployed   | 9-stream  
+2025-11-17T15:18:06.304404 - confusa02            | ksdh6a     | Allocated  | -         
+2025-11-17T15:18:06.304616 - confusa03            | e7dwrh     | Allocated  | -         
+2025-11-17T15:18:06.304826 - confusa04            | 7ehyxt     | Allocated  | -         
+2025-11-17T15:18:06.305034 - confusa05            | pdawwb     | Allocated  | -         
+2025-11-17T15:18:06.305242 - confusa06            | enhefn     | Allocated  | -         
+2025-11-17T15:18:06.305450 - confusa07            | x8ktgh     | Allocated  | -         
+2025-11-17T15:18:06.305662 - confusa08            | g8pw3x     | Allocated  | -         
+2025-11-17T15:18:06.305909 - confusa10            | kkgf43     | Deployed   | 9-stream  
+2025-11-17T15:18:06.306152 - confusa11            | b4tcdt     | Deployed   | noble     
+2025-11-17T15:18:06.306359 - confusa12            | twyrs3     | Allocated  | -         
+2025-11-17T15:18:06.306565 - confusa13            | 78tdd3     | Failed commissioning | -         
+2025-11-17T15:18:06.306776 - confusa14            | w8ddrg     | Allocated  | -         
+2025-11-17T15:18:06.306983 - omani001             | wd7f36     | Allocated  | -         
+2025-11-17T15:18:06.307231 - omani003             | a47776     | Deployed   | noble     
+2025-11-17T15:18:06.307480 - omani004             | qxafrm     | Deployed   | noble     
+2025-11-17T15:18:06.307689 - omani005             | ayyn8e     | Allocated  | -         
+2025-11-17T15:18:06.307897 - omani006             | cte77n     | Broken     | -         
+2025-11-17T15:18:06.308105 - omani007             | rbx68a     | Allocated  | -         
+2025-11-17T15:18:06.308316 - omani008             | qsqedf     | Allocated  | -         
+2025-11-17T15:18:06.308523 - omani009             | np8y6f     | Failed commissioning | -         
+2025-11-17T15:18:06.308730 - omani010             | f3phwb     | Allocated  | -         
+2025-11-17T15:18:06.308936 - irvingi01            | kqrcx4     | Ready      | -         
+2025-11-17T15:18:06.309299 - irvingi02            | gghwhd     | Deployed   | jammy     
+2025-11-17T15:18:06.309597 - irvingi03            | hw3h8x     | Deployed   | jammy     
+2025-11-17T15:18:06.309876 - irvingi04            | n67y3g     | Deployed   | jammy     
+2025-11-17T15:18:06.310137 - irvingi05            | wsskrw     | Deployed   | jammy     
+2025-11-17T15:18:06.310394 - irvingi06            | cwfbm7     | Deployed   | jammy     
+2025-11-17T15:18:06.310655 - irvingi07            | nabcab     | Deployed   | jammy     
+2025-11-17T15:18:06.310906 - irvingi08            | kbykkp     | Deployed   | jammy     
+2025-11-17T15:18:06.311157 - braggi01             | xxcwcs     | Deployed   | jammy     
+2025-11-17T15:18:06.311385 - braggi02             | 7y8rp8     | Deployed   | jammy     
+2025-11-17T15:18:06.311614 - braggi03             | xndrfr     | Deployed   | jammy     
+2025-11-17T15:18:06.311841 - braggi04             | 43ptc8     | Deployed   | 9-stream  
+2025-11-17T15:18:06.312036 - braggi05             | wcrhdk     | Allocated  | -         
+2025-11-17T15:18:06.312259 - braggi06             | qrebpa     | Deployed   | 9-stream  
+2025-11-17T15:18:06.312486 - braggi07             | cec3xk     | Deployed   | 9-stream  
+2025-11-17T15:18:06.312678 - braggi08             | 6m3f8y     | Allocated  | -         
+2025-11-17T15:18:06.312870 - braggi09             | cxpyab     | Allocated  | -         
+2025-11-17T15:18:06.313058 - braggi10             | n8etyc     | Allocated  | -         
+2025-11-17T15:18:06.313288 - braggi11             | x8c7d6     | Deployed   | jammy     
+2025-11-17T15:18:06.313482 - braggi12             | hbrbsb     | Allocated  | -         
+2025-11-17T15:18:06.313676 - braggi13             | 6rqakh     | Allocated  | -         
+2025-11-17T15:18:06.313903 - braggi14             | xtysxg     | Deployed   | 9-stream  
+2025-11-17T15:18:06.314094 - braggi15             | gyahnb     | Allocated  | -         
+2025-11-17T15:18:06.314322 - braggi16             | bgxfb7     | Deployed   | 9-stream  
+2025-11-17T15:18:06.314550 - braggi17             | h74db3     | Deployed   | jammy     
+2025-11-17T15:18:06.314773 - braggi18             | awbqm3     | Deployed   | noble     
+2025-11-17T15:18:06.314963 - braggi22             | 4pp7aa     | Allocated  | -         
+2025-11-17T15:18:06.315156 - sulcata02            | pfh3pf     | Failed commissioning | -         
+2025-11-17T15:18:06.315381 - braggi20             | 4r44k6     | Deployed   | jammy     
+2025-11-17T15:18:06.315606 - braggi19             | k7nfqc     | Deployed   | 9-stream  
+2025-11-17T15:18:06.315835 - gibba004             | 7qcacw     | Deployed   | noble     
+2025-11-17T15:18:06.316058 - gibba005             | ehfgy8     | Deployed   | noble     
+2025-11-17T15:18:06.316284 - gibba006             | gqpysn     | Deployed   | noble     
+2025-11-17T15:18:06.316476 - gibba008             | xynwxt     | Allocated  | -         
+2025-11-17T15:18:06.316668 - gibba009             | 8hfsy8     | Allocated  | -         
+2025-11-17T15:18:06.316859 - gibba010             | p8fsyp     | Allocated  | -         
+2025-11-17T15:18:06.317112 - gibba003             | aqk6pm     | Deployed   | noble     
+2025-11-17T15:18:06.317347 - refarch-r220-01      | ekx4yy     | Deployed   | noble     
+2025-11-17T15:18:06.317574 - refarch-r220-02      | g43rt7     | Deployed   | 9-stream  
+2025-11-17T15:18:06.317818 - refarch-r220-04      | k3rg6d     | Deployed   | 9-stream  
+2025-11-17T15:18:06.318023 - refarch-r220-05      | d4hweb     | Ready      | -         
+2025-11-17T15:18:06.318251 - refarch-r220-06      | pm3e7q     | Deployed   | noble     
+2025-11-17T17:41:56.703627 - Hostname             | System ID  | Status     | OS        
+2025-11-17T17:41:56.704888 - -----------------------------------------------------------------
+2025-11-17T17:41:56.705281 - confusa01            | erwppa     | Allocated  | -         
+2025-11-17T17:41:56.705609 - incerta08            | e3hbwr     | New        | -         
+2025-11-17T17:41:56.705912 - omani002             | bqk3ge     | Deployed   | -         
+2025-11-17T17:41:56.706309 - smithi004            | 6kqcxb     | Deployed   | jammy     
+2025-11-17T17:41:56.706577 - smithi015            | h8eaq4     | Ready      | -         
+2025-11-17T17:41:56.706833 - smithi034            | rnhtk4     | Allocated  | -         
+2025-11-17T17:41:56.707128 - smithi108            | x7et47     | Deployed   | 9-stream  
+2025-11-17T17:41:56.707412 - smithi147            | p4f766     | Deployed   | 9-stream  
+2025-11-17T17:41:56.707655 - incerta02            | 664qmy     | New        | -         
+2025-11-17T17:41:56.708049 - incerta03            | kqaxm3     | New        | -         
+2025-11-17T17:41:56.708367 - incerta04            | cm8a46     | New        | -         
+2025-11-17T17:41:56.708680 - adami01              | f3tqfp     | Deployed   | jammy     
+2025-11-17T17:41:56.708944 - adami02              | 8k73pr     | Allocated  | -         
+2025-11-17T17:41:56.709201 - adami03              | rayt3b     | Allocated  | -         
+2025-11-17T17:41:56.709457 - adami04              | k48a4y     | Allocated  | -         
+2025-11-17T17:41:56.709755 - adami05              | 6tttwd     | Deployed   | jammy     
+2025-11-17T17:41:56.710009 - adami06              | hsab36     | Allocated  | -         
+2025-11-17T17:41:56.710307 - adami07              | gnmttw     | Deployed   | jammy     
+2025-11-17T17:41:56.710613 - adami08              | eant8f     | Deployed   | 9-stream  
+2025-11-17T17:41:56.710914 - adami09              | a4dae7     | Deploying  | jammy     
+2025-11-17T17:41:56.711216 - adami10              | m8hpw6     | Deployed   | 9-stream  
+2025-11-17T17:41:56.711471 - confusa02            | ksdh6a     | Allocated  | -         
+2025-11-17T17:41:56.711726 - confusa03            | e7dwrh     | Allocated  | -         
+2025-11-17T17:41:56.711977 - confusa04            | 7ehyxt     | Allocated  | -         
+2025-11-17T17:41:56.712229 - confusa05            | pdawwb     | Allocated  | -         
+2025-11-17T17:41:56.712480 - confusa06            | enhefn     | Allocated  | -         
+2025-11-17T17:41:56.712732 - confusa07            | x8ktgh     | Allocated  | -         
+2025-11-17T17:41:56.712983 - confusa08            | g8pw3x     | Allocated  | -         
+2025-11-17T17:41:56.713281 - confusa10            | kkgf43     | Deployed   | 9-stream  
+2025-11-17T17:41:56.713577 - confusa11            | b4tcdt     | Deployed   | noble     
+2025-11-17T17:41:56.713829 - confusa12            | twyrs3     | Allocated  | -         
+2025-11-17T17:41:56.714081 - confusa13            | 78tdd3     | Failed commissioning | -         
+2025-11-17T17:41:56.714334 - confusa14            | w8ddrg     | Allocated  | -         
+2025-11-17T17:41:56.714588 - omani001             | wd7f36     | Allocated  | -         
+2025-11-17T17:41:56.714884 - omani003             | a47776     | Deployed   | noble     
+2025-11-17T17:41:56.715178 - omani004             | qxafrm     | Deployed   | noble     
+2025-11-17T17:41:56.715492 - omani005             | ayyn8e     | Allocated  | -         
+2025-11-17T17:41:56.715877 - omani006             | cte77n     | Broken     | -         
+2025-11-17T17:41:56.716216 - omani007             | rbx68a     | Allocated  | -         
+2025-11-17T17:41:56.716556 - omani008             | qsqedf     | Allocated  | -         
+2025-11-17T17:41:56.716845 - omani009             | np8y6f     | Failed commissioning | -         
+2025-11-17T17:41:56.717180 - omani010             | f3phwb     | Allocated  | -         
+2025-11-17T17:41:56.717483 - irvingi01            | kqrcx4     | Ready      | -         
+2025-11-17T17:41:56.717786 - irvingi02            | gghwhd     | Deployed   | jammy     
+2025-11-17T17:41:56.718173 - irvingi03            | hw3h8x     | Deployed   | jammy     
+2025-11-17T17:41:56.718515 - irvingi04            | n67y3g     | Deployed   | jammy     
+2025-11-17T17:41:56.718801 - irvingi05            | wsskrw     | Deployed   | jammy     
+2025-11-17T17:41:56.719071 - irvingi06            | cwfbm7     | Deployed   | jammy     
+2025-11-17T17:41:56.719346 - irvingi07            | nabcab     | Deployed   | jammy     
+2025-11-17T17:41:56.719674 - irvingi08            | kbykkp     | Deployed   | jammy     
+2025-11-17T17:41:56.719946 - braggi01             | xxcwcs     | Deployed   | jammy     
+2025-11-17T17:41:56.720211 - braggi02             | 7y8rp8     | Deployed   | jammy     
+2025-11-17T17:41:56.720484 - braggi03             | xndrfr     | Deployed   | jammy     
+2025-11-17T17:41:56.720752 - braggi04             | 43ptc8     | Deployed   | 9-stream  
+2025-11-17T17:41:56.720985 - braggi05             | wcrhdk     | Allocated  | -         
+2025-11-17T17:41:56.721256 - braggi06             | qrebpa     | Deployed   | 9-stream  
+2025-11-17T17:41:56.721529 - braggi07             | cec3xk     | Deployed   | 9-stream  
+2025-11-17T17:41:56.721758 - braggi08             | 6m3f8y     | Allocated  | -         
+2025-11-17T17:41:56.721989 - braggi09             | cxpyab     | Allocated  | -         
+2025-11-17T17:41:56.722217 - braggi10             | n8etyc     | Allocated  | -         
+2025-11-17T17:41:56.722485 - braggi11             | x8c7d6     | Deployed   | jammy     
+2025-11-17T17:41:56.722713 - braggi12             | hbrbsb     | Allocated  | -         
+2025-11-17T17:41:56.722943 - braggi13             | 6rqakh     | Allocated  | -         
+2025-11-17T17:41:56.723207 - braggi14             | xtysxg     | Deployed   | 9-stream  
+2025-11-17T17:41:56.723433 - braggi15             | gyahnb     | Allocated  | -         
+2025-11-17T17:41:56.723700 - braggi16             | bgxfb7     | Deployed   | 9-stream  
+2025-11-17T17:41:56.723965 - braggi17             | h74db3     | Deployed   | jammy     
+2025-11-17T17:41:56.724229 - braggi18             | awbqm3     | Deployed   | noble     
+2025-11-17T17:41:56.724452 - braggi22             | 4pp7aa     | Allocated  | -         
+2025-11-17T17:41:56.724682 - sulcata02            | pfh3pf     | Failed commissioning | -         
+2025-11-17T17:41:56.724944 - braggi20             | 4r44k6     | Deployed   | jammy     
+2025-11-17T17:41:56.725212 - braggi19             | k7nfqc     | Deployed   | 9-stream  
+2025-11-17T17:41:56.725542 - gibba004             | 7qcacw     | Deployed   | noble     
+2025-11-17T17:41:56.725992 - gibba005             | ehfgy8     | Deployed   | noble     
+2025-11-17T17:41:56.726270 - gibba006             | gqpysn     | Deployed   | noble     
+2025-11-17T17:41:56.726549 - gibba008             | xynwxt     | Allocated  | -         
+2025-11-17T17:41:56.726768 - gibba009             | 8hfsy8     | Allocated  | -         
+2025-11-17T17:41:56.726976 - gibba010             | p8fsyp     | Allocated  | -         
+2025-11-17T17:41:56.727216 - gibba003             | aqk6pm     | Deployed   | noble     
+2025-11-17T17:41:56.727455 - refarch-r220-01      | ekx4yy     | Deployed   | noble     
+2025-11-17T17:41:56.727693 - refarch-r220-02      | g43rt7     | Deployed   | 9-stream  
+2025-11-17T17:41:56.727931 - refarch-r220-04      | k3rg6d     | Deployed   | 9-stream  
+2025-11-17T17:41:56.728139 - refarch-r220-05      | d4hweb     | Ready      | -         
+2025-11-17T17:41:56.728378 - refarch-r220-06      | pm3e7q     | Deployed   | noble     
+2025-11-17T17:43:02.815783 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T17:43:02.816330 - Name: irvingi04
+System ID: n67y3g
+Status: Deployed
+OS Distro: jammy
+OS Type: ubuntu
+Owner: User
+Power Type: ipmi
+Power Status: PowerState.ON
+2025-11-17T17:43:57.604144 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T17:43:57.604633 - Name: irvingi04
+System ID: n67y3g
+Status: Deployed
+OS Distro: jammy
+OS Type: ubuntu
+Owner: User
+Power Type: ipmi
+Power Status: PowerState.ON
+2025-11-17T18:00:38.771042 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T18:00:38.771564 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: -
+OS Type: -
+Owner: -
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T18:01:14.893529 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T18:01:14.894047 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: -
+OS Type: -
+Owner: -
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T18:17:56.388333 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T18:17:56.388849 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: -
+OS Type: -
+Owner: -
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T18:58:32.501524 - Hostname             | System ID  | Status     | OS        
+2025-11-17T18:58:32.502048 - -----------------------------------------------------------------
+2025-11-17T18:58:32.502402 - confusa01            | erwppa     | Allocated  |           
+2025-11-17T18:58:32.502675 - incerta08            | e3hbwr     | New        |           
+2025-11-17T18:58:32.502933 - omani002             | bqk3ge     | Deployed   |           
+2025-11-17T18:58:32.503181 - smithi004            | 6kqcxb     | Deployed   | jammy     
+2025-11-17T18:58:32.503434 - smithi015            | h8eaq4     | Ready      |           
+2025-11-17T18:58:32.503689 - smithi034            | rnhtk4     | Allocated  |           
+2025-11-17T18:58:32.503941 - smithi108            | x7et47     | Deployed   | 9-stream  
+2025-11-17T18:58:32.504189 - smithi147            | p4f766     | Deployed   | 9-stream  
+2025-11-17T18:58:32.504434 - incerta02            | 664qmy     | New        |           
+2025-11-17T18:58:32.504820 - incerta03            | kqaxm3     | New        |           
+2025-11-17T18:58:32.505116 - incerta04            | cm8a46     | New        |           
+2025-11-17T18:58:32.505375 - adami01              | f3tqfp     | Deployed   | jammy     
+2025-11-17T18:58:32.505624 - adami02              | 8k73pr     | Allocated  |           
+2025-11-17T18:58:32.505873 - adami03              | rayt3b     | Allocated  |           
+2025-11-17T18:58:32.506114 - adami04              | k48a4y     | Allocated  |           
+2025-11-17T18:58:32.506356 - adami05              | 6tttwd     | Deployed   | jammy     
+2025-11-17T18:58:32.506599 - adami06              | hsab36     | Allocated  |           
+2025-11-17T18:58:32.506846 - adami07              | gnmttw     | Deployed   | jammy     
+2025-11-17T18:58:32.507089 - adami08              | eant8f     | Deployed   | 9-stream  
+2025-11-17T18:58:32.507328 - adami09              | a4dae7     | Deploying  | jammy     
+2025-11-17T18:58:32.507568 - adami10              | m8hpw6     | Deployed   | 9-stream  
+2025-11-17T18:58:32.507807 - confusa02            | ksdh6a     | Allocated  |           
+2025-11-17T18:58:32.508045 - confusa03            | e7dwrh     | Allocated  |           
+2025-11-17T18:58:32.508281 - confusa04            | 7ehyxt     | Allocated  |           
+2025-11-17T18:58:32.508523 - confusa05            | pdawwb     | Allocated  |           
+2025-11-17T18:58:32.508763 - confusa06            | enhefn     | Allocated  |           
+2025-11-17T18:58:32.509001 - confusa07            | x8ktgh     | Allocated  |           
+2025-11-17T18:58:32.509241 - confusa08            | g8pw3x     | Allocated  |           
+2025-11-17T18:58:32.509472 - confusa10            | kkgf43     | Deployed   | 9-stream  
+2025-11-17T18:58:32.509697 - confusa11            | b4tcdt     | Deployed   | noble     
+2025-11-17T18:58:32.509918 - confusa12            | twyrs3     | Allocated  |           
+2025-11-17T18:58:32.510136 - confusa13            | 78tdd3     | Failed commissioning |           
+2025-11-17T18:58:32.510349 - confusa14            | w8ddrg     | Allocated  |           
+2025-11-17T18:58:32.510564 - omani001             | wd7f36     | Allocated  |           
+2025-11-17T18:58:32.510777 - omani003             | a47776     | Deployed   | noble     
+2025-11-17T18:58:32.510992 - omani004             | qxafrm     | Deployed   | noble     
+2025-11-17T18:58:32.511205 - omani005             | ayyn8e     | Allocated  |           
+2025-11-17T18:58:32.511417 - omani006             | cte77n     | Broken     |           
+2025-11-17T18:58:32.511632 - omani007             | rbx68a     | Allocated  |           
+2025-11-17T18:58:32.511844 - omani008             | qsqedf     | Allocated  |           
+2025-11-17T18:58:32.512105 - omani009             | np8y6f     | Failed commissioning |           
+2025-11-17T18:58:32.512323 - omani010             | f3phwb     | Allocated  |           
+2025-11-17T18:58:32.512539 - irvingi01            | kqrcx4     | Ready      |           
+2025-11-17T18:58:32.512754 - irvingi02            | gghwhd     | Deployed   | jammy     
+2025-11-17T18:58:32.512971 - irvingi03            | hw3h8x     | Deployed   | jammy     
+2025-11-17T18:58:32.513196 - irvingi04            | n67y3g     | Ready      |           
+2025-11-17T18:58:32.513416 - irvingi05            | wsskrw     | Deployed   | jammy     
+2025-11-17T18:58:32.513636 - irvingi06            | cwfbm7     | Deployed   | jammy     
+2025-11-17T18:58:32.513857 - irvingi07            | nabcab     | Deployed   | jammy     
+2025-11-17T18:58:32.514085 - irvingi08            | kbykkp     | Deployed   | jammy     
+2025-11-17T18:58:32.514310 - braggi01             | xxcwcs     | Deployed   | jammy     
+2025-11-17T18:58:32.514529 - braggi02             | 7y8rp8     | Deployed   | jammy     
+2025-11-17T18:58:32.514973 - braggi03             | xndrfr     | Deployed   | jammy     
+2025-11-17T18:58:32.515229 - braggi04             | 43ptc8     | Deployed   | 9-stream  
+2025-11-17T18:58:32.515463 - braggi05             | wcrhdk     | Allocated  |           
+2025-11-17T18:58:32.515692 - braggi06             | qrebpa     | Deployed   | 9-stream  
+2025-11-17T18:58:32.515916 - braggi07             | cec3xk     | Deployed   | 9-stream  
+2025-11-17T18:58:32.516140 - braggi08             | 6m3f8y     | Allocated  |           
+2025-11-17T18:58:32.516363 - braggi09             | cxpyab     | Allocated  |           
+2025-11-17T18:58:32.516583 - braggi10             | n8etyc     | Allocated  |           
+2025-11-17T18:58:32.516806 - braggi11             | x8c7d6     | Deployed   | jammy     
+2025-11-17T18:58:32.517024 - braggi12             | hbrbsb     | Allocated  |           
+2025-11-17T18:58:32.517243 - braggi13             | 6rqakh     | Allocated  |           
+2025-11-17T18:58:32.517443 - braggi14             | xtysxg     | Deployed   | 9-stream  
+2025-11-17T18:58:32.517639 - braggi15             | gyahnb     | Allocated  |           
+2025-11-17T18:58:32.517836 - braggi16             | bgxfb7     | Deployed   | 9-stream  
+2025-11-17T18:58:32.518034 - braggi17             | h74db3     | Deployed   | jammy     
+2025-11-17T18:58:32.518233 - braggi18             | awbqm3     | Deployed   | noble     
+2025-11-17T18:58:32.518431 - braggi22             | 4pp7aa     | Allocated  |           
+2025-11-17T18:58:32.518634 - sulcata02            | pfh3pf     | Failed commissioning |           
+2025-11-17T18:58:32.518837 - braggi20             | 4r44k6     | Deployed   | jammy     
+2025-11-17T18:58:32.519037 - braggi19             | k7nfqc     | Deployed   | 9-stream  
+2025-11-17T18:58:32.519243 - gibba004             | 7qcacw     | Deployed   | noble     
+2025-11-17T18:58:32.519443 - gibba005             | ehfgy8     | Deployed   | noble     
+2025-11-17T18:58:32.519646 - gibba006             | gqpysn     | Deployed   | noble     
+2025-11-17T18:58:32.519846 - gibba008             | xynwxt     | Allocated  |           
+2025-11-17T18:58:32.520043 - gibba009             | 8hfsy8     | Allocated  |           
+2025-11-17T18:58:32.520241 - gibba010             | p8fsyp     | Allocated  |           
+2025-11-17T18:58:32.520442 - gibba003             | aqk6pm     | Deployed   | noble     
+2025-11-17T18:58:32.520643 - refarch-r220-01      | ekx4yy     | Deployed   | noble     
+2025-11-17T18:58:32.520844 - refarch-r220-02      | g43rt7     | Deployed   | 9-stream  
+2025-11-17T18:58:32.521044 - refarch-r220-04      | k3rg6d     | Deployed   | 9-stream  
+2025-11-17T18:58:32.521243 - refarch-r220-05      | d4hweb     | Ready      |           
+2025-11-17T18:58:32.521441 - refarch-r220-06      | pm3e7q     | Deployed   | noble     
+2025-11-17T18:59:03.377014 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T18:59:03.377869 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: 
+OS Type: 
+Owner: None
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T18:59:24.114556 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T18:59:24.115618 - Name: irvingi08
+System ID: kbykkp
+Status: Deployed
+OS Distro: jammy
+OS Type: ubuntu
+Owner: User
+Power Type: ipmi
+Power Status: PowerState.ON
+2025-11-17T19:02:35.085311 - Hostname             | System ID  | Status     | OS        
+2025-11-17T19:02:35.085518 - -----------------------------------------------------------------
+2025-11-17T19:02:35.086167 - confusa01            | erwppa     | Allocated  |           
+2025-11-17T19:02:35.086445 - incerta08            | e3hbwr     | New        |           
+2025-11-17T19:02:35.086704 - omani002             | bqk3ge     | Deployed   |           
+2025-11-17T19:02:35.086959 - smithi004            | 6kqcxb     | Deployed   | jammy     
+2025-11-17T19:02:35.087211 - smithi015            | h8eaq4     | Ready      |           
+2025-11-17T19:02:35.087458 - smithi034            | rnhtk4     | Allocated  |           
+2025-11-17T19:02:35.087704 - smithi108            | x7et47     | Deployed   | 9-stream  
+2025-11-17T19:02:35.087944 - smithi147            | p4f766     | Deployed   | 9-stream  
+2025-11-17T19:02:35.088188 - incerta02            | 664qmy     | New        |           
+2025-11-17T19:02:35.088440 - incerta03            | kqaxm3     | New        |           
+2025-11-17T19:02:35.088682 - incerta04            | cm8a46     | New        |           
+2025-11-17T19:02:35.088931 - adami01              | f3tqfp     | Deployed   | jammy     
+2025-11-17T19:02:35.089175 - adami02              | 8k73pr     | Allocated  |           
+2025-11-17T19:02:35.089428 - adami03              | rayt3b     | Allocated  |           
+2025-11-17T19:02:35.089694 - adami04              | k48a4y     | Allocated  |           
+2025-11-17T19:02:35.089937 - adami05              | 6tttwd     | Deployed   | jammy     
+2025-11-17T19:02:35.090193 - adami06              | hsab36     | Allocated  |           
+2025-11-17T19:02:35.090438 - adami07              | gnmttw     | Deployed   | jammy     
+2025-11-17T19:02:35.090688 - adami08              | eant8f     | Deployed   | 9-stream  
+2025-11-17T19:02:35.090934 - adami09              | a4dae7     | Deploying  | jammy     
+2025-11-17T19:02:35.091182 - adami10              | m8hpw6     | Deployed   | 9-stream  
+2025-11-17T19:02:35.091400 - confusa02            | ksdh6a     | Allocated  |           
+2025-11-17T19:02:35.091624 - confusa03            | e7dwrh     | Allocated  |           
+2025-11-17T19:02:35.091898 - confusa04            | 7ehyxt     | Allocated  |           
+2025-11-17T19:02:35.092142 - confusa05            | pdawwb     | Allocated  |           
+2025-11-17T19:02:35.092369 - confusa06            | enhefn     | Allocated  |           
+2025-11-17T19:02:35.092589 - confusa07            | x8ktgh     | Allocated  |           
+2025-11-17T19:02:35.092809 - confusa08            | g8pw3x     | Allocated  |           
+2025-11-17T19:02:35.093069 - confusa10            | kkgf43     | Deployed   | 9-stream  
+2025-11-17T19:02:35.093295 - confusa11            | b4tcdt     | Deployed   | noble     
+2025-11-17T19:02:35.093518 - confusa12            | twyrs3     | Allocated  |           
+2025-11-17T19:02:35.093759 - confusa13            | 78tdd3     | Failed commissioning |           
+2025-11-17T19:02:35.093974 - confusa14            | w8ddrg     | Allocated  |           
+2025-11-17T19:02:35.094189 - omani001             | wd7f36     | Allocated  |           
+2025-11-17T19:02:35.094403 - omani003             | a47776     | Deployed   | noble     
+2025-11-17T19:02:35.094618 - omani004             | qxafrm     | Deployed   | noble     
+2025-11-17T19:02:35.094834 - omani005             | ayyn8e     | Allocated  |           
+2025-11-17T19:02:35.095048 - omani006             | cte77n     | Broken     |           
+2025-11-17T19:02:35.095261 - omani007             | rbx68a     | Allocated  |           
+2025-11-17T19:02:35.095515 - omani008             | qsqedf     | Allocated  |           
+2025-11-17T19:02:35.095735 - omani009             | np8y6f     | Failed commissioning |           
+2025-11-17T19:02:35.095963 - omani010             | f3phwb     | Allocated  |           
+2025-11-17T19:02:35.096180 - irvingi01            | kqrcx4     | Ready      |           
+2025-11-17T19:02:35.096396 - irvingi02            | gghwhd     | Deployed   | jammy     
+2025-11-17T19:02:35.096615 - irvingi03            | hw3h8x     | Deployed   | jammy     
+2025-11-17T19:02:35.096831 - irvingi04            | n67y3g     | Ready      |           
+2025-11-17T19:02:35.097048 - irvingi05            | wsskrw     | Deployed   | jammy     
+2025-11-17T19:02:35.097264 - irvingi06            | cwfbm7     | Deployed   | jammy     
+2025-11-17T19:02:35.097477 - irvingi07            | nabcab     | Deployed   | jammy     
+2025-11-17T19:02:35.097691 - irvingi08            | kbykkp     | Deployed   | jammy     
+2025-11-17T19:02:35.097905 - braggi01             | xxcwcs     | Deployed   | jammy     
+2025-11-17T19:02:35.098125 - braggi02             | 7y8rp8     | Deployed   | jammy     
+2025-11-17T19:02:35.098342 - braggi03             | xndrfr     | Deployed   | jammy     
+2025-11-17T19:02:35.098560 - braggi04             | 43ptc8     | Deployed   | 9-stream  
+2025-11-17T19:02:35.098782 - braggi05             | wcrhdk     | Allocated  |           
+2025-11-17T19:02:35.098999 - braggi06             | qrebpa     | Deployed   | 9-stream  
+2025-11-17T19:02:35.099206 - braggi07             | cec3xk     | Deployed   | 9-stream  
+2025-11-17T19:02:35.099400 - braggi08             | 6m3f8y     | Allocated  |           
+2025-11-17T19:02:35.099594 - braggi09             | cxpyab     | Allocated  |           
+2025-11-17T19:02:35.099789 - braggi10             | n8etyc     | Allocated  |           
+2025-11-17T19:02:35.099984 - braggi11             | x8c7d6     | Deployed   | jammy     
+2025-11-17T19:02:35.100181 - braggi12             | hbrbsb     | Allocated  |           
+2025-11-17T19:02:35.100377 - braggi13             | 6rqakh     | Allocated  |           
+2025-11-17T19:02:35.100573 - braggi14             | xtysxg     | Deployed   | 9-stream  
+2025-11-17T19:02:35.100834 - braggi15             | gyahnb     | Allocated  |           
+2025-11-17T19:02:35.101081 - braggi16             | bgxfb7     | Deployed   | 9-stream  
+2025-11-17T19:02:35.101295 - braggi17             | h74db3     | Deployed   | jammy     
+2025-11-17T19:02:35.101506 - braggi18             | awbqm3     | Deployed   | noble     
+2025-11-17T19:02:35.101713 - braggi22             | 4pp7aa     | Allocated  |           
+2025-11-17T19:02:35.101916 - sulcata02            | pfh3pf     | Failed commissioning |           
+2025-11-17T19:02:35.102115 - braggi20             | 4r44k6     | Deployed   | jammy     
+2025-11-17T19:02:35.102317 - braggi19             | k7nfqc     | Deployed   | 9-stream  
+2025-11-17T19:02:35.102524 - gibba004             | 7qcacw     | Deployed   | noble     
+2025-11-17T19:02:35.102730 - gibba005             | ehfgy8     | Deployed   | noble     
+2025-11-17T19:02:35.102925 - gibba006             | gqpysn     | Deployed   | noble     
+2025-11-17T19:02:35.103119 - gibba008             | xynwxt     | Allocated  |           
+2025-11-17T19:02:35.103314 - gibba009             | 8hfsy8     | Allocated  |           
+2025-11-17T19:02:35.103509 - gibba010             | p8fsyp     | Allocated  |           
+2025-11-17T19:02:35.103703 - gibba003             | aqk6pm     | Deployed   | noble     
+2025-11-17T19:02:35.103896 - refarch-r220-01      | ekx4yy     | Deployed   | noble     
+2025-11-17T19:02:35.104089 - refarch-r220-02      | g43rt7     | Deployed   | 9-stream  
+2025-11-17T19:02:35.104281 - refarch-r220-04      | k3rg6d     | Deployed   | 9-stream  
+2025-11-17T19:02:35.104474 - refarch-r220-05      | d4hweb     | Ready      |           
+2025-11-17T19:02:35.104667 - refarch-r220-06      | pm3e7q     | Deployed   | noble     
+2025-11-17T19:03:00.924348 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T19:03:00.928664 - Name:             irvingi08
+System ID:        kbykkp
+Status:           Deployed
+OS Distro:        jammy
+OS Type:          ubuntu
+Owner:            User
+Power Type:       ipmi
+Power Status:     PowerState.ON
+Last Deployed At: -
+2025-11-17T19:08:03.791188 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T19:08:03.793703 - Name: irvingi08
+System ID: kbykkp
+Status: Deployed
+OS Distro: jammy
+OS Type: ubuntu
+Owner: User
+Power Type: ipmi
+Power Status: PowerState.ON
+2025-11-17T19:08:39.118994 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T19:08:39.119723 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: 
+OS Type: 
+Owner: None
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T19:08:39.121606 - [ERROR] irvingi04 appears powered off. Fix power before redeploying.
+2025-11-17T19:10:41.281519 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T19:10:41.286951 - Name: irvingi08
+System ID: kbykkp
+Status: Deployed
+OS Distro: jammy
+OS Type: ubuntu
+Owner: User
+Power Type: ipmi
+Power Status: PowerState.ON
+2025-11-17T19:10:41.290790 - [ACTION] Releasing irvingi08...
+2025-11-17T19:11:11.598986 - [ERROR] irvingi08 appears powered off. Check IPMI/power before deploying.
+2025-11-17T19:47:41.256908 - Last deployed machine: omani002 (bqk3ge)
+2025-11-17T19:52:47.996740 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T19:52:47.998523 - Name: irvingi08
+System ID: kbykkp
+Status: Ready
+OS Distro: 
+OS Type: 
+Owner: None
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T20:40:13.219176 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T20:40:13.221292 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: 
+OS Type: 
+Owner: None
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T20:41:33.198744 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T20:41:33.202358 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: 
+OS Type: 
+Owner: None
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T20:42:19.468134 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T20:42:19.472370 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: 
+OS Type: 
+Owner: None
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T20:42:19.481711 - [ERROR] irvingi04 appears powered off. Fix power before redeploying.
+2025-11-17T20:50:26.095636 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T20:50:26.096494 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: 
+OS Type: 
+Owner: None
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T20:50:51.585983 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T20:50:51.587016 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: 
+OS Type: 
+Owner: None
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T20:50:51.589455 - [ERROR] irvingi04 appears powered off. Fix power before redeploying.
+2025-11-17T21:00:54.867803 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T21:00:54.872684 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Ready
+OS Distro:        
+OS Type:          
+Owner:            None
+Power Type:       ipmi
+Power Status:     PowerState.OFF
+Last Deployed At: -
+2025-11-17T21:05:08.882163 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T21:05:08.882703 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Ready
+OS Distro:        
+OS Type:          
+Owner:            None
+Power Type:       ipmi
+Power Status:     PowerState.OFF
+2025-11-17T21:05:53.575691 - ID    | OS Type         | Release         | Architecture
+2025-11-17T21:05:53.575965 - ------------------------------------------------------------
+2025-11-17T21:05:53.576168 - 35    | centos          | 8               | amd64/generic
+2025-11-17T21:05:53.576379 - 34    | centos          | centos70        | amd64/generic
+2025-11-17T21:05:53.576533 - 1     | grub-efi-signed | uefi            | amd64/generic
+2025-11-17T21:05:53.576674 - 2     | grub-efi        | uefi            | arm64/generic
+2025-11-17T21:05:53.576814 - 3     | grub-ieee1275   | open-firmware   | ppc64el/generic
+2025-11-17T21:05:53.576947 - 4     | pxelinux        | pxe             | i386/generic
+2025-11-17T21:05:53.577077 - 19    | ubuntu          | jammy           | amd64/ga-22.04
+2025-11-17T21:05:53.577210 - 20    | ubuntu          | jammy           | amd64/ga-22.04-lowlatency
+2025-11-17T21:05:53.577338 - 21    | ubuntu          | jammy           | amd64/hwe-22.04
+2025-11-17T21:05:53.577470 - 22    | ubuntu          | jammy           | amd64/hwe-22.04-edge
+2025-11-17T21:05:53.577602 - 23    | ubuntu          | jammy           | amd64/hwe-22.04-lowlatency
+2025-11-17T21:05:53.577730 - 24    | ubuntu          | jammy           | amd64/hwe-22.04-lowlatency-edge
+2025-11-17T21:05:53.577853 - 25    | ubuntu          | jammy           | arm64/ga-22.04
+2025-11-17T21:05:53.577979 - 26    | ubuntu          | jammy           | arm64/hwe-22.04
+2025-11-17T21:05:53.578105 - 27    | ubuntu          | jammy           | arm64/hwe-22.04-edge
+2025-11-17T21:05:53.578233 - 28    | ubuntu          | jammy           | arm64/hwe-22.04-lowlatency
+2025-11-17T21:05:53.578358 - 29    | ubuntu          | jammy           | arm64/hwe-22.04-lowlatency-edge
+2025-11-17T21:05:53.578488 - 30    | ubuntu          | jammy           | arm64/xgene-uboot
+2025-11-17T21:05:53.578621 - 31    | ubuntu          | jammy           | arm64/xgene-uboot-mustang
+2025-11-17T21:05:53.578747 - 11    | ubuntu          | mantic          | amd64/ga-23.10
+2025-11-17T21:05:53.578873 - 12    | ubuntu          | mantic          | amd64/ga-23.10-lowlatency
+2025-11-17T21:05:53.579006 - 13    | ubuntu          | mantic          | arm64/ga-23.10
+2025-11-17T21:05:53.579144 - 5     | ubuntu          | noble           | amd64/ga-24.04
+2025-11-17T21:05:53.579282 - 6     | ubuntu          | noble           | amd64/ga-24.04-lowlatency
+2025-11-17T21:05:53.579420 - 7     | ubuntu          | noble           | amd64/hwe-24.04
+2025-11-17T21:05:53.579550 - 8     | ubuntu          | noble           | amd64/hwe-24.04-edge
+2025-11-17T21:05:53.579683 - 9     | ubuntu          | noble           | amd64/hwe-24.04-lowlatency
+2025-11-17T21:05:53.579812 - 10    | ubuntu          | noble           | amd64/hwe-24.04-lowlatency-edge
+2025-11-17T21:05:53.579940 - 14    | ubuntu          | noble           | arm64/ga-24.04
+2025-11-17T21:05:53.580069 - 15    | ubuntu          | noble           | arm64/hwe-24.04
+2025-11-17T21:05:53.580196 - 16    | ubuntu          | noble           | arm64/hwe-24.04-edge
+2025-11-17T21:05:53.580325 - 17    | ubuntu          | noble           | arm64/hwe-24.04-lowlatency
+2025-11-17T21:05:53.580463 - 18    | ubuntu          | noble           | arm64/hwe-24.04-lowlatency-edge
+2025-11-17T21:05:53.580593 - 32    | centos          | 9-stream        | amd64/generic
+2025-11-17T21:05:53.580722 - 33    | centos          | 9-stream        | arm64/generic
+2025-11-17T21:05:53.580851 - 40    | rhel            | rhel10          | amd64/generic
+2025-11-17T21:05:53.581001 - 39    | -               | -               | amd64/generic
+2025-11-17T21:05:53.581192 - 37    | -               | -               | arm64/generic
+2025-11-17T21:07:13.813849 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T21:07:13.816205 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Ready
+OS Distro:        
+OS Type:          
+Owner:            None
+Power Type:       ipmi
+Power Status:     PowerState.OFF
+2025-11-17T21:07:25.068320 - [ACTION] Deploying irvingi04 using OS 'focal'...
+2025-11-17T21:07:25.068694 - [ERROR] Failed to trigger deployment for irvingi04: Machine.deploy() got an unexpected keyword argument 'osystem'
+2025-11-17T21:08:58.693486 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T21:08:58.694944 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Ready
+OS Distro:        
+OS Type:          
+Owner:            None
+Power Type:       ipmi
+Power Status:     PowerState.OFF
+2025-11-17T21:09:06.128340 - [ACTION] Deploying irvingi04 using OS 'jammy'...
+2025-11-17T21:09:06.128733 - [ERROR] Failed to trigger deployment for irvingi04: Machine.deploy() got an unexpected keyword argument 'osystem'
+2025-11-17T21:13:57.401173 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T21:13:57.402518 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Ready
+OS Distro:        
+OS Type:          
+Owner:            None
+Power Type:       ipmi
+Power Status:     PowerState.OFF
+Last Deployed At: -
+2025-11-17T21:14:04.754705 - [ACTION] Deploying irvingi04 using OS 'focal'...
+2025-11-17T21:14:06.487998 - [ERROR] Failed to trigger deployment for irvingi04: POST http://refarch-r730xd-01.front.sepia.ceph.com:5240/MAAS/api/2.0/machines/n67y3g/?op=deploy -> HTTP 400 Bad Request ({"distro_series": ["'focal' is not a valid distro…)
+2025-11-17T21:25:07.363756 - Hostname             | System ID  | Status     | OS        
+2025-11-17T21:25:07.363916 - -----------------------------------------------------------------
+2025-11-17T21:25:07.364424 - confusa01            | erwppa     | Allocated  |           
+2025-11-17T21:25:07.364596 - incerta08            | e3hbwr     | New        |           
+2025-11-17T21:25:07.364770 - omani002             | bqk3ge     | Deployed   |           
+2025-11-17T21:25:07.364932 - smithi004            | 6kqcxb     | Deployed   | jammy     
+2025-11-17T21:25:07.365095 - smithi015            | h8eaq4     | Ready      |           
+2025-11-17T21:25:07.365257 - smithi034            | rnhtk4     | Allocated  |           
+2025-11-17T21:25:07.365419 - smithi108            | x7et47     | Deployed   | 9-stream  
+2025-11-17T21:25:07.365581 - smithi147            | p4f766     | Deployed   | 9-stream  
+2025-11-17T21:25:07.365745 - incerta02            | 664qmy     | New        |           
+2025-11-17T21:25:07.365910 - incerta03            | kqaxm3     | New        |           
+2025-11-17T21:25:07.366065 - incerta04            | cm8a46     | New        |           
+2025-11-17T21:25:07.366222 - adami01              | f3tqfp     | Deployed   | jammy     
+2025-11-17T21:25:07.366379 - adami02              | 8k73pr     | Allocated  |           
+2025-11-17T21:25:07.366538 - adami03              | rayt3b     | Allocated  |           
+2025-11-17T21:25:07.366697 - adami04              | k48a4y     | Allocated  |           
+2025-11-17T21:25:07.366858 - adami05              | 6tttwd     | Deployed   | jammy     
+2025-11-17T21:25:07.367024 - adami06              | hsab36     | Allocated  |           
+2025-11-17T21:25:07.367184 - adami07              | gnmttw     | Deployed   | jammy     
+2025-11-17T21:25:07.367347 - adami08              | eant8f     | Deployed   | 9-stream  
+2025-11-17T21:25:07.367508 - adami09              | a4dae7     | Deploying  | jammy     
+2025-11-17T21:25:07.367674 - adami10              | m8hpw6     | Deployed   | 9-stream  
+2025-11-17T21:25:07.367830 - confusa02            | ksdh6a     | Allocated  |           
+2025-11-17T21:25:07.367986 - confusa03            | e7dwrh     | Allocated  |           
+2025-11-17T21:25:07.368140 - confusa04            | 7ehyxt     | Allocated  |           
+2025-11-17T21:25:07.368294 - confusa05            | pdawwb     | Allocated  |           
+2025-11-17T21:25:07.368447 - confusa06            | enhefn     | Allocated  |           
+2025-11-17T21:25:07.368602 - confusa07            | x8ktgh     | Allocated  |           
+2025-11-17T21:25:07.368761 - confusa08            | g8pw3x     | Allocated  |           
+2025-11-17T21:25:07.368983 - confusa10            | kkgf43     | Deployed   | 9-stream  
+2025-11-17T21:25:07.369173 - confusa11            | b4tcdt     | Deployed   | noble     
+2025-11-17T21:25:07.369353 - confusa12            | twyrs3     | Allocated  |           
+2025-11-17T21:25:07.369612 - confusa13            | 78tdd3     | Failed commissioning |           
+2025-11-17T21:25:07.369933 - confusa14            | w8ddrg     | Allocated  |           
+2025-11-17T21:25:07.370112 - omani001             | wd7f36     | Allocated  |           
+2025-11-17T21:25:07.370289 - omani003             | a47776     | Deployed   | noble     
+2025-11-17T21:25:07.370453 - omani004             | qxafrm     | Deployed   | noble     
+2025-11-17T21:25:07.370623 - omani005             | ayyn8e     | Allocated  |           
+2025-11-17T21:25:07.370788 - omani006             | cte77n     | Broken     |           
+2025-11-17T21:25:07.370956 - omani007             | rbx68a     | Allocated  |           
+2025-11-17T21:25:07.371255 - omani008             | qsqedf     | Allocated  |           
+2025-11-17T21:25:07.371507 - omani009             | np8y6f     | Failed commissioning |           
+2025-11-17T21:25:07.371721 - omani010             | f3phwb     | Allocated  |           
+2025-11-17T21:25:07.372066 - irvingi01            | kqrcx4     | Ready      |           
+2025-11-17T21:25:07.372340 - irvingi02            | gghwhd     | Deployed   | jammy     
+2025-11-17T21:25:07.372614 - irvingi03            | hw3h8x     | Deployed   | jammy     
+2025-11-17T21:25:07.372877 - irvingi04            | n67y3g     | Ready      |           
+2025-11-17T21:25:07.373139 - irvingi05            | wsskrw     | Deployed   | jammy     
+2025-11-17T21:25:07.373393 - irvingi06            | cwfbm7     | Deployed   | jammy     
+2025-11-17T21:25:07.373645 - irvingi07            | nabcab     | Deployed   | jammy     
+2025-11-17T21:25:07.373895 - irvingi08            | kbykkp     | Ready      |           
+2025-11-17T21:25:07.374148 - braggi01             | xxcwcs     | Deployed   | jammy     
+2025-11-17T21:25:07.374402 - braggi02             | 7y8rp8     | Deployed   | jammy     
+2025-11-17T21:25:07.374661 - braggi03             | xndrfr     | Deployed   | jammy     
+2025-11-17T21:25:07.374913 - braggi04             | 43ptc8     | Deployed   | 9-stream  
+2025-11-17T21:25:07.375173 - braggi05             | wcrhdk     | Allocated  |           
+2025-11-17T21:25:07.375421 - braggi06             | qrebpa     | Deployed   | 9-stream  
+2025-11-17T21:25:07.375660 - braggi07             | cec3xk     | Deployed   | 9-stream  
+2025-11-17T21:25:07.375887 - braggi08             | 6m3f8y     | Allocated  |           
+2025-11-17T21:25:07.376115 - braggi09             | cxpyab     | Allocated  |           
+2025-11-17T21:25:07.376340 - braggi10             | n8etyc     | Allocated  |           
+2025-11-17T21:25:07.376570 - braggi11             | x8c7d6     | Deployed   | jammy     
+2025-11-17T21:25:07.376795 - braggi12             | hbrbsb     | Allocated  |           
+2025-11-17T21:25:07.377022 - braggi13             | 6rqakh     | Allocated  |           
+2025-11-17T21:25:07.377250 - braggi14             | xtysxg     | Deployed   | 9-stream  
+2025-11-17T21:25:07.377473 - braggi15             | gyahnb     | Allocated  |           
+2025-11-17T21:25:07.377695 - braggi16             | bgxfb7     | Deployed   | 9-stream  
+2025-11-17T21:25:07.377924 - braggi17             | h74db3     | Deployed   | jammy     
+2025-11-17T21:25:07.378147 - braggi18             | awbqm3     | Deployed   | noble     
+2025-11-17T21:25:07.378337 - braggi22             | 4pp7aa     | Allocated  |           
+2025-11-17T21:25:07.378496 - sulcata02            | pfh3pf     | Failed commissioning |           
+2025-11-17T21:25:07.378654 - braggi20             | 4r44k6     | Deployed   | jammy     
+2025-11-17T21:25:07.378813 - braggi19             | k7nfqc     | Deployed   | 9-stream  
+2025-11-17T21:25:07.379055 - gibba004             | 7qcacw     | Deployed   | noble     
+2025-11-17T21:25:07.379263 - gibba005             | ehfgy8     | Deployed   | noble     
+2025-11-17T21:25:07.379428 - gibba006             | gqpysn     | Deployed   | noble     
+2025-11-17T21:25:07.379592 - gibba008             | xynwxt     | Allocated  |           
+2025-11-17T21:25:07.379754 - gibba009             | 8hfsy8     | Allocated  |           
+2025-11-17T21:25:07.379969 - gibba010             | p8fsyp     | Allocated  |           
+2025-11-17T21:25:07.380126 - gibba003             | aqk6pm     | Deployed   | noble     
+2025-11-17T21:25:07.380281 - refarch-r220-01      | ekx4yy     | Deployed   | noble     
+2025-11-17T21:25:07.380436 - refarch-r220-02      | g43rt7     | Deployed   | 9-stream  
+2025-11-17T21:25:07.380593 - refarch-r220-04      | k3rg6d     | Deployed   | 9-stream  
+2025-11-17T21:25:07.380744 - refarch-r220-05      | d4hweb     | Ready      |           
+2025-11-17T21:25:07.380895 - refarch-r220-06      | pm3e7q     | Deployed   | noble     
+2025-11-17T21:25:34.807935 - ID    | OS Type         | Release         | Architecture
+2025-11-17T21:25:34.808423 - ------------------------------------------------------------
+2025-11-17T21:25:34.809073 - 35    | centos          | 8               | amd64/generic
+2025-11-17T21:25:34.809277 - 34    | centos          | centos70        | amd64/generic
+2025-11-17T21:25:34.809466 - 1     | grub-efi-signed | uefi            | amd64/generic
+2025-11-17T21:25:34.809650 - 2     | grub-efi        | uefi            | arm64/generic
+2025-11-17T21:25:34.809831 - 3     | grub-ieee1275   | open-firmware   | ppc64el/generic
+2025-11-17T21:25:34.810009 - 4     | pxelinux        | pxe             | i386/generic
+2025-11-17T21:25:34.810187 - 19    | ubuntu          | jammy           | amd64/ga-22.04
+2025-11-17T21:25:34.810363 - 20    | ubuntu          | jammy           | amd64/ga-22.04-lowlatency
+2025-11-17T21:25:34.810540 - 21    | ubuntu          | jammy           | amd64/hwe-22.04
+2025-11-17T21:25:34.810715 - 22    | ubuntu          | jammy           | amd64/hwe-22.04-edge
+2025-11-17T21:25:34.810891 - 23    | ubuntu          | jammy           | amd64/hwe-22.04-lowlatency
+2025-11-17T21:25:34.811067 - 24    | ubuntu          | jammy           | amd64/hwe-22.04-lowlatency-edge
+2025-11-17T21:25:34.811241 - 25    | ubuntu          | jammy           | arm64/ga-22.04
+2025-11-17T21:25:34.811415 - 26    | ubuntu          | jammy           | arm64/hwe-22.04
+2025-11-17T21:25:34.811588 - 27    | ubuntu          | jammy           | arm64/hwe-22.04-edge
+2025-11-17T21:25:34.811762 - 28    | ubuntu          | jammy           | arm64/hwe-22.04-lowlatency
+2025-11-17T21:25:34.811936 - 29    | ubuntu          | jammy           | arm64/hwe-22.04-lowlatency-edge
+2025-11-17T21:25:34.812105 - 30    | ubuntu          | jammy           | arm64/xgene-uboot
+2025-11-17T21:25:34.812280 - 31    | ubuntu          | jammy           | arm64/xgene-uboot-mustang
+2025-11-17T21:25:34.812451 - 11    | ubuntu          | mantic          | amd64/ga-23.10
+2025-11-17T21:25:34.812623 - 12    | ubuntu          | mantic          | amd64/ga-23.10-lowlatency
+2025-11-17T21:25:34.812796 - 13    | ubuntu          | mantic          | arm64/ga-23.10
+2025-11-17T21:25:34.812965 - 5     | ubuntu          | noble           | amd64/ga-24.04
+2025-11-17T21:25:34.813136 - 6     | ubuntu          | noble           | amd64/ga-24.04-lowlatency
+2025-11-17T21:25:34.813307 - 7     | ubuntu          | noble           | amd64/hwe-24.04
+2025-11-17T21:25:34.813510 - 8     | ubuntu          | noble           | amd64/hwe-24.04-edge
+2025-11-17T21:25:34.813680 - 9     | ubuntu          | noble           | amd64/hwe-24.04-lowlatency
+2025-11-17T21:25:34.813850 - 10    | ubuntu          | noble           | amd64/hwe-24.04-lowlatency-edge
+2025-11-17T21:25:34.814014 - 14    | ubuntu          | noble           | arm64/ga-24.04
+2025-11-17T21:25:34.814187 - 15    | ubuntu          | noble           | arm64/hwe-24.04
+2025-11-17T21:25:34.814366 - 16    | ubuntu          | noble           | arm64/hwe-24.04-edge
+2025-11-17T21:25:34.814549 - 17    | ubuntu          | noble           | arm64/hwe-24.04-lowlatency
+2025-11-17T21:25:34.814718 - 18    | ubuntu          | noble           | arm64/hwe-24.04-lowlatency-edge
+2025-11-17T21:25:34.814885 - 32    | centos          | 9-stream        | amd64/generic
+2025-11-17T21:25:34.815052 - 33    | centos          | 9-stream        | arm64/generic
+2025-11-17T21:25:34.815325 - 40    | rhel            | rhel10          | amd64/generic
+2025-11-17T21:25:34.815498 - 39    | -               | -               | amd64/generic
+2025-11-17T21:25:34.815671 - 37    | -               | -               | arm64/generic
+2025-11-17T21:26:02.865862 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T21:26:02.866722 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Ready
+OS Distro:        
+OS Type:          
+Owner:            None
+Power Type:       ipmi
+Power Status:     PowerState.OFF
+Last Deployed At: -
+2025-11-17T21:26:44.182501 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T21:26:44.183607 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Ready
+OS Distro:        
+OS Type:          
+Owner:            None
+Power Type:       ipmi
+Power Status:     PowerState.OFF
+Last Deployed At: -
+2025-11-17T21:26:58.161401 - [ACTION] Deploying irvingi04 using OS 'focal'...
+2025-11-17T21:26:59.794098 - [ERROR] Failed to trigger deployment for irvingi04: POST http://refarch-r730xd-01.front.sepia.ceph.com:5240/MAAS/api/2.0/machines/n67y3g/?op=deploy -> HTTP 400 Bad Request ({"distro_series": ["'focal' is not a valid distro…)
+2025-11-17T21:28:55.999828 - Machine 'grim027' not found.
+2025-11-17T21:29:31.449775 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T21:29:31.450083 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: -
+OS Type: -
+Owner: -
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T21:30:01.746168 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T21:30:01.746706 - Name: irvingi04
+System ID: n67y3g
+Status: Ready
+OS Distro: -
+OS Type: -
+Owner: -
+Power Type: ipmi
+Power Status: PowerState.OFF
+2025-11-17T21:36:37.116576 - Machine irvingi04 successfully redeployed with jammy
+2025-11-17T21:37:26.661158 - 
+Machine Details
+------------------------------------------------------------
+2025-11-17T21:37:26.662744 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Deployed
+OS Distro:        jammy
+OS Type:          ubuntu
+Owner:            User
+Power Type:       ipmi
+Power Status:     PowerState.ON
+2025-11-17T21:37:26.664868 - [ACTION] Releasing irvingi04...
+2025-11-17T21:38:21.798002 - [ACTION] Deploying irvingi04 using OS 'jammy'...
+2025-11-17T21:44:55.041127 - [SUCCESS] Deployment completed for irvingi04.
+2025-11-17T21:44:55.041644 - [SUCCESS] Redeployment completed for irvingi04.
+2025-11-18T11:34:41.539246 - 
+Machine Details
+------------------------------------------------------------
+2025-11-18T11:34:41.543879 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Deployed
+OS Distro:        jammy
+OS Type:          ubuntu
+Owner:            User
+Power Type:       ipmi
+Power Status:     PowerState.ON
+2025-11-18T11:40:22.041395 - 
+Machine Details
+------------------------------------------------------------
+2025-11-18T11:40:22.043391 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Deployed
+OS Distro:        jammy
+OS Type:          ubuntu
+Owner:            User
+Power Type:       ipmi
+Power Status:     PowerState.ON
+2025-11-18T11:48:44.977520 - 
+Machine Details
+------------------------------------------------------------
+2025-11-18T11:48:44.979302 - Name:             irvingi04
+System ID:        n67y3g
+Status:           Deployed
+OS Distro:        jammy
+OS Type:          ubuntu
+Owner:            User
+Power Type:       ipmi
+Power Status:     PowerState.ON
+2025-11-18T11:48:44.980320 - [ACTION] Releasing irvingi04...
+2025-11-18T11:49:08.905242 - [ACTION] Deploying irvingi04 using OS 'jammy'...
+2025-11-18T11:55:23.921828 - [SUCCESS] Deployment completed for irvingi04.
+2025-11-18T11:55:23.923607 - [SUCCESS] Redeployment completed for irvingi04

--- a/builder-reimage/requirements.txt
+++ b/builder-reimage/requirements.txt
@@ -1,0 +1,9 @@
+requests>=2.31.0
+aiohttp>=3.9.0
+asyncio>=3.4.3
+python-dotenv>=1.0.1
+tabulate>=0.9.0
+cryptography>=36.0.0
+maas>=1.3.2
+python-libmaas>=0.6.8
+setuptools>=80.9.0

--- a/builder-reimage/tester.py
+++ b/builder-reimage/tester.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import asyncio
+from maas.client import connect
+
+
+MAAS_URL = "http://sepia-maas.front.sepia.ceph.com:5240/MAAS"
+API_KEY  = "xVHTt7i4DaFKQB9NSF:x1wybSshyACdPWFbgd:AKrF3dz8GAmONo7OOAjVN5nVW1vtZiFz"
+
+MACHINE_NAME = "irvingi08"             # <<< MACHINE TO TEST
+TEST_OWNER   = "jitendra"              # <<< TAG NAME TO TEST
+
+
+async def debug_tag_test():
+    print("\nConnecting to MAAS...")
+    client = await connect(MAAS_URL, apikey=API_KEY)
+
+    print("\nFetching machines...")
+    machines = await client.machines.list()
+
+    machine = next((m for m in machines if m.hostname == MACHINE_NAME), None)
+    if not machine:
+        print(f"ERROR: Machine '{MACHINE_NAME}' not found.")
+        return
+
+    print(f"\nMachine found: {machine.hostname} ({machine.system_id})")
+
+    # --------------------------
+    # SHOW EXISTING TAGS
+    # --------------------------
+    print("\n=== BEFORE TAGGING ===")
+    print("machine.tags =", machine.tags)
+
+    print("\nclient.tags.list():")
+    tags = await client.tags.list()
+    for t in tags:
+        print(" -", t, " name=", getattr(t, "name", None))
+
+    # --------------------------
+    # APPLY OWNER TAG
+    # --------------------------
+    sanitized = TEST_OWNER.replace(" ", "_").replace("@", "_")
+    print(f"\nSanitized tag name = '{sanitized}'")
+
+    # Create tag if missing
+    if not any(getattr(t, "name", "") == sanitized for t in tags):
+        print(f"Creating new tag '{sanitized}'...")
+        await client.tags.create(name=sanitized)
+    else:
+        print(f"Tag '{sanitized}' already exists.")
+
+    # Assign the tag
+    tag_obj = await client.tags.get(name=sanitized)
+    print(f"Assigning tag '{sanitized}' to machine '{machine.hostname}'...")
+    await machine.tags.add(tag_obj)
+
+    # Refresh machine
+    print("Refreshing machine after tagging...")
+    await machine.refresh()
+
+    # --------------------------
+    # SHOW UPDATED TAGS
+    # --------------------------
+    print("\n=== AFTER TAGGING ===")
+    print("machine.tags =", machine.tags)
+
+    tags = await client.tags.list()
+    print("\nclient.tags.list():")
+    for t in tags:
+        print(" -", t, " name=", getattr(t, "name", None))
+
+    print("\n=== DONE ===")
+
+
+if __name__ == "__main__":
+    asyncio.run(debug_tag_test())
+

--- a/ceph-website-prs/build/build
+++ b/ceph-website-prs/build/build
@@ -4,6 +4,10 @@ set -ex
 env
 
 BRANCH=$(echo $GIT_BRANCH | sed 's:.*/::')
+if [ "$BRANCH" = "main" ]; then
+  echo "branch must not be named 'main', exiting"
+  exit 1
+fi
 
 set +e
 export NVM_DIR="$HOME/.nvm"
@@ -18,16 +22,14 @@ npm ci
 
 npm run build:development
 
-if [ "$BRANCH" = "main" ]; then
-  echo "branch must not be named 'main', exiting"
-  exit 1
+# This will support "/" and "." in branch names - specific usecase being depadabot branches
+OUTPUT_DIR=$(echo "$BRANCH" | tr '/.' '-')
+
+if [ ! -d /opt/www/${OUTPUT_DIR} ]; then
+  mkdir -p /opt/www/${OUTPUT_DIR}
 fi
 
-if [ ! -d /opt/www/${BRANCH} ]; then
-  mkdir -p /opt/www/${BRANCH}
-fi
-
-rsync -av --delete-after dist/ /opt/www/${BRANCH}/
+rsync -av --delete-after dist/ /opt/www/${OUTPUT_DIR}/
 
 echo "===== Begin pruning old builds ====="
 old_builds=$(find /opt/www/ -maxdepth 1 -not -path "/opt/www/main" -type d -mtime +90 | sed 's:.*/::')
@@ -42,4 +44,4 @@ echo "===== Done pruning old builds ====="
 # This just makes the last `echo` line not repeat
 { set +x; } 2>/dev/null
 
-echo "Success!  This site is available at https://${BRANCH}.ceph.io."
+echo "Success!  This site is available at https://${OUTPUT_DIR}.ceph.io."

--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -16,7 +16,10 @@ set -euxo pipefail
 # when jenkins-job-builder 6.5 or later is released, this requirement should change to
 # jenkins-job-builder>=6.5
 
-pkgs=( "dataclasses" "jenkins-job-builder>=6.4.3" )
+# setuptools>=82 drops pkg_resources in practice; stevedore (used by JJB) still
+# imports pkg_resources when loading CLI subcommands, which breaks `jenkins-jobs`
+# on Python 3.12 with "No module named 'pkg_resources'".
+pkgs=( "dataclasses" "jenkins-job-builder>=6.4.3" "setuptools<82" )
 TEMPVENV=$(create_venv_dir)
 VENV=${TEMPVENV}/bin
 install_python_packages $TEMPVENV "pkgs[@]" latest

--- a/release-tracker-workflow/README.rst
+++ b/release-tracker-workflow/README.rst
@@ -1,0 +1,44 @@
+Release Tracker Workflow
+========================
+
+A Jenkins pipeline that automates RC (release candidate) testing for Ceph release trackers:
+
+- Resolve or accept a Ceph SHA1 (optional **CEPH_SHA1**; must exist on Shaman).
+- Wait for the SHA1 on Shaman, then schedule teuthology suites (all triggered at once, then wait for all).
+- Aggregate pass/fail results and post to Redmine (tracker.ceph.com) and/or send email.
+
+No build step: the pipeline relies on Shaman only (SHA1 must already be built and available).
+
+Requirements
+------------
+
+- Jenkins agent with label **teuthology-agent** (or set **AGENT_LABEL**); teuthology installed, ``~/.teuthology.yaml``, Shaman/Paddles reachable.
+- Credential **redmine-api-key** (or set **REDMINE_CREDENTIAL_ID**) in Jenkins for posting to tracker.ceph.com when **SKIP_TRACKER_UPDATE** is false.
+
+Parameters
+----------
+
+- **CEPH_BRANCH** / **CEPH_SHA1**: Branch to resolve SHA1 from, or a specific SHA1 to use (must exist on Shaman).
+- **SUITE_LIST_SOURCE**: Path relative to workspace (e.g. ``release-tracker-workflow/config/suites.yaml``) or URL for suite list; empty = use **SUITE_NAME**.
+- **SKIP_TRACKER_UPDATE** (default true): Do not post to Redmine.
+- **TRACKER_ISSUE_ID**: Redmine issue ID when posting (required when SKIP_TRACKER_UPDATE is false).
+
+Configuration (no hardcodings)
+------------------------------
+
+Paths and URLs are parameterized so the same job works across environments:
+
+- **AGENT_LABEL**: Jenkins agent label (default ``teuthology-agent``).
+- **TEUTHOLOGY_SCRIPT_DIR** / **TEUTHOLOGY_VIRTUALENV_PATH** / **TEUTHOLOGY_OVERRIDE_YAML**: Teuthology install path, virtualenv, and optional override YAML for teuthology-suite.
+- **PULPITO_BASE**: Base URL for Pulpito run links (default ``https://pulpito.ceph.com``).
+- **PADDLES_URL**: Paddles base URL for aggregation.
+- **REDMINE_CREDENTIAL_ID**: Jenkins credential ID for Redmine API key.
+- **SUITE_MACHINE_TYPE**, **SUITE_LIMIT**: Teuthology suite machine type and --limit.
+- **SHAMAN_WAIT_TIMEOUT**, **SHAMAN_WAIT_INTERVAL**, **SUITE_WAIT_SLEEP**: Timeouts and sleep for Shaman wait and suite scheduling.
+
+Suite lists
+-----------
+
+- ``release-tracker-workflow/config/suites.yaml``: list of teuthology suites to run.
+
+Set **SUITE_LIST_SOURCE** to this path (or a URL) to run multiple suites; all are triggered in parallel, then the pipeline waits for all and aggregates results.

--- a/release-tracker-workflow/build/Jenkinsfile
+++ b/release-tracker-workflow/build/Jenkinsfile
@@ -1,0 +1,524 @@
+/**
+ * Release tracker workflow: resolve SHA1 -> wait for shaman -> schedule suites -> aggregate -> report to redmine + email.
+ * Relies on Shaman only (no build step). Paths and URLs are parameterized.
+ */
+import com.cloudbees.groovy.cps.NonCPS
+
+pipeline {
+    agent { label "${params.AGENT_LABEL}" }
+    options { timestamps(); timeout(time: 24, unit: 'HOURS'); buildDiscarder(logRotator(numToKeepStr: '30')) }
+    environment {
+        PIPELINE_DIR = "${WORKSPACE}/release-tracker-workflow"
+        SCRIPT_DIR = "${params.TEUTHOLOGY_SCRIPT_DIR ?: ''}"
+        VIRTUALENV_PATH = "${params.TEUTHOLOGY_VIRTUALENV_PATH ?: ''}"
+        OVERRIDE_YAML = "${params.TEUTHOLOGY_OVERRIDE_YAML ?: ''}"
+        CEPH_DIR = "${WORKSPACE}/ceph"
+        PULPITO_BASE = "${params.PULPITO_BASE}"
+    }
+    parameters {
+        string(name: 'AGENT_LABEL', defaultValue: 'teuthology', description: 'Jenkins agent label to run this pipeline (e.g. teuthology for soko04).')
+        booleanParam(name: 'USE_WORKSPACE_TEUTHOLOGY', defaultValue: true, description: 'If true, clone teuthology into workspace (Jenkins-owned). If false, use TEUTHOLOGY_SCRIPT_DIR.')
+        string(name: 'TEUTHOLOGY_REPO_URL', defaultValue: 'https://github.com/ceph/teuthology.git', description: 'Teuthology repo URL (used when USE_WORKSPACE_TEUTHOLOGY is true).')
+        string(name: 'TEUTHOLOGY_BRANCH', defaultValue: 'main', description: 'Teuthology branch to clone (used when USE_WORKSPACE_TEUTHOLOGY is true).')
+        string(name: 'TEUTHOLOGY_SCRIPT_DIR', defaultValue: '', description: 'Path to existing teuthology clone (used when USE_WORKSPACE_TEUTHOLOGY is false).')
+        string(name: 'TEUTHOLOGY_VIRTUALENV_PATH', defaultValue: '', description: 'Path to teuthology virtualenv (used when USE_WORKSPACE_TEUTHOLOGY is false).')
+        string(name: 'TEUTHOLOGY_OVERRIDE_YAML', defaultValue: '', description: 'Optional override YAML passed to teuthology-suite. Use empty to omit.')
+        string(name: 'PULPITO_BASE', defaultValue: 'https://pulpito.ceph.com', description: 'Base URL for Pulpito (suite run links).')
+        string(name: 'WORKFLOW_REPO', defaultValue: '', description: 'Override: repo URL for workflow checkout (Jenkinsfile, scripts). Empty = use job SCM.')
+        string(name: 'WORKFLOW_BRANCH', defaultValue: 'main', description: 'Branch for workflow checkout. Used when WORKFLOW_REPO is set.')
+        string(name: 'CEPH_REPO', defaultValue: 'https://github.com/ceph/ceph.git', description: 'Ceph repo URL to test.')
+        string(name: 'CEPH_BRANCH', defaultValue: 'reef', description: 'Ceph branch to test.')
+        string(name: 'CEPH_SHA1', defaultValue: '', description: 'Optional: Ceph commit SHA1 to use. If set, run on this SHA1 (must exist on Shaman). Empty = resolve from branch tip.')
+        string(name: 'RELEASE_VERSION', defaultValue: '20.1.0', description: 'Release version (e.g. 20.1.0). Used in artifacts and suite list resolution.')
+        string(name: 'BUILD_JOB_NAME', defaultValue: 'sample-ceph-pipeline', description: 'Build job to trigger when SKIP_BUILD is false.')
+        booleanParam(name: 'SKIP_BUILD', defaultValue: true, description: 'If true, do not trigger the build job. Only check Shaman for the resolved SHA1.')
+        string(name: 'TRACKER_ISSUE_ID', defaultValue: '', description: 'Redmine tracker issue ID. Required when posting to tracker.')
+        string(name: 'SUITE_NAME', defaultValue: 'smoke', description: 'Single suite when SUITE_LIST_SOURCE is empty')
+        string(name: 'SUITE_LIST_SOURCE', defaultValue: '', description: 'Path under workspace or HTTPS URL. URLs must be github.com or raw.githubusercontent.com under org ceph only. Empty = use SUITE_NAME.')
+        string(name: 'EMAIL_RECIPIENTS', defaultValue: '', description: 'Comma-separated emails to notify when run finishes. Empty = no email.')
+        string(name: 'REDMINE_CREDENTIAL_ID', defaultValue: '', description: 'Jenkins credential ID for Redmine API key.')
+        string(name: 'SUITE_REPO', defaultValue: 'https://github.com/ceph/ceph-ci.git', description: 'Suite repo URL for teuthology-suite (--suite-repo).')
+        string(name: 'SUITE_SHA', defaultValue: '', description: 'Optional suite repo commit SHA for teuthology-suite. Empty = default branch behavior.')
+        string(name: 'SUITE_MACHINE_TYPE', defaultValue: 'trial', description: 'Machine type for teuthology-suite.')
+        string(name: 'SUITE_LIMIT', defaultValue: '1', description: '--limit for teuthology-suite.')
+        string(name: 'SUITE_JOB_THRESHOLD', defaultValue: '', description: 'Optional: --job-threshold for teuthology-suite (non-negative integer). Empty = omit.')
+        string(name: 'SUITE_SUBSET', defaultValue: '', description: 'Optional: --subset for teuthology-suite (e.g. 1/10000). Empty = omit.')
+        string(name: 'SHAMAN_WAIT_TIMEOUT', defaultValue: '3600', description: 'Timeout in seconds for wait_for_shaman_sha1.py.')
+        string(name: 'SHAMAN_WAIT_INTERVAL', defaultValue: '120', description: 'Poll interval in seconds for wait_for_shaman_sha1.py.')
+        string(name: 'SHAMAN_WAIT_PLATFORMS', defaultValue: 'ubuntu-noble-default,centos-9-default', description: 'Comma-separated platforms for wait_for_shaman_sha1.py --platform (must match Shaman, e.g. ubuntu-jammy for older branches).')
+        string(name: 'SUITE_WAIT_SLEEP', defaultValue: '15', description: 'Seconds to sleep after scheduling all suites before teuthology-wait.')
+        booleanParam(name: 'SKIP_TRACKER_UPDATE', defaultValue: true, description: 'If true, do not post to Redmine. Enable only when you want to update the tracker.')
+    }
+    stages {
+        stage('Checkout and Resolve SHA1') {
+            steps {
+                script {
+                    if (params.WORKFLOW_REPO?.trim()) {
+                        checkout([$class: 'GitSCM', branches: [[name: params.WORKFLOW_BRANCH ?: 'main']],
+                            userRemoteConfigs: [[url: params.WORKFLOW_REPO.trim()]]])
+                    } else {
+                        checkout scm
+                    }
+                    if (params.CEPH_SHA1?.trim()) {
+                        env.SHA1 = params.CEPH_SHA1.trim()
+                        echo "Using CEPH_SHA1: ${env.SHA1} (must exist on Shaman for branch ${params.CEPH_BRANCH})"
+                    } else {
+                        dir("${env.CEPH_DIR}") {
+                            checkout([$class: "GitSCM", branches: [[name: "${params.CEPH_BRANCH}"]],
+                                extensions: [[$class: "CloneOption", depth: 1, shallow: true]],
+                                userRemoteConfigs: [[url: "${params.CEPH_REPO}"]]])
+                            env.SHA1 = sh(script: 'git rev-parse HEAD 2>/dev/null || echo "unknown"', returnStdout: true).trim()
+                        }
+                        echo "Branch: ${params.CEPH_BRANCH} | SHA1: ${env.SHA1}"
+                    }
+                }
+            }
+        }
+        stage('Setup teuthology') {
+            when { expression { return params.USE_WORKSPACE_TEUTHOLOGY } }
+            steps {
+                script {
+                    def teuthDir = "${env.WORKSPACE}/teuthology"
+                    dir(teuthDir) {
+                        checkout([$class: 'GitSCM', branches: [[name: params.TEUTHOLOGY_BRANCH ?: 'main']],
+                            extensions: [[$class: 'CloneOption', depth: 1, shallow: true]],
+                            userRemoteConfigs: [[url: params.TEUTHOLOGY_REPO_URL]]])
+                    }
+                    dir(teuthDir) {
+                        if (fileExists('bootstrap')) {
+                            sh './bootstrap'
+                        } else {
+                            sh 'python3 -m venv virtualenv'
+                            sh 'virtualenv/bin/pip install --upgrade pip'
+                            sh 'virtualenv/bin/pip install -r requirements.txt 2>/dev/null || true'
+                            sh 'virtualenv/bin/pip install -e .'
+                        }
+                    }
+                    env.SCRIPT_DIR = teuthDir
+                    env.VIRTUALENV_PATH = "${teuthDir}/virtualenv"
+                    echo "Teuthology cloned to ${teuthDir} (Jenkins-owned)"
+                }
+            }
+        }
+        stage('Build') {
+            when { expression { return !params.SKIP_BUILD } }
+            steps {
+                script {
+                    def b = build job: params.BUILD_JOB_NAME, wait: true, propagate: true
+                    env.BUILD_JOB_URL = b.absoluteUrl
+                }
+            }
+        }
+        stage('Wait for Shaman') {
+            steps {
+                script {
+                    def w = "${env.PIPELINE_DIR}/scripts/wait_for_shaman_sha1.py"
+                    if (fileExists(w)) sh "python3 ${w} --branch ${params.CEPH_BRANCH} --sha1 ${env.SHA1} --timeout ${params.SHAMAN_WAIT_TIMEOUT} --interval ${params.SHAMAN_WAIT_INTERVAL} --platform ${params.SHAMAN_WAIT_PLATFORMS}"
+                    else echo "wait_for_shaman_sha1.py not found; continuing."
+                }
+            }
+        }
+        stage('Resolve suite list') {
+            steps {
+                script {
+                    env.SUITE_LIST = resolveSuiteList(params.SUITE_LIST_SOURCE, params.SUITE_NAME, params.CEPH_BRANCH, params.RELEASE_VERSION)
+                    echo "Suites to run: ${env.SUITE_LIST}"
+                }
+            }
+        }
+        stage('Schedule suites') {
+            steps {
+                script {
+                    def scriptDir
+                    def virtualenvPath
+                    def useWorkspace = (params.get('USE_WORKSPACE_TEUTHOLOGY') != null) ? params.get('USE_WORKSPACE_TEUTHOLOGY') : true
+                    if (useWorkspace) {
+                        scriptDir = "${env.WORKSPACE}/teuthology"
+                        virtualenvPath = "${scriptDir}/virtualenv"
+                    } else {
+                        def scriptDirParam = null
+                        def venvParam = null
+                        try { scriptDirParam = params.TEUTHOLOGY_SCRIPT_DIR?.toString()?.trim() } catch (e) { }
+                        try { venvParam = params.TEUTHOLOGY_VIRTUALENV_PATH?.toString()?.trim() } catch (e) { }
+                        def envScriptDir = (env.TEUTHOLOGY_SCRIPT_DIR?.trim() && env.TEUTHOLOGY_SCRIPT_DIR != 'null') ? env.TEUTHOLOGY_SCRIPT_DIR.trim() : null
+                        def envScriptDir2 = (env.SCRIPT_DIR?.trim() && env.SCRIPT_DIR != 'null') ? env.SCRIPT_DIR.trim() : null
+                        def envVenv = (env.TEUTHOLOGY_VIRTUALENV_PATH?.trim() && env.TEUTHOLOGY_VIRTUALENV_PATH != 'null') ? env.TEUTHOLOGY_VIRTUALENV_PATH.trim() : null
+                        def envVenv2 = (env.VIRTUALENV_PATH?.trim() && env.VIRTUALENV_PATH != 'null') ? env.VIRTUALENV_PATH.trim() : null
+                        scriptDir = scriptDirParam ?: envScriptDir ?: envScriptDir2 ?: "${env.WORKSPACE}/teuthology"
+                        virtualenvPath = venvParam ?: envVenv ?: envVenv2 ?: "${scriptDir}/virtualenv"
+                        echo "DEBUG: scriptDirParam='${scriptDirParam}' envScriptDir='${envScriptDir}' envScriptDir2='${envScriptDir2}' -> scriptDir='${scriptDir}'"
+                        if (!scriptDir || scriptDir == "${env.WORKSPACE}/teuthology" || scriptDir == 'null') {
+                            error("USE_WORKSPACE_TEUTHOLOGY is false but TEUTHOLOGY_SCRIPT_DIR is not set. Set TEUTHOLOGY_SCRIPT_DIR and TEUTHOLOGY_VIRTUALENV_PATH as job parameters or as environment variables (Job > Configure).")
+                        }
+                    }
+                    echo "Teuthology: scriptDir=${scriptDir} virtualenvPath=${virtualenvPath} (USE_WORKSPACE_TEUTHOLOGY=${useWorkspace})"
+                    def teuthologyConfigPath = '/etc/teuthology.yaml'
+                    if (!fileExists(teuthologyConfigPath)) {
+                        error("Required site config not found: ${teuthologyConfigPath}")
+                    }
+                    echo "Using site config: ${teuthologyConfigPath}"
+                    def cfgText = readFile(teuthologyConfigPath)
+                    def aggPaddlesUrl = parseAggPaddlesUrlFromTeuthYaml(cfgText)
+                    if (!aggPaddlesUrl) {
+                        error("Could not resolve results_server/lock_server from ${teuthologyConfigPath}")
+                    }
+                    env.AGG_PADDLES_URL = aggPaddlesUrl.endsWith('/') ? aggPaddlesUrl : (aggPaddlesUrl + '/')
+                    echo "Aggregation Paddles URL from config: ${env.AGG_PADDLES_URL}"
+                    def defaultList = params.SUITE_NAME?.trim() ? [params.SUITE_NAME] : []
+                    def suites = env.SUITE_LIST?.split(',')?.collect { it.trim() }?.findAll { it } ?: defaultList
+                    suites = suites.findAll { it?.trim() }
+                    if (!suites) {
+                        error("No suites to run: SUITE_LIST resolved empty and SUITE_NAME is not set. Set SUITE_LIST_SOURCE (e.g. release-tracker-workflow/config/suites.yaml) or SUITE_NAME.")
+                    }
+                    def suiteNamePattern = ~'^[a-zA-Z0-9_/:-]+$'
+                    for (suite in suites) {
+                        def s = suite?.toString()?.trim()
+                        if (!s || !(s ==~ suiteNamePattern)) {
+                            error("Invalid suite name (only letters, digits, /, _, :, - allowed): ${suite}")
+                        }
+                    }
+                    def envVars = [
+                        "SCRIPT_DIR=${scriptDir}",
+                        "VIRTUALENV_PATH=${virtualenvPath}",
+                        "HOME=${env.WORKSPACE}",
+                    ] + paddlesTlsSslEnv()
+                    if (teuthologyConfigPath) {
+                        envVars << "TEUTHOLOGY_CONFIG=${teuthologyConfigPath}"
+                    }
+                    def runInfos = []
+                    withEnv(envVars) {
+                        for (suite in suites) {
+                            def runName = scheduleSuiteOnly(params.CEPH_BRANCH, env.SHA1, suite)
+                            if (runName) runInfos << [suite, runName]
+                        }
+                    }
+                    def runNames = runInfos.collect { it[1] }
+                    env.TEUTHOLOGY_RUN_NAMES = runNames ? runNames.join(',') : ''
+                    env.RELEASE_TRACKER_TEUTH_SCRIPT_DIR = scriptDir
+                    env.RELEASE_TRACKER_TEUTH_VENV = virtualenvPath
+                    writeFile file: "${WORKSPACE}/.release_tracker_run_infos.txt", text: runInfos.collect { "${it[0]}|${it[1]}" }.join('\n')
+                }
+            }
+        }
+        stage('Wait for suite runs') {
+            steps {
+                script {
+                    def names = env.TEUTHOLOGY_RUN_NAMES?.trim()
+                    if (!names) {
+                        echo 'No teuthology runs to wait for (nothing scheduled).'
+                        return
+                    }
+                    def runNameList = names.split(',').collect { it.trim() }.findAll { it }
+                    if (!runNameList) {
+                        echo 'No teuthology runs to wait for.'
+                        return
+                    }
+                    def sd = env.RELEASE_TRACKER_TEUTH_SCRIPT_DIR
+                    def ve = env.RELEASE_TRACKER_TEUTH_VENV
+                    if (!sd?.trim() || !ve?.trim()) {
+                        error('RELEASE_TRACKER_TEUTH_SCRIPT_DIR / RELEASE_TRACKER_TEUTH_VENV not set (Schedule suites stage must run first).')
+                    }
+                    sleep(time: params.SUITE_WAIT_SLEEP.toInteger(), unit: 'SECONDS')
+                    def waitEnv = ["HOME=${env.WORKSPACE}"] + paddlesTlsSslEnv()
+                    def teuthCfg = '/etc/teuthology.yaml'
+                    if (fileExists(teuthCfg)) {
+                        waitEnv << "TEUTHOLOGY_CONFIG=${teuthCfg}"
+                    }
+                    withEnv(waitEnv) {
+                        dir(sd) {
+                            for (runName in runNameList) {
+                                sh "${ve}/bin/teuthology-wait --run ${runName}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Collect results, aggregate, and summarize') {
+            steps {
+                script {
+                    def runInfos = []
+                    if (fileExists("${WORKSPACE}/.release_tracker_run_infos.txt")) {
+                        def txt = readFile("${WORKSPACE}/.release_tracker_run_infos.txt").trim()
+                        if (txt) {
+                            for (line in txt.split('\n')) {
+                                def t = line.trim()
+                                if (!t) continue
+                                def pipeAt = t.indexOf('|')
+                                if (pipeAt > 0 && pipeAt < t.length() - 1) {
+                                    runInfos << [t.substring(0, pipeAt), t.substring(pipeAt + 1)]
+                                }
+                            }
+                        }
+                    }
+                    def runNames = runInfos.collect { it[1] }
+                    def aggScript = "${env.PIPELINE_DIR}/scripts/aggregate_suite_results.py"
+                    env.TEUTHOLOGY_RUN_NAMES = runNames.join(',')
+                    env.TEUTHOLOGY_RUN_NAME = runNames ? runNames[0] : 'N/A'
+                    if (runInfos && fileExists(aggScript)) {
+                        def runFlags = runNames.collect { "--run ${it}" }.join(' ')
+                        withEnv(paddlesTlsSslEnv()) {
+                            sh "python3 ${aggScript} ${runFlags} --paddles-url ${env.AGG_PADDLES_URL} --out ${WORKSPACE}/aggregate_table.txt"
+                        }
+                    } else if (!fileExists("${WORKSPACE}/aggregate_table.txt")) {
+                        writeFile file: "${WORKSPACE}/aggregate_table.txt", text: "Runs: ${env.TEUTHOLOGY_RUN_NAMES ?: ''}"
+                    }
+                    if (env.TEUTHOLOGY_RUN_NAME != 'N/A' && !fileExists("${WORKSPACE}/aggregate_table.txt")) {
+                        def a = "${env.PIPELINE_DIR}/scripts/aggregate_suite_results.py"
+                        if (fileExists(a)) {
+                            withEnv(paddlesTlsSslEnv()) {
+                                sh "python3 ${a} --run ${env.TEUTHOLOGY_RUN_NAME} --paddles-url ${env.AGG_PADDLES_URL} --out ${WORKSPACE}/aggregate_table.txt"
+                            }
+                        } else {
+                            writeFile file: "${WORKSPACE}/aggregate_table.txt", text: "Run: ${env.TEUTHOLOGY_RUN_NAME}"
+                        }
+                    }
+                    if (!env.TEUTHOLOGY_RUN_NAME) env.TEUTHOLOGY_RUN_NAME = 'skipped'
+                    if (!env.TEUTHOLOGY_RUN_NAMES) env.TEUTHOLOGY_RUN_NAMES = env.TEUTHOLOGY_RUN_NAME
+                    if (!env.BUILD_JOB_URL) env.BUILD_JOB_URL = 'N/A'
+                    def lines = []
+                    lines << "Release workflow: ${env.BUILD_URL}"
+                    lines << "Version: ${params.RELEASE_VERSION}"
+                    lines << "Branch: ${params.CEPH_BRANCH}"
+                    lines << "SHA1: ${env.SHA1}"
+                    lines << "Build job: ${env.BUILD_JOB_URL}"
+                    lines << ''
+                    lines << 'Run details:'
+                    if (runInfos) {
+                        for (info in runInfos) {
+                            lines << "  - ${info[0]}: ${env.PULPITO_BASE}/${info[1]}"
+                        }
+                    } else if (env.TEUTHOLOGY_RUN_NAMES && env.TEUTHOLOGY_RUN_NAMES != 'skipped') {
+                        for (rn in env.TEUTHOLOGY_RUN_NAMES.split(',').collect { it.trim() }.findAll { it }) {
+                            lines << "  - ${env.PULPITO_BASE}/${rn}"
+                        }
+                    } else {
+                        lines << '  (none)'
+                    }
+                    if (fileExists("${WORKSPACE}/aggregate_table.txt")) {
+                        lines << ''
+                        lines << 'Suite results:'
+                        lines << readFile("${WORKSPACE}/aggregate_table.txt")
+                    }
+                    writeFile file: "${WORKSPACE}/tracker_note.txt", text: lines.join('\n')
+                }
+            }
+        }
+        stage('Update tracker') {
+            when { expression { return !params.SKIP_TRACKER_UPDATE && params.TRACKER_ISSUE_ID?.trim() } }
+            steps {
+                script {
+                    def scriptPath = "${env.PIPELINE_DIR}/build/scripts/redmine_post_note.sh"
+                    withCredentials([string(credentialsId: params.REDMINE_CREDENTIAL_ID, variable: 'REDMINE_API_KEY')]) {
+                        withEnv(['REDMINE_URL=https://tracker.ceph.com']) {
+                            if (fileExists(scriptPath)) sh "bash ${scriptPath} ${params.TRACKER_ISSUE_ID.trim()} ${WORKSPACE}/tracker_note.txt"
+                            else echo "Redmine script not found; post tracker_note.txt manually to #${params.TRACKER_ISSUE_ID}"
+                        }
+                    }
+                }
+            }
+        }
+        stage('Release notes stub and archive') {
+            steps {
+                script {
+                    writeFile file: "${WORKSPACE}/release_notes_draft.md", text: "# Ceph ${params.RELEASE_VERSION} (${params.CEPH_BRANCH})\n\nBranch: ${params.CEPH_BRANCH}\nSHA1: ${env.SHA1}\nBuild job: ${env.BUILD_JOB_URL ?: 'N/A'}\nSuite: ${env.TEUTHOLOGY_RUN_NAME ?: 'N/A'}\n\nTracker #${params.TRACKER_ISSUE_ID ?: '(not set)'}."
+                    archiveArtifacts artifacts: "release_notes_draft.md", allowEmptyArchive: true
+                }
+            }
+        }
+    }
+    post {
+        success { echo "Done." }
+        failure { echo "Failed." }
+        always {
+            script {
+                if (params.EMAIL_RECIPIENTS?.trim()) {
+                    def redmineTrackerBase = 'https://tracker.ceph.com'
+                    def bodyParts = []
+                    bodyParts << "RC testing flow: ${env.JOB_NAME} #${env.BUILD_NUMBER}"
+                    bodyParts << "Result: ${currentBuild.currentResult}"
+                    bodyParts << "Pipeline: ${env.BUILD_URL}"
+                    bodyParts << "Build job: ${env.BUILD_JOB_URL ?: 'N/A'}"
+                    if (params.TRACKER_ISSUE_ID?.trim()) {
+                        def tid = params.TRACKER_ISSUE_ID.trim()
+                        bodyParts << "Tracker: #${tid} (${redmineTrackerBase}/issues/${tid})"
+                    }
+                    bodyParts << ''
+                    if (fileExists("${WORKSPACE}/tracker_note.txt")) {
+                        bodyParts << readFile("${WORKSPACE}/tracker_note.txt")
+                    } else if (fileExists("${WORKSPACE}/aggregate_table.txt")) {
+                        bodyParts << 'Suite results:'
+                        bodyParts << readFile("${WORKSPACE}/aggregate_table.txt")
+                    } else {
+                        bodyParts << '(No tracker summary file for this run.)'
+                    }
+                    def bodyText = bodyParts.join('\n')
+                    def subj = params.TRACKER_ISSUE_ID?.trim()
+                        ? "RC testing ${env.JOB_NAME} #${env.BUILD_NUMBER} - tracker #${params.TRACKER_ISSUE_ID.trim()} - ${currentBuild.currentResult}"
+                        : "RC testing ${env.JOB_NAME} #${env.BUILD_NUMBER} - ${currentBuild.currentResult}"
+                    try {
+                        mail to: params.EMAIL_RECIPIENTS.trim(),
+                             subject: subj,
+                             body: bodyText
+                    } catch (Exception e) {
+                        echo "Email failed: ${e.message}"
+                    }
+                }
+            }
+        }
+    }
+}
+
+@NonCPS
+def parseAggPaddlesUrlFromTeuthYaml(String cfgText) {
+    def m = (cfgText =~ ~'(?m)^\\s*results_server\\s*:\\s*(\\S+)\\s*$')
+    if (m.find()) {
+        return m.group(1).trim()
+    }
+    m = (cfgText =~ ~'(?m)^\\s*lock_server\\s*:\\s*(\\S+)\\s*$')
+    if (m.find()) {
+        return m.group(1).trim()
+    }
+    return null
+}
+
+def paddlesTlsSslEnv() {
+    return [
+        'REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt',
+        'SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt',
+    ]
+}
+
+/** SUITE_LIST_SOURCE HTTP(S): only github.com / raw.githubusercontent.com, path must be under org ceph. */
+def assertSuiteListSourceGithubCephOrgUrl(String urlString) {
+    java.net.URL u
+    try {
+        u = new java.net.URL(urlString)
+    } catch (Exception e) {
+        error("SUITE_LIST_SOURCE: invalid URL: ${e.message}")
+    }
+    def host = (u.host ?: '').toLowerCase()
+    def path = u.path ?: ''
+    def okHosts = ['github.com', 'www.github.com', 'raw.githubusercontent.com']
+    if (!(host in okHosts)) {
+        error('SUITE_LIST_SOURCE URL: only https://github.com/... or https://raw.githubusercontent.com/... (GitHub) are allowed')
+    }
+    def p = path.toLowerCase()
+    if (!(p == '/ceph' || p.startsWith('/ceph/'))) {
+        error('SUITE_LIST_SOURCE URL: must point under the ceph GitHub org (e.g. https://github.com/ceph/... or https://raw.githubusercontent.com/ceph/...)')
+    }
+}
+
+def resolveSuiteList(String source, String defaultSuite, String branch, String version) {
+    if (!source?.trim()) return defaultSuite
+    def s = source.trim()
+    if (s.length() > 8192) {
+        error('SUITE_LIST_SOURCE: exceeds max length (8192)')
+    }
+    if (s.contains("'") || s.contains('"') || s.contains('\n') || s.contains('\r') || s.contains('`') || s.contains('$(')) {
+        error('SUITE_LIST_SOURCE: contains forbidden characters')
+    }
+    def raw = null
+    def lower = s.toLowerCase()
+    if (lower.startsWith('https://') || lower.startsWith('http://')) {
+        if (s.contains(';') || s.contains('|') || s.contains('>') || s.contains('<')) {
+            error('SUITE_LIST_SOURCE URL: forbidden characters')
+        }
+        assertSuiteListSourceGithubCephOrgUrl(s)
+        try {
+            def conn = new java.net.URL(s).openConnection()
+            conn.setConnectTimeout(15000)
+            conn.setReadTimeout(60000)
+            raw = conn.getInputStream().getText('UTF-8').trim()
+        } catch (Exception e) {
+            error("SUITE_LIST_SOURCE: failed to fetch URL: ${e.message}")
+        }
+    } else {
+        def path = s
+        if (path.contains('..')) {
+            error('SUITE_LIST_SOURCE path: parent segment ".." not allowed')
+        }
+        if (path.contains('${') || path.contains('branch') || path.contains('version')) {
+            path = path.replace('${branch}', branch).replace('${version}', version).replace('${BRANCH}', branch).replace('${VERSION}', version)
+        }
+        if (!path.startsWith('/')) {
+            path = "${WORKSPACE}/${path}"
+        }
+        def wsFile = new File(env.WORKSPACE as String).canonicalFile
+        def target = new File(path).canonicalFile
+        def wsPath = wsFile.absolutePath
+        def tpath = target.absolutePath
+        if (!tpath.startsWith(wsPath + File.separator) && tpath != wsPath) {
+            error('SUITE_LIST_SOURCE path must resolve under WORKSPACE')
+        }
+        def relPath = tpath.substring(wsPath.length() + 1)
+        if (fileExists(relPath)) {
+            raw = readFile(relPath).trim()
+        }
+    }
+    if (!raw) return defaultSuite
+    def list = []
+    for (line in raw.split('\n')) {
+        def t = line.trim()
+        def entry = null
+        if (t.startsWith('-')) entry = t.drop(1).trim()
+        else if (t && !t.startsWith('#') && !t.startsWith('suites:')) entry = t
+        if (entry) {
+            if (!(entry ==~ ~'^[a-zA-Z0-9_/:-]+$')) {
+                error("SUITE_LIST_SOURCE: invalid suite name (allowed: letters, digits, /, _, :, -): ${entry}")
+            }
+            list << entry
+        }
+    }
+    return list ? list.join(',') : defaultSuite
+}
+
+def scheduleSuiteOnly(String branch, String sha1, String suiteName) {
+    if (!suiteName?.trim()) return null
+    def safeName = suiteName.replaceAll('/', '_')
+    def runName = null
+    dir(env.SCRIPT_DIR) {
+        def outFile = "${env.WORKSPACE}/suite_out_${safeName}.txt"
+        def runner = "${env.PIPELINE_DIR}/scripts/run_teuthology_suite.sh"
+        if (!fileExists(runner)) {
+            error("run_teuthology_suite.sh not found: ${runner}")
+        }
+        def machineType = params.SUITE_MACHINE_TYPE?.trim() ?: 'trial'
+        def suiteLimit = params.SUITE_LIMIT?.trim() ?: '1'
+        def suiteRepo = params.SUITE_REPO?.trim() ?: ''
+        def suiteSha = params.SUITE_SHA?.trim() ?: ''
+        def jobThreshold = params.SUITE_JOB_THRESHOLD?.trim() ?: ''
+        def subset = params.SUITE_SUBSET?.trim() ?: ''
+        withEnv([
+            "SUITE_NAME=${suiteName}",
+            "CEPH_BRANCH=${branch}",
+            "CEPH_SHA1=${sha1}",
+            "OVERRIDE_YAML=${env.OVERRIDE_YAML ?: ''}",
+            "CEPH_REPO=${params.CEPH_REPO}",
+            "SUITE_LIMIT=${suiteLimit}",
+            "MACHINE_TYPE=${machineType}",
+            "SUITE_REPO=${suiteRepo}",
+            "SUITE_SHA=${suiteSha}",
+            "SUITE_JOB_THRESHOLD=${jobThreshold}",
+            "SUITE_SUBSET=${subset}",
+        ]) {
+            sh(script: "bash \"${runner}\" > \"${outFile}\" 2>&1; true", returnStatus: true)
+        }
+        def out = readFile(outFile)
+        def maxLen = 50000
+        echo "teuthology-suite output:\n${out.take(maxLen)}${out.size() > maxLen ? "\n...(truncated, full output in ${outFile})" : ''}"
+        def prefix = 'Job scheduled with name '
+        def i = out.indexOf(prefix)
+        if (i >= 0) {
+            def start = i + prefix.length()
+            def lineEnd = out.indexOf('\n', start)
+            if (lineEnd < 0) lineEnd = out.length()
+            def restOfLine = out.substring(start, lineEnd).trim()
+            runName = restOfLine.split()[0]
+        }
+        if (!runName) {
+            error("teuthology-suite did not schedule suite '${suiteName}'. Expected 'Job scheduled with name <run_name>' in output. Check teuthology-suite output above (beanstalk/Paddles connectivity, missing packages, etc.).")
+        }
+    }
+    return runName
+}

--- a/release-tracker-workflow/build/scripts/redmine_post_note.sh
+++ b/release-tracker-workflow/build/scripts/redmine_post_note.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Post a note to a Redmine issue. Usage: redmine_post_note.sh <issue_id> <note_file>
+# Requires: REDMINE_API_KEY in environment.
+set -euo pipefail
+ISSUE_ID="${1:?}"; NOTE_FILE="${2:?}"; REDMINE_URL="${REDMINE_URL:-https://tracker.ceph.com}"
+[[ -z "${REDMINE_API_KEY:-}" ]] && { echo "REDMINE_API_KEY not set."; exit 0; }
+[[ ! -f "$NOTE_FILE" ]] && { echo "Note file not found: $NOTE_FILE"; exit 1; }
+NOTE_JSON=$(python3 -c "import json,sys; f=open(sys.argv[1]); print(json.dumps({'issue':{'notes':f.read()}}))" "$NOTE_FILE")
+HTTP_CODE=$(curl -s -w "%{http_code}" -o /tmp/redmine_resp.json -X PUT \
+  -H "X-Redmine-API-Key: $REDMINE_API_KEY" -H "Content-Type: application/json" \
+  -d "$NOTE_JSON" "${REDMINE_URL}/issues/${ISSUE_ID}.json")
+[[ "$HTTP_CODE" != "200" && "$HTTP_CODE" != "204" ]] && { echo "HTTP $HTTP_CODE"; cat /tmp/redmine_resp.json; exit 1; }
+echo "Posted note to ${REDMINE_URL}/issues/${ISSUE_ID}"

--- a/release-tracker-workflow/config/definitions/release-tracker-workflow.yml
+++ b/release-tracker-workflow/config/definitions/release-tracker-workflow.yml
@@ -1,0 +1,87 @@
+# Release tracker workflow: RC testing automation
+# SHA1 -> wait Shaman -> schedule suites -> aggregate -> report to Redmine (Shaman only, no build)
+# Requires: teuthology-agent label, redmine-api-key credential
+- job:
+    name: release-tracker-workflow
+    description: |
+      Resolve or use CEPH_SHA1, wait for Shaman, schedule teuthology suites (all at once),
+      aggregate results, post to Redmine and/or email. Relies on Shaman only (no build step).
+      Use CEPH_SHA1 to run on a given SHA1 if present on Shaman.
+    project-type: pipeline
+    quiet-period: 1
+    concurrent: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/ceph/ceph-build
+            branches:
+              - ${{CEPH_BUILD_BRANCH}}
+            shallow-clone: true
+            submodule:
+              disable: true
+            wipe-workspace: true
+      script-path: release-tracker-workflow/build/Jenkinsfile
+      lightweight-checkout: true
+      do-not-fetch-tags: true
+
+    parameters:
+      - string:
+          name: CEPH_REPO
+          description: "Ceph repository URL"
+          default: "https://github.com/ceph/ceph.git"
+      - string:
+          name: CEPH_BRANCH
+          description: "Ceph branch (e.g. main, reef, tentacle)"
+          default: main
+      - string:
+          name: CEPH_SHA1
+          description: "Optional: Ceph commit SHA1. If set, run on this SHA1 (must exist on Shaman). Empty = resolve from branch tip."
+          default: ""
+      - string:
+          name: RELEASE_VERSION
+          description: "Release version (e.g. 20.1.0)"
+          default: "20.1.0"
+      - string:
+          name: TRACKER_ISSUE_ID
+          description: "Redmine tracker issue ID. Required when posting to tracker."
+          default: ""
+      - string:
+          name: SUITE_NAME
+          description: "Single suite when SUITE_LIST_SOURCE is empty"
+          default: smoke
+      - string:
+          name: SUITE_LIST_SOURCE
+          description: "File path (e.g. release-tracker-workflow/config/suites.yaml) or URL for suite list. Empty = use SUITE_NAME."
+          default: ""
+      - string:
+          name: SUITE_REPO
+          description: "Suite repo URL for teuthology-suite (--suite-repo, e.g. https://github.com/ceph/ceph-ci.git)"
+          default: "https://github.com/ceph/ceph-ci.git"
+      - string:
+          name: PADDLES_URL
+          description: "Paddles base URL for aggregation"
+          default: "http://paddles.front.sepia.ceph.com/"
+      - string:
+          name: EMAIL_RECIPIENTS
+          description: "Comma-separated emails to notify when run finishes."
+          default: ""
+      - bool:
+          name: USE_WORKSPACE_TEUTHOLOGY
+          description: "If true, clone teuthology into workspace. If false, use TEUTHOLOGY_SCRIPT_DIR."
+          default: true
+      - string:
+          name: TEUTHOLOGY_SCRIPT_DIR
+          description: "Path to existing teuthology clone (used when USE_WORKSPACE_TEUTHOLOGY is false)"
+          default: ""
+      - string:
+          name: TEUTHOLOGY_VIRTUALENV_PATH
+          description: "Path to teuthology virtualenv (used when USE_WORKSPACE_TEUTHOLOGY is false)"
+          default: ""
+      - bool:
+          name: SKIP_TRACKER_UPDATE
+          description: "If true, do not post to Redmine."
+          default: true
+      - string:
+          name: CEPH_BUILD_BRANCH
+          description: "Use the Jenkinsfile from this ceph-build branch"
+          default: main

--- a/release-tracker-workflow/config/suites.yaml
+++ b/release-tracker-workflow/config/suites.yaml
@@ -1,0 +1,12 @@
+# Suite list for release-tracker-workflow
+suites:
+  - teuthology:nop
+  - orch
+  - rbd
+  - fs
+  - rgw
+  - krbd
+  - upgrade
+  - crimson-rados
+  - crimson-rados/basic
+  - rados

--- a/release-tracker-workflow/scripts/aggregate_suite_results.py
+++ b/release-tracker-workflow/scripts/aggregate_suite_results.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Fetch job results from Paddles for one or more runs and output aggregated pass/fail table.
+
+Usage:
+  aggregate_suite_results.py --run RUN [--run RUN ...] [--paddles-url URL] [--out FILE]
+"""
+import argparse
+import sys
+try:
+    import requests
+except ImportError:
+    print("pip install requests", file=sys.stderr)
+    sys.exit(2)
+
+DEFAULT_PADDLES = "http://paddles.front.sepia.ceph.com/"
+
+
+def get_jobs(paddles_url, run_name, fields=None):
+    fields = fields or ["job_id", "status", "description"]
+    if "job_id" not in fields:
+        fields = list(fields) + ["job_id"]
+    uri = f"{paddles_url.rstrip('/')}/runs/{run_name}/jobs/?fields={','.join(fields)}"
+    try:
+        r = requests.get(uri, timeout=60)
+        r.raise_for_status()
+        return r.json()
+    except Exception as e:
+        print(f"Failed to get jobs: {e}", file=sys.stderr)
+        return None
+
+
+def suite_from_desc(desc):
+    return (desc or "unknown").split("/")[0] if "/" in (desc or "") else (desc or "unknown").split()[0] if desc else "unknown"
+
+
+def aggregate(jobs):
+    by_suite = {}
+    for j in jobs:
+        desc = j.get("description") or ""
+        status = (j.get("status") or "unknown").lower()
+        suite = suite_from_desc(desc)
+        if suite not in by_suite:
+            by_suite[suite] = {"pass": 0, "fail": 0}
+        if status == "pass":
+            by_suite[suite]["pass"] += 1
+        else:
+            by_suite[suite]["fail"] += 1
+    return {s: "PASS" if c["fail"] == 0 and c["pass"] > 0 else "FAIL" for s, c in by_suite.items()}
+
+
+def merged_table(paddles_url, run_names):
+    combined = {}
+    any_jobs = False
+    for run_name in run_names:
+        jobs = get_jobs(paddles_url, run_name)
+        if jobs is None:
+            return None
+        if not jobs:
+            continue
+        any_jobs = True
+        combined.update(aggregate(jobs))
+    if not any_jobs:
+        return "No jobs found"
+    return "\n".join(
+        ["Suite | Status", "------|------"]
+        + [f"{k} | {v}" for k, v in sorted(combined.items())]
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--run",
+        action="append",
+        dest="runs",
+        required=True,
+        metavar="RUN",
+        help="Teuthology run name (repeat for multiple runs; merged into one table).",
+    )
+    ap.add_argument("--paddles-url", default=DEFAULT_PADDLES)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    table = merged_table(args.paddles_url, args.runs)
+    if table is None:
+        sys.exit(1)
+    print(table)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(table)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/release-tracker-workflow/scripts/run_teuthology_suite.sh
+++ b/release-tracker-workflow/scripts/run_teuthology_suite.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Run teuthology-suite with fixed argv, intended for Jenkins.
+# Required env -  VIRTUALENV_PATH, SUITE_NAME, CEPH_BRANCH, CEPH_SHA1
+# Optional - OVERRIDE_YAML, MACHINE_TYPE, CEPH_REPO, SUITE_LIMIT, SUITE_JOB_THRESHOLD, SUITE_SUBSET,
+# SUITE_REPO (--suite-repo), SUITE_SHA (--suite-sha1).
+# Job params map via the Jenkinsfile.
+set -euo pipefail
+
+: "${VIRTUALENV_PATH:?VIRTUALENV_PATH must be set}"
+: "${SUITE_NAME:?SUITE_NAME must be set}"
+: "${CEPH_BRANCH:?CEPH_BRANCH must be set}"
+: "${CEPH_SHA1:?CEPH_SHA1 must be set}"
+
+if [[ ! "${SUITE_NAME}" =~ ^[a-zA-Z0-9_/:-]+$ ]]; then
+  echo "run_teuthology_suite.sh: invalid SUITE_NAME: ${SUITE_NAME}" >&2
+  exit 1
+fi
+if [[ ! "${CEPH_BRANCH}" =~ ^[a-zA-Z0-9/._-]+$ ]]; then
+  echo "run_teuthology_suite.sh: invalid CEPH_BRANCH: ${CEPH_BRANCH}" >&2
+  exit 1
+fi
+if [[ "${CEPH_SHA1}" == "unknown" ]]; then
+  :
+elif [[ ! "${CEPH_SHA1}" =~ ^[a-fA-F0-9]+$ ]] || [[ ${#CEPH_SHA1} -lt 7 ]]; then
+  echo "run_teuthology_suite.sh: invalid CEPH_SHA1: ${CEPH_SHA1}" >&2
+  exit 1
+fi
+
+TEUTHOLOGY_SUITE="${VIRTUALENV_PATH}/bin/teuthology-suite"
+if [[ ! -f "${TEUTHOLOGY_SUITE}" ]]; then
+  echo "run_teuthology_suite.sh: teuthology-suite not found: ${TEUTHOLOGY_SUITE}" >&2
+  exit 1
+fi
+
+MACHINE_TYPE="${MACHINE_TYPE:-trial}"
+CEPH_REPO="${CEPH_REPO:-https://github.com/ceph/ceph.git}"
+SUITE_LIMIT="${SUITE_LIMIT:-1}"
+
+if [[ ! "${MACHINE_TYPE}" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
+  echo "run_teuthology_suite.sh: invalid MACHINE_TYPE: ${MACHINE_TYPE}" >&2
+  exit 1
+fi
+if [[ ! "${SUITE_LIMIT}" =~ ^[0-9]+$ ]] || [[ "${SUITE_LIMIT}" == "0" ]]; then
+  echo "run_teuthology_suite.sh: invalid SUITE_LIMIT (positive integer): ${SUITE_LIMIT}" >&2
+  exit 1
+fi
+
+if [[ -n "${SUITE_REPO:-}" ]] && [[ ! "${SUITE_REPO}" =~ ^[a-zA-Z0-9@.:/_-]+$ ]]; then
+  echo "run_teuthology_suite.sh: invalid SUITE_REPO: ${SUITE_REPO}" >&2
+  exit 1
+fi
+if [[ -n "${SUITE_SHA:-}" ]]; then
+  if [[ ! "${SUITE_SHA}" =~ ^[a-fA-F0-9]+$ ]] || [[ ${#SUITE_SHA} -lt 7 ]]; then
+    echo "run_teuthology_suite.sh: invalid SUITE_SHA: ${SUITE_SHA}" >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "${SUITE_JOB_THRESHOLD:-}" ]]; then
+  if [[ ! "${SUITE_JOB_THRESHOLD}" =~ ^[0-9]+$ ]]; then
+    echo "run_teuthology_suite.sh: invalid SUITE_JOB_THRESHOLD (non-negative integer): ${SUITE_JOB_THRESHOLD}" >&2
+    exit 1
+  fi
+fi
+if [[ -n "${SUITE_SUBSET:-}" ]]; then
+  if [[ ! "${SUITE_SUBSET}" =~ ^[0-9]+/[0-9]+$ ]]; then
+    echo "run_teuthology_suite.sh: invalid SUITE_SUBSET (expected N/M, e.g. 1/10000): ${SUITE_SUBSET}" >&2
+    exit 1
+  fi
+fi
+
+set -- \
+  "${TEUTHOLOGY_SUITE}" \
+  --suite "${SUITE_NAME}" \
+  --machine-type "${MACHINE_TYPE}" \
+  --ceph "${CEPH_BRANCH}" \
+  --ceph-repo "${CEPH_REPO}" \
+  --limit "${SUITE_LIMIT}"
+
+if [[ -n "${SUITE_JOB_THRESHOLD:-}" ]]; then
+  set -- "$@" --job-threshold "${SUITE_JOB_THRESHOLD}"
+fi
+if [[ -n "${SUITE_SUBSET:-}" ]]; then
+  set -- "$@" --subset "${SUITE_SUBSET}"
+fi
+
+set -- "$@" --sha1 "${CEPH_SHA1}"
+
+if [[ -n "${SUITE_REPO:-}" ]]; then
+  set -- "$@" --suite-repo "${SUITE_REPO}"
+fi
+if [[ -n "${SUITE_SHA:-}" ]]; then
+  set -- "$@" --suite-sha1 "${SUITE_SHA}"
+fi
+if [[ -n "${OVERRIDE_YAML:-}" ]]; then
+  set -- "$@" "${OVERRIDE_YAML}"
+fi
+
+exec "$@"

--- a/release-tracker-workflow/scripts/wait_for_shaman_sha1.py
+++ b/release-tracker-workflow/scripts/wait_for_shaman_sha1.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Wait for Shaman availability for branch/platform(s).
+
+Modes:
+  - With --sha1: wait until that exact SHA exists on all platforms.
+  - Without --sha1: poll latest endpoints until all platforms converge to the
+    same latest SHA.
+Exits 0 when ready, 1 on timeout. Prints SHA1 on success.
+"""
+import argparse
+import sys
+import time
+try:
+    import requests
+except ImportError:
+    print("pip install requests", file=sys.stderr)
+    sys.exit(2)
+
+SHAMAN_BUILD_URL = "https://shaman.ceph.com/api/repos/ceph/{branch}/{sha1}/{os_type}/{os_version}/flavors/{flavor}/"
+SHAMAN_LATEST_URL = "https://shaman.ceph.com/api/repos/ceph/{branch}/latest/{os_type}/{os_version}/flavors/{flavor}/"
+
+def _fetch_builds(url):
+    r = requests.get(url, timeout=30)
+    if not r.ok:
+        return []
+    payload = r.json()
+    return payload if isinstance(payload, list) else [payload]
+
+
+def sha1_on_platform(branch, platform, sha1, arch="x86_64"):
+    parts = platform.split("-", 2)
+    if len(parts) < 3:
+        return False
+    os_type, os_version, flavor = parts[0], parts[1], parts[2]
+    url = SHAMAN_BUILD_URL.format(
+        branch=branch,
+        sha1=sha1,
+        os_type=os_type,
+        os_version=os_version,
+        flavor=flavor,
+    )
+    try:
+        builds = _fetch_builds(url)
+        for b in builds:
+            if arch in b.get("archs", []) and b.get("sha1") == sha1:
+                return True
+        return False
+    except Exception:
+        return False
+
+
+def latest_sha_on_platform(branch, platform, arch="x86_64"):
+    parts = platform.split("-", 2)
+    if len(parts) < 3:
+        return None
+    os_type, os_version, flavor = parts[0], parts[1], parts[2]
+    url = SHAMAN_LATEST_URL.format(branch=branch, os_type=os_type, os_version=os_version, flavor=flavor)
+    try:
+        builds = _fetch_builds(url)
+        for b in builds:
+            if arch in b.get("archs", []) and b.get("sha1"):
+                return b.get("sha1")
+        return None
+    except Exception:
+        return None
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--branch", required=True)
+    ap.add_argument("--sha1", default="")
+    ap.add_argument(
+        "--platform",
+        default="ubuntu-noble-default,centos-9-default",
+        help="Comma-separated Shaman platform keys (os-osver-flavor), e.g. ubuntu-noble-default.",
+    )
+    ap.add_argument("--timeout", type=int, default=3600)
+    ap.add_argument("--interval", type=int, default=60)
+    ap.add_argument("--arch", default="x86_64")
+    args = ap.parse_args()
+    branch = args.branch.strip().lower()
+    sha1 = args.sha1.strip().lower() if args.sha1 else ""
+    platforms = [p.strip() for p in args.platform.split(",") if p.strip()] or ["ubuntu-noble-default", "centos-9-default"]
+    start = time.monotonic()
+    while True:
+        if sha1:
+            if all(sha1_on_platform(branch, p, sha1, args.arch) for p in platforms):
+                print(sha1)
+                return 0
+        else:
+            latest = [latest_sha_on_platform(branch, p, args.arch) for p in platforms]
+            if all(latest) and len(set(latest)) == 1:
+                print(latest[0])
+                return 0
+        if time.monotonic() - start >= args.timeout:
+            if sha1:
+                print(f"Timeout: SHA1 {sha1} not on Shaman for {branch}", file=sys.stderr)
+            else:
+                print(f"Timeout: no converged latest SHA on Shaman for {branch}", file=sys.stderr)
+            return 1
+        time.sleep(args.interval)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sign-debs
+++ b/scripts/sign-debs
@@ -1,0 +1,57 @@
+#!/bin/bash -ex
+# vim: ts=2:sw=2:expandtab
+
+keyid=460F3994
+
+function usage() {
+    echo "sign-debs <project> [ release [ release ..]]"
+}
+
+if [[ $# -lt 1 ]] ; then usage ; exit 1 ; fi
+
+project=$1; shift
+
+if [ $# -eq 0 ]; then
+    releases=( reef squid tentacle umbrella )
+else
+    releases=( "$@" )
+fi
+
+distro_versions=( jessie )
+
+for release in "${releases[@]}"; do
+    for distro_version in "${distro_versions[@]}"; do
+        for path in /opt/repos/$project/$release*; do
+            if [ -d "$path/debian/$distro_version" ]; then
+
+                # Check if any Release file is missing a valid signature
+                needs_signing=0
+                while IFS= read -r release_file; do
+                    release_dir=$(dirname "$release_file")
+                    if ! gpg --verify "$release_dir/Release.gpg" "$release_file" 2>/dev/null; then
+                        needs_signing=1
+                        break
+                    fi
+                done < <(find "$path/debian/$distro_version/dists" -maxdepth 2 -name "Release" -not -name "InRelease")
+
+                if [[ $needs_signing -eq 0 ]]; then
+                    echo "already signed, skipping: $path/debian/$distro_version"
+                    continue
+                fi
+
+                echo "Signing: $path/debian/$distro_version"
+                merfi gpg "$path/debian/$distro_version"
+
+                # Verify all Release files that merfi just signed (#63336)
+                while IFS= read -r release_file; do
+                    release_dir=$(dirname "$release_file")
+                    echo "verifying: $release_dir/Release.gpg"
+                    gpg --verify "$release_dir/Release.gpg" "$release_file"
+                    echo "verifying: $release_dir/InRelease"
+                    gpg --verify "$release_dir/InRelease"
+                done < <(find "$path/debian/$distro_version/dists" -maxdepth 2 -name "Release" -not -name "InRelease")
+
+            fi
+        done
+    done
+done


### PR DESCRIPTION
builder.yml task fails with error:

```
Conditional result (...) was derived from value of type 'str'
Conditionals must have a boolean result
```

Cause:
Using regex_search in when returns a string instead of a boolean, which is no longer allowed in newer Ansible versions.

Problematic code:
`when: item | regex_search('^(172\.21\.|8\.43\.|10\.20\.)')`

Fix:
`when: item is match('^(172\.21\.|8\.43\.|10\.20\.)')`