### PR TITLE
cephadm-e2e: fix libvirt socket permission denied in rootless podman

### DIFF
--- a/scripts/dashboard/install-cephadm-e2e-deps.sh
+++ b/scripts/dashboard/install-cephadm-e2e-deps.sh
@@ -58,6 +58,7 @@ podman pull ${KCLI_CONTAINER_IMAGE}
 echo "#!/usr/bin/env bash
 
 podman run --rm --net host --security-opt label=disable \
+    --group-add keep-groups \
     -v ${KCLI_CONFIG_DIR}:/root/.kcli \
     -v ${PWD}:/workdir \
     -v /var/lib/libvirt/images:/var/lib/libvirt/images \


### PR DESCRIPTION
Rootless podman drops host supplementary groups when creating a user namespace. The kcli container loses the libvirt GID and cannot access /var/run/libvirt/libvirt-sock, causing all e2e builds to fail.

Add --group-add keep-groups to preserve the host user's groups inside the container.