### PR TITLE
teuthology-nightly-cadence: raise priority, trim EOL suites, add umbr…

### DIFF
--- a/teuthology-nightly-cadence/README.rst
+++ b/teuthology-nightly-cadence/README.rst
@@ -5,10 +5,11 @@ Thin Jenkins jobs that expand **daily/weekly cadence** into **SUITE_RUNS_JSON** 
 suite) and invoke **teuthology-runner**.
 
 - ``teuthology-nightly-cadence``: ``cadenceSteps`` expands to JSON (random ``--subset`` per ``N``). **Daily** is
-  ``smoke`` plus one suite from the per-branch weekly list (index by UTC day). **Weekly** runs the full
-  list (same definitions as ``ceph.git`` ``qa/crontab/teuthology-cronjobs`` by branch).
+  ``smoke`` plus one suite from the per-branch weekly list (index by UTC day); **main** and **umbrella** use
+  the same suite list and daily behavior. **Weekly** runs the full list (same definitions as ``ceph.git``
+  ``qa/crontab/teuthology-cronjobs`` by branch).
 - ``teuthology-nightly-cadence-trigger``: JJB ``timed`` block, ``TZ=Etc/UTC``, ``wait: false``. Timer runs
-  **daily** cadence once per **main**, **tentacle**, and **squid**. Manual runs use the selected
+  **daily** cadence once per **main**, **tentacle**, **squid**, and **umbrella**. Manual runs use the selected
   ``CEPH_BRANCH`` only. Tune ``triggers`` in the YAML.
 
 Scripts and Shaman/suite logic live under ``teuthology-runner/``. Ensure the **teuthology-runner**

--- a/teuthology-nightly-cadence/build/Jenkinsfile
+++ b/teuthology-nightly-cadence/build/Jenkinsfile
@@ -5,6 +5,9 @@ import com.cloudbees.groovy.cps.NonCPS
 import java.util.Calendar
 import java.util.TimeZone
 
