### PR TITLE
ceph-dev-cron: add jammy to umbrella

### DIFF
--- a/ceph-dev-cron/build/Jenkinsfile
+++ b/ceph-dev-cron/build/Jenkinsfile
@@ -22,7 +22,7 @@ node('built-in') {
           ]
       ],
       umbrella: [
-          distros: 'noble rocky10 centos9 windows',
+          distros: 'noble jammy rocky10 centos9 windows',
           extras : [
               [distros:'centos9 rocky10', flavors:'debug', archs:'x86_64']
           ]


### PR DESCRIPTION
umbrella will still support ubuntu jammy, and qa suites there depend on jammy packages. reenable jammy in ceph-dev-cron builds in case we want to schedule suites directly against the tip of umbrella

https://docs.ceph.com/en/latest/start/os-recommendations/#platforms