### PR TITLE
ceph-dev-pipeline: Fix NotSerializableException when iterating readPr…

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -282,8 +282,8 @@ pipeline {
                   // as written during ceph-source-dist but we don't to be able to define
                   // ceph-releases.git or chacra.ceph.com as parameters for ceph-dev-pipeline.
                   def props = readProperties file: "${WORKSPACE}/dist/other_envvars"
-                  for (p in props) {
-                    env."${p.key}" = p.value
+                  for (def key in props.keySet()) {
+                    env."${key}" = props[key]
                   }
                 }
                 def branch_ui_value = env.BRANCH


### PR DESCRIPTION
…operties result

Jenkins periodically saves its state to disk so it can resume builds after a restart or when waiting for an agent. Some Java objects cannot be saved this way. We were looping over a properties file in a way that created one of those unsaveable objects, which caused Jenkins to crash when it happened to try saving at that moment.

The fix changes the loop to only work with plain strings, which Jenkins has no trouble saving.