### PR TITLE
enhancement: split `Chacra` and `Pulp` upload into independent pipeline stages

### DIFF
--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -72,7 +72,7 @@
       - bool:
           name: PULP_UPLOAD
           description: "Whether to upload packages to Pulp"
-          default: false
+          default: true
 
       - bool:
           name: PULP_REGISTRY_UPLOAD


### PR DESCRIPTION
Refactor the ceph-dev-pipeline build job so Chacra and Pulp uploads are independently configurable and run as separate Jenkins stages.

Changes consists of:
- Add `CHACRA_UPLOAD` parameter (default: `true`) and enable `PULP_UPLOAD` by default, allowing each artifact destination to be toggled separately.
- Split `check for built packages` into `configure Chacra`, `configure Pulp`, and `validate artifact checks stages`, with Pulp repository existence checks mirroring the existing Chacra chacractl check.
- Split `upload packages` into `prepare upload`, `upload to Chacra`, and `upload to Pulp stages`; Shaman status updates are scoped to the Chacra stage.
- Extract `build_ceph_release_rpm()` helper so ceph-release RPM generation is shared for both Chacra and Pulp repo URLs.
- Require `PULP_SERVER_URL`, `PULP_USERNAME`, and `PULP_PASSWORD` in `setup_pulp.sh`; move the Pulp server URL into the Jenkinsfile.