### PR TITLE
mgr/dashboard: Fix image sync issue grafana

### DIFF
--- a/sync-images/build/build
+++ b/sync-images/build/build
@@ -16,8 +16,8 @@ EOF
 # make sure we pull the last stable image
 podman pull quay.io/skopeo/stable
 podman run --rm --security-opt label=disable \
-  -v ./sync.yml:/sync.yml:ro quay.io/skopeo/stable sync --all \
   -e GODEBUG=http2client=0 \
+  -v ./sync.yml:/sync.yml:ro quay.io/skopeo/stable sync --all \
   --retry-times 5 \
   --src yaml \
   --src-username "${DOCKER_HUB_USERNAME}" \


### PR DESCRIPTION
In the build script, `-e GODEBUG=http2client=0` is placed after the container image name (quay.io/skopeo/stable sync --all), which means it gets passed as a flag to skopeo sync,  not to podman run.