### PR TITLE
builder.yml: Get libvirt-devel from CRB

### DIFF
--- a/ansible/examples/builder.yml
+++ b/ansible/examples/builder.yml
@@ -623,11 +623,11 @@
         disablerepo: epel
       when: ansible_os_family == "RedHat"
 
-    - name: Install RPMs with EPEL
+    - name: Install RPMs with EPEL,CRB
       yum:
         name: "{{ epel_rpms|default([]) }}"
         state: latest
-        enablerepo: epel
+        enablerepo: "epel,crb"
       when: ansible_os_family == "RedHat"
 
     - name: Install Suse RPMs


### PR DESCRIPTION
Tested on CentOS 9 Stream and Rocky 10