### PR TITLE
teuthology-nightly-cadence: crontab coverage parity & update default …

### DIFF
--- a/teuthology-nightly-cadence/README.rst
+++ b/teuthology-nightly-cadence/README.rst
@@ -1,14 +1,15 @@
 teuthology-nightly-cadence
 ===========================
 
-Thin Jenkins jobs that expand **daily/weekly cadence** locally into **SUITE_RUNS_JSON** (partition /
-subset per suite) and invoke **teuthology-runner**.
+Thin Jenkins jobs that expand **daily/weekly cadence** into **SUITE_RUNS_JSON** (partition / subset per
+suite) and invoke **teuthology-runner**.
 
-- ``teuthology-nightly-cadence``: builds JSON from ``cadenceSteps`` / day-of-year in this folder's Jenkinsfile, then triggers the runner job (default ``teuthology-runner``; set **TEUTHOLOGY_RUNNER_JOB_NAME** for a test copy).
-- ``teuthology-nightly-cadence-trigger``: JJB ``timed`` block with ``TZ=Etc/UTC`` (same pattern as
-  ``ceph-dev-cron``). Schedules echo ``qa/crontab/teuthology-cronjobs``: weekday **06:00** UTC → **daily**
-  cadence; **Sunday 20:00** UTC → **weekly** cadence (cf. ``00 20 * * 0`` weekly main runs there).
-  ``wait: false``. Edit ``triggers`` in the YAML to tune times.
+- ``teuthology-nightly-cadence``: ``cadenceSteps`` expands to JSON (random ``--subset`` per ``N``). **Daily** is
+  ``smoke`` plus one suite from the per-branch weekly list (index by UTC day). **Weekly** runs the full
+  list (same definitions as ``ceph.git`` ``qa/crontab/teuthology-cronjobs`` by branch).
+- ``teuthology-nightly-cadence-trigger``: JJB ``timed`` block, ``TZ=Etc/UTC``, ``wait: false``. Timer runs
+  **daily** cadence once per **main**, **tentacle**, and **squid**. Manual runs use the selected
+  ``CEPH_BRANCH`` only. Tune ``triggers`` in the YAML.
 
 Scripts and Shaman/suite logic live under ``teuthology-runner/``. Ensure the **teuthology-runner**
 job exists in Jenkins (see ``teuthology-runner/config/definitions/teuthology-runner.yml``).

--- a/teuthology-nightly-cadence/build/Jenkinsfile
+++ b/teuthology-nightly-cadence/build/Jenkinsfile
@@ -1,9 +1,9 @@
 /**
  * teuthology-nightly-cadence: expands daily/weekly cadence into SUITE_RUNS_JSON and invokes teuthology-runner.
- * Cadence definitions live here (partition/subset).
  */
 import java.util.Calendar
 import java.util.TimeZone
