### PR TITLE
introduce debug builds for noble

### DIFF
--- a/ceph-dev-cron/build/Jenkinsfile
+++ b/ceph-dev-cron/build/Jenkinsfile
@@ -18,19 +18,19 @@ node('built-in') {
       tentacle: [
           distros: 'noble jammy rocky10 centos9 windows',
           extras : [
-              [distros:'centos9 rocky10', flavors:'debug', archs:'x86_64']
+              [distros:'centos9 rocky10 noble', flavors:'debug', archs:'x86_64']
           ]
       ],
       umbrella: [
           distros: 'noble rocky10 centos9 windows',
           extras : [
-              [distros:'centos9 rocky10', flavors:'debug', archs:'x86_64']
+              [distros:'centos9 rocky10 noble', flavors:'debug', archs:'x86_64']
           ]
       ],
       main: [
           distros: 'noble jammy rocky10 centos9 windows',
           extras : [
-              [distros:'centos9 rocky10', flavors:'debug', archs:'x86_64'],
+              [distros:'centos9 rocky10 noble', flavors:'debug', archs:'x86_64'],
               [distros:'centos9 rocky10', flavors:'default', archs:'arm64'],
           ]
       ]

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -201,7 +201,7 @@ pipeline {
             values 'default', 'debug'
           }
         }
-        // debug flavor is currently only supported on centos9 and rocky10, x86_64
+        // debug flavor is currently only supported on centos9, rocky10 and noble, x86_64
         excludes {
           exclude {
             axis {
@@ -210,7 +210,7 @@ pipeline {
             }
             axis {
               name 'DIST'
-              notValues 'centos9', 'rocky10'
+              notValues 'centos9', 'rocky10', 'noble'
             }
           }
           exclude {

--- a/ceph-trigger-build/build/Jenkinsfile
+++ b/ceph-trigger-build/build/Jenkinsfile
@@ -58,7 +58,7 @@ def params_from_branch(initialParams) {
       if ( !singleSet ) {
         params << params[0].clone()
         params[-1]['ARCHS'] = 'x86_64'
-        params[-1]['DISTROS'] = 'centos9 rocky10'
+        params[-1]['DISTROS'] = 'centos9 rocky10 noble'
         params[-1]['FLAVOR'] = 'debug'
       } else {
         params[0]['ARCHS'] += ' arm64'
@@ -78,7 +78,7 @@ def params_from_branch(initialParams) {
       if ( !singleSet ) {
         params << params[0].clone()
         params[-1]['ARCHS'] = 'x86_64'
-        params[-1]['DISTROS'] = 'centos9 rocky10'
+        params[-1]['DISTROS'] = 'centos9 rocky10 noble'
         params[-1]['FLAVOR'] = 'debug'
       } else {
         params[0]['FLAVOR'] += ' debug'


### PR DESCRIPTION
This commit adds debug builds for the distro noble. With this change, we will also get debug noble builds. This is especially useful for testing crimson in QA suites.