+// Nightly tier: ahead of the old 800+ backlog but behind dev/release jobs (50–75).
+final String NIGHTLY_PRIORITY = '200'
+
 pipeline {
     agent { label 'built-in' }
     options {
@@ -16,8 +19,8 @@ pipeline {
         string(name: 'CEPH_BUILD_BRANCH', defaultValue: 'main', description: 'ceph-build branch for teuthology-runner SCM.')
         string(name: 'TEUTHOLOGY_RUNNER_JOB_NAME', defaultValue: 'teuthology-runner', description: 'Jenkins job name for the runner pipeline.')
         string(name: 'AGENT_LABEL', defaultValue: 'teuthology', description: 'Agent label for teuthology-runner.')
-        choice(name: 'CADENCE', choices: ['daily', 'weekly'], description: 'daily: main gets nop+smoke+one rotating suite; tentacle/squid get one rotating suite (+smoke on Sundays); quincy rotates one upgrade suite. weekly: full per-branch suite list.')
-        choice(name: 'CEPH_BRANCH', choices: ['main', 'tentacle', 'squid', 'quincy'], description: 'Ceph branch.')
+        choice(name: 'CADENCE', choices: ['daily', 'weekly'], description: 'daily: main/umbrella get smoke+one rotating suite; tentacle/squid get one rotating suite (+smoke on Sundays). weekly: full per-branch suite list.')
+        choice(name: 'CEPH_BRANCH', choices: ['main', 'tentacle', 'squid', 'umbrella'], description: 'Ceph branch.')
         string(name: 'CEPH_REPO', defaultValue: 'https://github.com/ceph/ceph.git', description: 'Ceph git URL.')
         string(name: 'CEPH_SHA1', defaultValue: '', description: 'Optional SHA1. Empty = resolve from Shaman for SHAMAN_WAIT_PLATFORMS, then pass explicitly to teuthology-runner.')
         booleanParam(name: 'USE_WORKSPACE_TEUTHOLOGY', defaultValue: true, description: 'Clone teuthology in runner workspace.')
@@ -30,7 +33,7 @@ pipeline {
         string(name: 'TEUTH_CONFIG_OVERRIDE_YAML', defaultValue: '', description: 'Optional teuthology-suite argv.')
         string(name: 'SHAMAN_WAIT_TIMEOUT', defaultValue: '7200', description: 'Shaman wait timeout (seconds).')
         string(name: 'SHAMAN_WAIT_INTERVAL', defaultValue: '120', description: 'Shaman poll interval.')
-        string(name: 'SHAMAN_WAIT_PLATFORMS', defaultValue: '', description: 'Optional Shaman --platform override. Empty = branch defaults (main/tentacle: rocky-10+ubuntu-noble+centos-9; squid: ubuntu-jammy+centos-9; quincy: ubuntu-jammy+debian-bullseye).')
+        string(name: 'SHAMAN_WAIT_PLATFORMS', defaultValue: '', description: 'Optional Shaman --platform override. Empty = branch defaults (main/tentacle/umbrella: rocky-10+ubuntu-noble+centos-9; squid: ubuntu-jammy+centos-9).')
         booleanParam(name: 'SKIP_SHAMAN_WAIT', defaultValue: false, description: 'Skip Shaman wait.')
         booleanParam(name: 'WAIT_FOR_RUNS', defaultValue: false, description: 'teuthology-wait in runner.')
         string(name: 'SUITE_WAIT_SLEEP', defaultValue: '15', description: 'Sleep before teuthology-wait.')
@@ -138,13 +141,12 @@ String resolveShamanWaitPlatforms(String branch, String override) {
     switch (branch.toLowerCase()) {
         case 'main':
         case 'tentacle':
+        case 'umbrella':
             return 'rocky-10-default,ubuntu-noble-default,centos-9-default'
         case 'squid':
             return 'ubuntu-jammy-default,centos-9-default'
-        case 'quincy':
-            return 'ubuntu-jammy-default,debian-bullseye-default'
         default:
-            return 'ubuntu-jammy-default,debian-bullseye-default'
+            return 'ubuntu-jammy-default,centos-9-default'
     }
 }
 
@@ -194,47 +196,41 @@ List weeklySuiteSteps(String branch) {
     def b = branch.toLowerCase()
     switch (b) {
         case 'main':
+        case 'umbrella':
             return [
                 [suite: 'rados', partitions: 100000, priority: '101', forcePriority: true],
                 [suite: 'rados', partitions: 100000, priority: '101', forcePriority: true, flavor: 'debug'],
-                [suite: 'orch', partitions: 64, priority: '950', forcePriority: false],
-                [suite: 'rbd', partitions: 128, priority: '950', forcePriority: false],
-                [suite: 'fs', partitions: 512, priority: '700', forcePriority: false],
-                [suite: 'powercycle', partitions: 4, priority: '950', forcePriority: false],
+                [suite: 'orch', partitions: 64, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'rbd', partitions: 128, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'fs', partitions: 512, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'powercycle', partitions: 4, priority: NIGHTLY_PRIORITY, forcePriority: false],
                 [suite: 'rgw', partitions: 30000, priority: '150', forcePriority: false],
-                [suite: 'krbd', partitions: 4, priority: '950', forcePriority: false, kernel: 'testing'],
-                [suite: 'upgrade', partitions: 32, priority: '850', forcePriority: false],
+                [suite: 'krbd', partitions: 4, priority: NIGHTLY_PRIORITY, forcePriority: false, kernel: 'testing'],
+                [suite: 'upgrade', partitions: 32, priority: NIGHTLY_PRIORITY, forcePriority: false],
                 [suite: 'crimson-rados', partitions: 1, priority: '101', forcePriority: true, flavor: 'debug'],
                 [suite: 'crimson-rados', partitions: 1, priority: '101', forcePriority: true],
             ]
         case 'tentacle':
             return [
-                [suite: 'rados', partitions: 100000, priority: '831', forcePriority: false],
-                [suite: 'orch', partitions: 64, priority: '830', forcePriority: false],
-                [suite: 'rbd', partitions: 128, priority: '830', forcePriority: false],
-                [suite: 'fs', partitions: 512, priority: '830', forcePriority: false],
-                [suite: 'powercycle', partitions: 4, priority: '830', forcePriority: false],
-                [suite: 'rgw', partitions: 1, priority: '830', forcePriority: false],
-                [suite: 'krbd', partitions: 4, priority: '830', forcePriority: false, kernel: 'testing'],
+                [suite: 'rados', partitions: 100000, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'orch', partitions: 64, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'rbd', partitions: 128, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'fs', partitions: 512, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'powercycle', partitions: 4, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'rgw', partitions: 1, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'krbd', partitions: 4, priority: NIGHTLY_PRIORITY, forcePriority: false, kernel: 'testing'],
                 [suite: 'upgrade', partitions: 1, priority: '150', forcePriority: false],
             ]
         case 'squid':
             return [
-                [suite: 'rados', partitions: 100000, priority: '921', forcePriority: false],
-                [suite: 'orch', partitions: 64, priority: '920', forcePriority: false],
-                [suite: 'rbd', partitions: 128, priority: '920', forcePriority: false],
-                [suite: 'fs', partitions: 512, priority: '920', forcePriority: false],
-                [suite: 'powercycle', partitions: 4, priority: '920', forcePriority: false],
-                [suite: 'rgw', partitions: 1, priority: '920', forcePriority: false],
-                [suite: 'krbd', partitions: 4, priority: '920', forcePriority: false, kernel: 'testing'],
-                [suite: 'upgrade', partitions: 32, priority: '840', forcePriority: true],
-            ]
-        case 'quincy':
-            return [
-                [suite: 'upgrade-clients/client-upgrade-octopus-quincy', partitions: 1, priority: '820', forcePriority: false, suiteBranch: 'octopus'],
-                [suite: 'upgrade-clients/client-upgrade-pacific-quincy', partitions: 1, priority: '820', forcePriority: false, suiteBranch: 'pacific'],
-                [suite: 'upgrade:octopus-x', partitions: 120000, priority: '820', forcePriority: false],
-                [suite: 'upgrade:pacific-x', partitions: 120000, priority: '820', forcePriority: false],
+                [suite: 'rados', partitions: 100000, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'orch', partitions: 64, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'rbd', partitions: 128, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'fs', partitions: 512, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'powercycle', partitions: 4, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'rgw', partitions: 1, priority: NIGHTLY_PRIORITY, forcePriority: false],
+                [suite: 'krbd', partitions: 4, priority: NIGHTLY_PRIORITY, forcePriority: false, kernel: 'testing'],
+                [suite: 'upgrade', partitions: 32, priority: NIGHTLY_PRIORITY, forcePriority: true],
             ]
         default:
             return []
@@ -263,9 +259,8 @@ def cadenceSteps(String cadence, String branch) {
     def utcCal = Calendar.getInstance(TimeZone.getTimeZone('UTC'))
     def epochDay = utcCal.getTimeInMillis().intdiv(86400000L)
     def idx = (epochDay % weeklies.size()) as int
-    if (b == 'main') {
+    if (b in ['main', 'umbrella']) {
         return [
-            [suite: 'teuthology/nop', partitions: 1, priority: '1', forcePriority: true],
             smokeStep,
             weeklies[idx],
         ]

--- a/teuthology-nightly-cadence/build/trigger/Jenkinsfile
+++ b/teuthology-nightly-cadence/build/trigger/Jenkinsfile
@@ -1,7 +1,7 @@
 /**
  * Triggers teuthology-nightly-cadence with wait:false. Timer builds use CADENCE=daily for all branches
- * (main, tentacle, squid, quincy). Each branch rotates one suite per day from its pool; tentacle and squid
- * also prepend smoke on Sundays. Manual builds use the selected CEPH_BRANCH and CADENCE.
+ * (main, tentacle, squid, umbrella). main and umbrella: smoke plus one rotating suite daily.
+ * tentacle and squid: one rotating suite daily (+smoke on Sundays). Manual builds use the selected CEPH_BRANCH and CADENCE.
  */
 pipeline {
     agent any
@@ -13,7 +13,7 @@ pipeline {
     }
     parameters {
         choice(name: 'CADENCE', choices: ['daily', 'weekly'], description: 'Cadence tier.')
-        choice(name: 'CEPH_BRANCH', choices: ['main', 'tentacle', 'squid', 'quincy'], description: 'Ceph branch (manual builds only; timer fires all branches).')
+        choice(name: 'CEPH_BRANCH', choices: ['main', 'tentacle', 'squid', 'umbrella'], description: 'Ceph branch (manual builds only; timer fires all branches).')
         string(
             name: 'CEPH_BUILD_BRANCH',
             defaultValue: 'main',
@@ -51,7 +51,7 @@ pipeline {
 
                     def branches
                     if (timerCause && !timerCause.isEmpty()) {
-                        branches = ['main', 'tentacle', 'squid', 'quincy']
+                        branches = ['main', 'tentacle', 'squid', 'umbrella']
                     } else {
                         branches = [params.CEPH_BRANCH]
                     }

--- a/teuthology-nightly-cadence/config/definitions/teuthology-nightly-cadence.yml
+++ b/teuthology-nightly-cadence/config/definitions/teuthology-nightly-cadence.yml
@@ -40,7 +40,7 @@
 - job:
     name: teuthology-nightly-cadence-trigger
     description: |
-      Triggers teuthology-nightly-cadence with wait:false. Timed builds run daily cadence for all branches (main, tentacle, squid, quincy). Each branch rotates one suite per day; tentacle and squid also run smoke on Sundays.
+      Triggers teuthology-nightly-cadence with wait:false. Timed builds run daily cadence for all branches (main, tentacle, squid, umbrella). main and umbrella: smoke plus one rotating suite daily. tentacle and squid: one rotating suite daily (smoke on Sundays).
     project-type: pipeline
     quiet-period: 0
     concurrent: true


### PR DESCRIPTION
…ella

Bump maintenance nightly suites to priority 200 so jobs run ahead of the old 800+ backlog while staying behind dev/release work at 50–75. Drop teuthology/nop and quincy (EOL). Add umbrella with the same suite list and daily cadence as main; keep squid for active stable testing. Timer now fires main, tentacle, squid, and umbrella