### PR TITLE
ceph-pull-requests: add parameter for DISTRO_BASE

### DIFF
--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -17,6 +17,10 @@
         name: ghprbPullId
         description: "the GitHub pull id, like '72' in 'ceph/pull/72'"
         default: origin/main
+    - string:
+        name: DISTRO_BASE
+        default: jammy
+        description: "the distribution used to create the container that builds and hosts the tests (see build-with-container.py for supported values)"
     project-type: freestyle
     properties:
     - build-discarder:

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -27,6 +27,10 @@
       - string:
           name: ghprbPullId
           description: "the GitHub pull id, like '72' in 'ceph/pull/72'"
+      - string:
+          name: DISTRO_BASE
+          default: jammy
+          description: "the distribution used to create the container that builds and hosts the tests (see build-with-container.py for supported values)"
 
     triggers:
       - github-pull-request:


### PR DESCRIPTION
This new parameter can be used to manually start a "make check" job via with jenkins ui with a distro base other than the default value of "jammy". This will allow us to test on a newer distro base and eventually let (some) users self-service test their fixes for these issues.