### PR TITLE
ceph-pr-api: Split out squid-specific job

### DIFF
--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -1,9 +1,9 @@
-- job:
-    name: ceph-api
+- job-template:
+    name: '{job_name}'
     project-type: freestyle
     defaults: global
     concurrent: true
-    node: huge && installed-os-noble && x86_64 && !smithi
+    node: "huge && {os_label} && x86_64 && !smithi"
     display-name: 'ceph: API'
     quiet-period: 5
     block-downstream: false
@@ -34,13 +34,7 @@
           allow-whitelist-orgs-as-admins: true
           org-list:
             - ceph
-          white-list-target-branches:
-            - main
-            - umbrella
-            - tentacle
-            - squid
-            - reef
-            - "feature-.*"
+          white-list-target-branches: '{obj:target_branches}'
           trigger-phrase: 'jenkins test api'
           skip-build-phrase: '^jenkins do not test.*'
           only-trigger-phrase: false
@@ -96,3 +90,20 @@
               credential-id: github-readonly-token
               username: GITHUB_USER
               password: GITHUB_PASS
+
+- project:
+    name: ceph-api-project
+    jobs:
+      - '{job_name}'
+    job_name:
+      - ceph-api:
+          os_label: installed-os-noble
+          target_branches:
+            - main
+            - umbrella
+            - tentacle
+            - "feature-.*"
+      - ceph-api-squid:
+          os_label: installed-os-jammy
+          target_branches:
+            - squid


### PR DESCRIPTION
The Squid branch still requires python3.10 in order to build.  Most of our builders are running Ubuntu Noble now which does not have python3.10.

So run ceph API tests for Squid-targeted PRs on installed-os-jammy and all others on installed-os-noble.

The job names were chosen to keep the existing naming scheme for non-squid jobs (e.g., https://jenkins.ceph.com/job/ceph-api vs. https://jenkins.ceph.com/job/ceph-api-squid)