+import java.util.concurrent.ThreadLocalRandom
 
 pipeline {
     agent { label 'built-in' }
@@ -16,8 +16,8 @@ pipeline {
         string(name: 'CEPH_BUILD_BRANCH', defaultValue: 'main', description: 'ceph-build branch for teuthology-runner SCM.')
         string(name: 'TEUTHOLOGY_RUNNER_JOB_NAME', defaultValue: 'teuthology-runner', description: 'Jenkins job name for the runner pipeline.')
         string(name: 'AGENT_LABEL', defaultValue: 'teuthology', description: 'Agent label for teuthology-runner.')
-        choice(name: 'CADENCE', choices: ['daily', 'weekly'], description: 'daily ≈ nop+smoke; weekly ≈ ceph.git teuthology-cronjobs style.')
-        choice(name: 'CEPH_BRANCH', choices: ['main', 'tentacle', 'squid', 'reef'], description: 'Ceph branch.')
+        choice(name: 'CADENCE', choices: ['daily', 'weekly'], description: 'daily: main gets nop+smoke+one rotating suite; tentacle/squid get one rotating suite (+smoke on Sundays); quincy rotates one upgrade suite. weekly: full per-branch suite list.')
+        choice(name: 'CEPH_BRANCH', choices: ['main', 'tentacle', 'squid', 'quincy'], description: 'Ceph branch.')
         string(name: 'CEPH_REPO', defaultValue: 'https://github.com/ceph/ceph.git', description: 'Ceph git URL.')
         string(name: 'CEPH_SHA1', defaultValue: '', description: 'Optional SHA1. Empty = resolve from Shaman for SHAMAN_WAIT_PLATFORMS, then pass explicitly to teuthology-runner.')
         booleanParam(name: 'USE_WORKSPACE_TEUTHOLOGY', defaultValue: true, description: 'Clone teuthology in runner workspace.')
@@ -26,7 +26,7 @@ pipeline {
         string(name: 'TEUTHOLOGY_SCRIPT_DIR', defaultValue: '', description: 'When USE_WORKSPACE_TEUTHOLOGY false.')
         string(name: 'TEUTHOLOGY_VIRTUALENV_PATH', defaultValue: '', description: 'When USE_WORKSPACE_TEUTHOLOGY false.')
         string(name: 'SUITE_REPO', defaultValue: 'https://github.com/ceph/ceph.git', description: 'teuthology-suite --suite-repo.')
-        string(name: 'SUITE_MACHINE_TYPE', defaultValue: 'smithi', description: 'teuthology-suite --machine-type.')
+        string(name: 'SUITE_MACHINE_TYPE', defaultValue: 'trial', description: 'teuthology-suite --machine-type.')
         string(name: 'TEUTH_CONFIG_OVERRIDE_YAML', defaultValue: '', description: 'Optional teuthology-suite argv.')
         string(name: 'SHAMAN_WAIT_TIMEOUT', defaultValue: '7200', description: 'Shaman wait timeout (seconds).')
         string(name: 'SHAMAN_WAIT_INTERVAL', defaultValue: '120', description: 'Shaman poll interval.')
@@ -37,6 +37,7 @@ pipeline {
         booleanParam(name: 'RUN_AGGREGATE', defaultValue: false, description: 'Aggregate in runner.')
         string(name: 'PADDLES_URL', defaultValue: '', description: 'Optional Paddles override.')
         string(name: 'PULPITO_BASE', defaultValue: 'https://pulpito.ceph.com', description: 'Pulpito base URL for teuthology-runner.')
+        string(name: 'TEUTHOLOGY_SUITE_NEWEST', defaultValue: '100', description: 'Passed to teuthology-runner: teuthology-suite --newest. Empty = omit.')
     }
     stages {
         stage('teuthology-runner') {
@@ -80,6 +81,7 @@ pipeline {
                     if (!rows) {
                         error("No suites for CADENCE=${params.CADENCE} CEPH_BRANCH=${params.CEPH_BRANCH}")
                     }
+                    echo "Cadence suites: ${rows.collect { it.suite }.join(', ')}"
                     def json = suiteRunsRowsToJson(rows)
                     def tp = []
                     tp << string(name: 'AGENT_LABEL', value: params.AGENT_LABEL.trim())
@@ -110,6 +112,10 @@ pipeline {
                     tp << booleanParam(name: 'WAIT_FOR_RUNS', value: params.WAIT_FOR_RUNS)
                     tp << string(name: 'SUITE_WAIT_SLEEP', value: params.SUITE_WAIT_SLEEP.trim())
                     tp << booleanParam(name: 'RUN_AGGREGATE', value: params.RUN_AGGREGATE)
+                    def newest = params.TEUTHOLOGY_SUITE_NEWEST?.trim()
+                    if (newest) {
+                        tp << string(name: 'TEUTHOLOGY_SUITE_NEWEST', value: newest)
+                    }
                     tp << text(name: 'SUITE_RUNS_JSON', value: json)
                     build job: runnerJob, wait: true, propagate: true, parameters: tp
                 }
@@ -123,24 +129,25 @@ List expandCadenceToRows(String cadence, String branch) {
     if (!steps) {
         return []
     }
-    def utcCal = Calendar.getInstance(TimeZone.getTimeZone('UTC'))
-    def doy = utcCal.get(Calendar.DAY_OF_YEAR)
+    def rnd = ThreadLocalRandom.current()
     def rows = []
     for (def st in steps) {
         def part = st.partitions as int
-        def idx = doy % part
+        def idx = rnd.nextInt(part)
         def subset = "${idx}/${part}"
-        def lim = st.limit != null ? st.limit as String : "${part}"
-        def thr = st.threshold != null ? st.threshold as String : "${part}"
         def pr = st.priority ?: ''
         def m = [
             suite: st.suite,
-            limit: lim,
-            threshold: thr,
             subset: subset,
             priority: pr,
             forcePriority: st.forcePriority ? true : false,
         ]
+        if (st.threshold != null) {
+            m.threshold = st.threshold as String
+        }
+        if (st.limit != null) {
+            m.limit = st.limit as String
+        }
         if (st.flavor) {
             m.flavor = st.flavor
         }
@@ -150,22 +157,16 @@ List expandCadenceToRows(String cadence, String branch) {
         if (st.filter) {
             m.filter = st.filter
         }
+        if (st.suiteBranch) {
+            m.suiteBranch = st.suiteBranch
+        }
         rows << m
     }
     return rows
 }
 
-def cadenceSteps(String cadence, String branch) {
+List weeklySuiteSteps(String branch) {
     def b = branch.toLowerCase()
-    if (cadence?.toLowerCase() == 'daily') {
-        return [
-            [suite: 'teuthology/nop', partitions: 1, priority: '1', forcePriority: true],
-            [suite: 'smoke', partitions: 1, priority: '100', forcePriority: true],
-        ]
-    }
-    if (cadence?.toLowerCase() != 'weekly') {
-        return []
-    }
     switch (b) {
         case 'main':
             return [
@@ -175,8 +176,9 @@ def cadenceSteps(String cadence, String branch) {
                 [suite: 'rbd', partitions: 128, priority: '950', forcePriority: false],
                 [suite: 'fs', partitions: 512, priority: '700', forcePriority: false],
                 [suite: 'powercycle', partitions: 4, priority: '950', forcePriority: false],
-                [suite: 'rgw', partitions: 30000, limit: '1', threshold: '1', priority: '150', forcePriority: false],
+                [suite: 'rgw', partitions: 30000, priority: '150', forcePriority: false],
                 [suite: 'krbd', partitions: 4, priority: '950', forcePriority: false, kernel: 'testing'],
+                [suite: 'upgrade', partitions: 32, priority: '850', forcePriority: false],
                 [suite: 'crimson-rados', partitions: 1, priority: '101', forcePriority: true, flavor: 'debug'],
                 [suite: 'crimson-rados', partitions: 1, priority: '101', forcePriority: true],
             ]
@@ -187,8 +189,9 @@ def cadenceSteps(String cadence, String branch) {
                 [suite: 'rbd', partitions: 128, priority: '830', forcePriority: false],
                 [suite: 'fs', partitions: 512, priority: '830', forcePriority: false],
                 [suite: 'powercycle', partitions: 4, priority: '830', forcePriority: false],
-                [suite: 'rgw', partitions: 30000, limit: '1', threshold: '1', priority: '830', forcePriority: false],
+                [suite: 'rgw', partitions: 1, priority: '830', forcePriority: false],
                 [suite: 'krbd', partitions: 4, priority: '830', forcePriority: false, kernel: 'testing'],
+                [suite: 'upgrade', partitions: 1, priority: '150', forcePriority: false],
             ]
         case 'squid':
             return [
@@ -197,22 +200,59 @@ def cadenceSteps(String cadence, String branch) {
                 [suite: 'rbd', partitions: 128, priority: '920', forcePriority: false],
                 [suite: 'fs', partitions: 512, priority: '920', forcePriority: false],
                 [suite: 'powercycle', partitions: 4, priority: '920', forcePriority: false],
-                [suite: 'rgw', partitions: 30000, limit: '1', threshold: '1', priority: '920', forcePriority: false],
+                [suite: 'rgw', partitions: 1, priority: '920', forcePriority: false],
                 [suite: 'krbd', partitions: 4, priority: '920', forcePriority: false, kernel: 'testing'],
+                [suite: 'upgrade', partitions: 32, priority: '840', forcePriority: true],
             ]
-        case 'reef':
+        case 'quincy':
             return [
-                [suite: 'rados', partitions: 100000, priority: '920', forcePriority: false],
-                [suite: 'orch', partitions: 64, priority: '920', forcePriority: false],
-                [suite: 'rbd', partitions: 128, priority: '920', forcePriority: false],
-                [suite: 'fs', partitions: 512, priority: '920', forcePriority: false],
-                [suite: 'powercycle', partitions: 4, priority: '920', forcePriority: false],
-                [suite: 'rgw', partitions: 30000, limit: '1', threshold: '1', priority: '920', forcePriority: false],
-                [suite: 'krbd', partitions: 4, priority: '920', forcePriority: false, kernel: 'testing'],
+                [suite: 'upgrade-clients/client-upgrade-octopus-quincy', partitions: 1, priority: '820', forcePriority: false, suiteBranch: 'octopus'],
+                [suite: 'upgrade-clients/client-upgrade-pacific-quincy', partitions: 1, priority: '820', forcePriority: false, suiteBranch: 'pacific'],
+                [suite: 'upgrade:octopus-x', partitions: 120000, priority: '820', forcePriority: false],
+                [suite: 'upgrade:pacific-x', partitions: 120000, priority: '820', forcePriority: false],
             ]
         default:
             return []
     }
+}
+
+def cadenceSteps(String cadence, String branch) {
+    def b = branch.toLowerCase()
+    def c = cadence?.toLowerCase()
+    def smokeStep = [suite: 'smoke', partitions: 1, priority: '100', forcePriority: true]
+    if (c == 'weekly') {
+        def weeklies = weeklySuiteSteps(b)
+        if (b in ['tentacle', 'squid']) {
+            return [smokeStep] + weeklies
+        }
+        return weeklies
+    }
+    if (c != 'daily') {
+        return []
+    }
+    def weeklies = weeklySuiteSteps(b)
+    if (!weeklies) {
+        return []
+    }
+    def utcCal = Calendar.getInstance(TimeZone.getTimeZone('UTC'))
+    def epochDay = utcCal.getTimeInMillis().intdiv(86400000L)
+    def idx = (epochDay % weeklies.size()) as int
+    if (b == 'main') {
+        return [
+            [suite: 'teuthology/nop', partitions: 1, priority: '1', forcePriority: true],
+            smokeStep,
+            weeklies[idx],
+        ]
+    }
+    // tentacle/squid: smoke runs on Sunday only, matching crontab (08/16 05 * * 0).
+    if (b in ['tentacle', 'squid']) {
+        def dow = Calendar.getInstance(TimeZone.getTimeZone('UTC')).get(Calendar.DAY_OF_WEEK)
+        if (dow == Calendar.SUNDAY) {
+            return [smokeStep, weeklies[idx]]
+        }
+        return [weeklies[idx]]
+    }
+    return [weeklies[idx]]
 }
 
 String suiteRunsRowsToJson(List rows) {

--- a/teuthology-nightly-cadence/build/trigger/Jenkinsfile
+++ b/teuthology-nightly-cadence/build/trigger/Jenkinsfile
@@ -1,11 +1,8 @@
 /**
- * Thin trigger job that fires teuthology-nightly-cadence with wait:false.
- * builds: Sunday UTC → weekly cadence (Sunday 20:00 trigger matches qa/crontab/teuthology-cronjobs
- * weekly block); any other day → daily. Manual builds use CADENCE / CEPH_BRANCH parameters.
+ * Triggers teuthology-nightly-cadence with wait:false. Timer builds use CADENCE=daily for all branches
+ * (main, tentacle, squid, quincy). Each branch rotates one suite per day from its pool; tentacle and squid
+ * also prepend smoke on Sundays. Manual builds use the selected CEPH_BRANCH and CADENCE.
  */
-import java.util.Calendar
-import java.util.TimeZone
-
 pipeline {
     agent any
     options {
@@ -16,7 +13,7 @@ pipeline {
     }
     parameters {
         choice(name: 'CADENCE', choices: ['daily', 'weekly'], description: 'Cadence tier.')
-        choice(name: 'CEPH_BRANCH', choices: ['main', 'tentacle', 'squid', 'reef'], description: 'Ceph branch to test.')
+        choice(name: 'CEPH_BRANCH', choices: ['main', 'tentacle', 'squid', 'quincy'], description: 'Ceph branch (manual builds only; timer fires all branches).')
         string(
             name: 'CEPH_BUILD_BRANCH',
             defaultValue: 'main',
@@ -32,6 +29,11 @@ pipeline {
             defaultValue: 'teuthology-nightly-cadence',
             description: 'Jenkins job name of the cadence pipeline to trigger.',
         )
+        string(
+            name: 'TEUTHOLOGY_SUITE_NEWEST',
+            defaultValue: '100',
+            description: 'Forwarded to teuthology-nightly-cadence: teuthology-suite --newest (ceph.git TEUTHOLOGY_SUITE_ARGS). Empty = omit.',
+        )
     }
     stages {
         stage('Trigger teuthology-nightly-cadence') {
@@ -40,26 +42,33 @@ pipeline {
                     def timerCause = currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause')
                     def cadence = params.CADENCE
                     if (timerCause && !timerCause.isEmpty()) {
-                        def utcCal = Calendar.getInstance(TimeZone.getTimeZone('UTC'))
-                        def dow = utcCal.get(Calendar.DAY_OF_WEEK)
-                        // Calendar: Sunday=1 … Saturday=7 (avoid java.time / static enum fields in sandbox)
-                        cadence = (dow == 1) ? 'weekly' : 'daily'
-                        echo "Timer-triggered build: CADENCE=${cadence} (Sunday=weekly per weekly cron line; else daily)."
+                        cadence = 'daily'
                     }
-                    def cephBranch = params.CEPH_BRANCH
                     def cadenceJob = (params.TEUTHOLOGY_NIGHTLY_CADENCE_JOB ?: 'teuthology-nightly-cadence').trim() ?: 'teuthology-nightly-cadence'
-                    echo "Triggering ${cadenceJob} CADENCE=${cadence} CEPH_BRANCH=${cephBranch}"
                     def rj = (params.TEUTHOLOGY_RUNNER_JOB_NAME ?: 'teuthology-runner').trim() ?: 'teuthology-runner'
-                    build(
-                        wait: false,
-                        job: cadenceJob,
-                        parameters: [
+                    def newest = params.TEUTHOLOGY_SUITE_NEWEST?.trim() ?: ''
+                    def buildBranch = params.CEPH_BUILD_BRANCH.trim()
+
+                    def branches
+                    if (timerCause && !timerCause.isEmpty()) {
+                        branches = ['main', 'tentacle', 'squid', 'quincy']
+                    } else {
+                        branches = [params.CEPH_BRANCH]
+                    }
+
+                    for (def br in branches) {
+                        def bp = [
                             string(name: 'CADENCE', value: cadence),
-                            string(name: 'CEPH_BRANCH', value: cephBranch),
-                            string(name: 'CEPH_BUILD_BRANCH', value: params.CEPH_BUILD_BRANCH.trim()),
+                            string(name: 'CEPH_BRANCH', value: br),
+                            string(name: 'CEPH_BUILD_BRANCH', value: buildBranch),
                             string(name: 'TEUTHOLOGY_RUNNER_JOB_NAME', value: rj),
-                        ],
-                    )
+                        ]
+                        if (newest) {
+                            bp << string(name: 'TEUTHOLOGY_SUITE_NEWEST', value: newest)
+                        }
+                        echo "Triggering ${cadenceJob} CADENCE=${cadence} CEPH_BRANCH=${br}"
+                        build(wait: false, job: cadenceJob, parameters: bp)
+                    }
                 }
             }
         }

--- a/teuthology-nightly-cadence/config/definitions/teuthology-nightly-cadence.yml
+++ b/teuthology-nightly-cadence/config/definitions/teuthology-nightly-cadence.yml
@@ -9,7 +9,7 @@
       job in Jenkins. Ceph SHA from CEPH_SHA1 or branch tip via git ls-remote in teuthology-runner.
     project-type: pipeline
     quiet-period: 2
-    concurrent: false
+    concurrent: true
     pipeline-scm:
       scm:
         - git:
@@ -32,22 +32,22 @@
           name: TEUTHOLOGY_RUNNER_JOB_NAME
           description: "Jenkins job name for the runner pipeline (default teuthology-runner)"
           default: "teuthology-runner"
+      - string:
+          name: TEUTHOLOGY_SUITE_NEWEST
+          description: "teuthology-suite --newest; empty to omit"
+          default: "100"
 
 - job:
     name: teuthology-nightly-cadence-trigger
     description: |
-      Triggers teuthology-nightly-cadence with wait:false. Timed triggers follow the same schedule as
-      ceph.git qa/crontab/teuthology-cronjobs.
+      Triggers teuthology-nightly-cadence with wait:false. Timed builds run daily cadence for all branches (main, tentacle, squid, quincy). Each branch rotates one suite per day; tentacle and squid also run smoke on Sundays.
     project-type: pipeline
     quiet-period: 0
     concurrent: true
     triggers:
       - timed: |
           TZ=Etc/UTC
-          # Daily tier: weekday morning.
-          0 6 * * 1-5
-          # Weekly tier: Sunday 20:00 UTC.
-          0 20 * * 0
+          0 6 * * *
     pipeline-scm:
       scm:
         - git:
@@ -74,3 +74,7 @@
           name: TEUTHOLOGY_NIGHTLY_CADENCE_JOB
           description: "Jenkins job name of the cadence pipeline to trigger"
           default: "teuthology-nightly-cadence"
+      - string:
+          name: TEUTHOLOGY_SUITE_NEWEST
+          description: "Forwarded to cadence job: teuthology-suite --newest (empty to omit)"
+          default: "100"

--- a/teuthology-runner/README.rst
+++ b/teuthology-runner/README.rst
@@ -7,10 +7,11 @@ When **CEPH_SHA1** is empty, the branch tip is resolved with **``git ls-remote``
 **SUITE_RUNS_JSON** (text parameter): JSON array of objects. Each object must include ``suite``
 (optional alias ``name``). Optional per-row fields: ``limit``, ``threshold``, ``subset``, ``priority``,
 ``flavor``, ``kernel``, ``filter``, ``forcePriority``, ``suiteSha``. Missing fields fall back to job
-parameters ``SUITE_LIMIT``, ``SUITE_JOB_THRESHOLD``, ``SUITE_SUBSET``, ``SUITE_SHA``.
+parameters ``SUITE_LIMIT``, ``SUITE_JOB_THRESHOLD``, ``SUITE_SUBSET``, ``SUITE_SHA``. Empty job-level
+``SUITE_LIMIT`` omits ``--limit`` for ``teuthology-suite``
 
 **SUITE_LIST** (comma-separated names): used when ``SUITE_RUNS_JSON`` is empty; each run uses the
-global ``SUITE_LIMIT`` / ``SUITE_JOB_THRESHOLD`` / ``SUITE_SUBSET`` / ``SUITE_SHA``.
+global ``SUITE_LIMIT`` / ``SUITE_JOB_THRESHOLD`` / ``SUITE_SUBSET`` / ``SUITE_SHA`` when set.
 
 Callers: **teuthology-nightly-cadence** builds JSON from its own cadence tables; **release-tracker-workflow**
 resolves a suite list and passes ``SUITE_LIST`` plus only the optional parameters that are set.

--- a/teuthology-runner/build/Jenkinsfile
+++ b/teuthology-runner/build/Jenkinsfile
@@ -31,8 +31,9 @@ pipeline {
         string(name: 'SUITE_REPO', defaultValue: 'https://github.com/ceph/ceph.git', description: 'teuthology-suite --suite-repo.')
         string(name: 'SUITE_SHA', defaultValue: '', description: 'Optional --suite-sha1.')
         string(name: 'SUITE_MACHINE_TYPE', defaultValue: 'trial', description: 'teuthology-suite --machine-type.')
-        string(name: 'SUITE_LIMIT', defaultValue: '1', description: 'Default --limit')
+        string(name: 'SUITE_LIMIT', defaultValue: '', description: 'Optional teuthology-suite --limit. Empty = omit (default).')
         string(name: 'SUITE_JOB_THRESHOLD', defaultValue: '', description: 'Default --job-threshold for SUITE_LIST mode / JSON row fallback.')
+        string(name: 'TEUTHOLOGY_SUITE_NEWEST', defaultValue: '', description: 'Optional teuthology-suite --newest. Empty = omit.')
         string(name: 'SUITE_SUBSET', defaultValue: '', description: 'Default --subset for SUITE_LIST mode / JSON row fallback.')
         string(name: 'SUITE_LIST', defaultValue: '', description: 'Comma-separated suite names when SUITE_RUNS_JSON empty.')
         text(name: 'SUITE_RUNS_JSON', defaultValue: '', description: 'JSON array of objects: suite (required), optional limit, threshold, subset, priority, flavor, kernel, filter, forcePriority, suiteSha.')
@@ -161,6 +162,10 @@ pipeline {
                         "SCRIPT_DIR=${env.SCRIPT_DIR}",
                         "VIRTUALENV_PATH=${env.VIRTUALENV_PATH}",
                     ]
+                    def newest = params.TEUTHOLOGY_SUITE_NEWEST?.trim()
+                    if (newest) {
+                        runEnvBase << "TEUTHOLOGY_SUITE_NEWEST=${newest}"
+                    }
 
                     def runInfos = []
                     def jsonText = params.SUITE_RUNS_JSON?.trim()
@@ -198,7 +203,7 @@ pipeline {
                             for (suite in suites) {
                                 def runName = scheduleFromRow([
                                     suite: suite,
-                                    limit: params.SUITE_LIMIT?.trim() ?: '1',
+                                    limit: params.SUITE_LIMIT?.trim() ?: '',
                                     threshold: params.SUITE_JOB_THRESHOLD?.trim() ?: '',
                                     subset: params.SUITE_SUBSET?.trim() ?: '',
                                 ])
@@ -328,7 +333,7 @@ String scheduleFromRow(Map row) {
     if (!suite) {
         error('Each schedule row must include "suite" (or "name")')
     }
-    def lim = coalesceRow(row, 'limit', params.SUITE_LIMIT?.trim() ?: '1')
+    def lim = coalesceRow(row, 'limit', params.SUITE_LIMIT?.trim() ?: '')
     def thr = coalesceRow(row, 'threshold', params.SUITE_JOB_THRESHOLD?.trim() ?: '')
     def subset = coalesceRow(row, 'subset', params.SUITE_SUBSET?.trim() ?: '')
     def priority = coalesceRow(row, 'priority', '')
@@ -337,6 +342,7 @@ String scheduleFromRow(Map row) {
     def filter = coalesceRow(row, 'filter', '')
     def fp = rowForcePriority(row) ? 'true' : ''
     def suiteSha = coalesceRow(row, 'suiteSha', params.SUITE_SHA?.trim() ?: '')
+    def suiteBranch = coalesceRow(row, 'suiteBranch', '')
 
     def safeName = suite.replaceAll('/', '_')
     def runName = null
@@ -346,7 +352,7 @@ String scheduleFromRow(Map row) {
         if (!fileExists(runner)) {
             error("run_teuthology_suite.sh not found: ${runner}")
         }
-        def machineType = params.SUITE_MACHINE_TYPE?.trim() ?: 'smithi'
+        def machineType = params.SUITE_MACHINE_TYPE?.trim() ?: 'trial'
         def suiteRepo = params.SUITE_REPO?.trim() ?: ''
         def overrideYaml = env.TEUTH_CONFIG_OVERRIDE_YAML?.trim() ?: ''
         def envList = [
@@ -355,7 +361,6 @@ String scheduleFromRow(Map row) {
             "CEPH_SHA1=${env.SHA1}",
             "TEUTH_CONFIG_OVERRIDE_YAML=${overrideYaml}",
             "CEPH_REPO=${params.CEPH_REPO}",
-            "SUITE_LIMIT=${lim}",
             "MACHINE_TYPE=${machineType}",
             "SUITE_REPO=${suiteRepo}",
             "SUITE_JOB_THRESHOLD=${thr}",
@@ -367,6 +372,12 @@ String scheduleFromRow(Map row) {
             "SUITE_FORCE_PRIORITY=${fp}",
             "SUITE_SHA=${suiteSha}",
         ]
+        if (lim) {
+            envList << "SUITE_LIMIT=${lim}"
+        }
+        if (suiteBranch) {
+            envList << "SUITE_BRANCH=${suiteBranch}"
+        }
         withEnv(envList) {
             sh(script: "bash \"${runner}\" > \"${outFile}\" 2>&1; true", returnStatus: true)
         }

--- a/teuthology-runner/scripts/run_teuthology_suite.sh
+++ b/teuthology-runner/scripts/run_teuthology_suite.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 # Run teuthology-suite with fixed argv, intended for Jenkins (nightly cadence).
 # Required env: VIRTUALENV_PATH, SUITE_NAME, CEPH_BRANCH, CEPH_SHA1
-# Optional: TEUTH_CONFIG_OVERRIDE_YAML (legacy: OVERRIDE_YAML), MACHINE_TYPE, CEPH_REPO, SUITE_LIMIT, SUITE_JOB_THRESHOLD, SUITE_SUBSET,
-# SUITE_REPO, SUITE_SHA, SUITE_PRIORITY (-p), SUITE_KERNEL, SUITE_FILTER, SUITE_FLAVOR, SUITE_FORCE_PRIORITY
+# Optional: TEUTH_CONFIG_OVERRIDE_YAML (legacy: OVERRIDE_YAML), MACHINE_TYPE, CEPH_REPO, SUITE_LIMIT (omit for teuthology-suite default),
+# TEUTHOLOGY_SUITE_NEWEST (optional --newest N; ceph.git TEUTHOLOGY_SUITE_ARGS uses 100),
+# SUITE_JOB_THRESHOLD, SUITE_SUBSET,
+# SUITE_REPO, SUITE_SHA, SUITE_BRANCH (--suite-branch),
+# SUITE_PRIORITY (-p), SUITE_KERNEL, SUITE_FILTER, SUITE_FLAVOR, SUITE_FORCE_PRIORITY
 set -euo pipefail
 
 : "${VIRTUALENV_PATH:?VIRTUALENV_PATH must be set}"
@@ -33,15 +36,16 @@ fi
 
 MACHINE_TYPE="${MACHINE_TYPE:-trial}"
 CEPH_REPO="${CEPH_REPO:-https://github.com/ceph/ceph.git}"
-SUITE_LIMIT="${SUITE_LIMIT:-1}"
 
 if [[ ! "${MACHINE_TYPE}" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
-  echo "run_teuthology_suite.sh: invalid MACHINE_TYPE: ${MACHINE_TYPE}" >&2
-  exit 1
+    echo "run_teuthology_suite.sh: invalid MACHINE_TYPE: ${MACHINE_TYPE}" >&2
+    exit 1
 fi
-if [[ ! "${SUITE_LIMIT}" =~ ^[0-9]+$ ]] || [[ "${SUITE_LIMIT}" == "0" ]]; then
-  echo "run_teuthology_suite.sh: invalid SUITE_LIMIT (positive integer): ${SUITE_LIMIT}" >&2
-  exit 1
+if [[ -n "${SUITE_LIMIT:-}" ]]; then
+    if [[ ! "${SUITE_LIMIT}" =~ ^[0-9]+$ ]] || [[ "${SUITE_LIMIT}" == "0" ]]; then
+        echo "run_teuthology_suite.sh: invalid SUITE_LIMIT (positive integer): ${SUITE_LIMIT}" >&2
+        exit 1
+    fi
 fi
 
 if [[ -n "${SUITE_REPO:-}" ]] && [[ ! "${SUITE_REPO}" =~ ^[a-zA-Z0-9@.:/_-]+$ ]]; then
@@ -86,6 +90,16 @@ if [[ -n "${SUITE_FLAVOR:-}" ]] && [[ ! "${SUITE_FLAVOR}" =~ ^[a-zA-Z0-9._-]+$ ]
   echo "run_teuthology_suite.sh: invalid SUITE_FLAVOR: ${SUITE_FLAVOR}" >&2
   exit 1
 fi
+if [[ -n "${SUITE_BRANCH:-}" ]] && [[ ! "${SUITE_BRANCH}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+  echo "run_teuthology_suite.sh: invalid SUITE_BRANCH: ${SUITE_BRANCH}" >&2
+  exit 1
+fi
+if [[ -n "${TEUTHOLOGY_SUITE_NEWEST:-}" ]]; then
+  if [[ ! "${TEUTHOLOGY_SUITE_NEWEST}" =~ ^[0-9]+$ ]] || [[ "${TEUTHOLOGY_SUITE_NEWEST}" == "0" ]]; then
+    echo "run_teuthology_suite.sh: invalid TEUTHOLOGY_SUITE_NEWEST (positive integer): ${TEUTHOLOGY_SUITE_NEWEST}" >&2
+    exit 1
+  fi
+fi
 
 set -- \
   "${TEUTHOLOGY_SUITE}" \
@@ -93,7 +107,15 @@ set -- \
   --machine-type "${MACHINE_TYPE}" \
   --ceph "${CEPH_BRANCH}" \
   --ceph-repo "${CEPH_REPO}" \
-  --limit "${SUITE_LIMIT}"
+  --non-interactive
+
+if [[ -n "${TEUTHOLOGY_SUITE_NEWEST:-}" ]]; then
+  set -- "$@" --newest="${TEUTHOLOGY_SUITE_NEWEST}"
+fi
+
+if [[ -n "${SUITE_LIMIT:-}" ]]; then
+    set -- "$@" --limit "${SUITE_LIMIT}"
+fi
 
 if [[ -n "${SUITE_PRIORITY:-}" ]]; then
   set -- "$@" -p "${SUITE_PRIORITY}"
@@ -112,6 +134,9 @@ if [[ -n "${SUITE_REPO:-}" ]]; then
 fi
 if [[ -n "${SUITE_SHA:-}" ]]; then
   set -- "$@" --suite-sha1 "${SUITE_SHA}"
+fi
+if [[ -n "${SUITE_BRANCH:-}" ]]; then
+  set -- "$@" --suite-branch "${SUITE_BRANCH}"
 fi
 if [[ -n "${SUITE_FILTER:-}" ]]; then
   set -- "$@" --filter "${SUITE_FILTER}"


### PR DESCRIPTION
…machine_type

Brings teuthology-nightly-cadence to full feature parity with qa/crontab/teuthology-cronjobs:

- Add upgrade suites for main, tentacle, squid, and quincy branches
- Add quincy branch with daily rotating upgrade suite cadence
- Fix tentacle/squid smoke to run weekly (Sundays only) matching crontab
- Add --suite-branch support end-to-end for quincy upgrade-clients suites
- Drop --limit default; add --newest=100 and --non-interactive flags
- Switch concurrent: false -> true to allow parallel branch builds