### PR TITLE
builder-reimage: Noop if builder not found

### DIFF
--- a/builder-reimage/build/jenkins_node_control.py
+++ b/builder-reimage/build/jenkins_node_control.py
@@ -52,7 +52,7 @@ def resolve_node_name(session, base_url, short_name):
         if short_name in display_name:
             return display_name
 
-    raise RuntimeError(f"Could not resolve Jenkins node name for {short_name}")
+    return None
 
 
 def get_node_info(session, base_url, node_name):
@@ -143,6 +143,10 @@ def main():
 
     if args.action == "prepare_for_reimage":
         node_name = resolve_node_name(session, base_url, short_name)
+        if node_name is None:
+            print(f"[WARN] No Jenkins node found for {short_name}; skipping offline preparation", flush=True)
+            sys.exit(0)
+
         node_info = get_node_info(session, base_url, node_name)
 
         state = {

--- a/builder-reimage/build/sync_labels.py
+++ b/builder-reimage/build/sync_labels.py
@@ -58,8 +58,8 @@ for n in nodes:
         break
 
 if not node_name:
-    print(f"[ERROR] Could not find Jenkins node for {short_name}")
-    exit(1)
+    print(f"[WARN] No Jenkins node found for {short_name}; skipping label sync")
+    exit(0)
 
 # Encode node name (important for '+' → '%2B')
 encoded_node = quote(node_name, safe='')


### PR DESCRIPTION
If we're adding a host to Jenkins for the first time, it won't exist yet.  And we'll send the labels when we run builder.yml.