### PR TITLE
Fix: when conditional failure due to non-boolean result

### DIFF
--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -442,7 +442,7 @@
         permanent: true
         nodename: "{{ ansible_hostname }}"
       with_items: "{{ ansible_all_ipv4_addresses }}"
-      when: item | regex_search('^(172\\.21\\.|8\\.43\\.|10\\.20\\.)')
+      when: item is match('^(172\\.21\\.|8\\.43\\.|10\\.20\\.)')
       tags: always
 
     ## EPHEMERAL SLAVE TASKS


### PR DESCRIPTION
The **builder.yml** task fails with error:

```
Conditional result (...) was derived from value of type 'str'
Conditionals must have a boolean result

```
Cause:
Using regex_search in when returns a string instead of a boolean, which is no longer allowed in newer Ansible versions.

Problematic code:
`when: item | regex_search('^(172\.21\.|8\.43\.|10\.20\.)')`

Fix:
`when: item is match('^(172\.21\.|8\.43\.|10\.20\.)')`