### PR TITLE
ceph-windows: actually disable the mgr for the vstart cluster

### DIFF
--- a/scripts/ceph-windows/setup_ceph_vstart
+++ b/scripts/ceph-windows/setup_ceph_vstart
@@ -34,8 +34,8 @@ cd ~/ceph
     -DCMAKE_BUILD_TYPE=Release \
     -DWITH_RADOSGW=OFF \
     -DWITH_MGR_DASHBOARD_FRONTEND=OFF \
-    -WITH_MGR=OFF \
-    -WITH_LTTNG=OFF \
+    -DWITH_MGR=OFF \
+    -DWITH_LTTNG=OFF \
     -DWITH_TESTS=OFF
 cd ./build
 ninja vstart
@@ -59,7 +59,8 @@ cat > ${VSTART_DIR}/ceph-vstart.sh << EOF
 mkdir -p \$HOME/ceph-vstart/out
 
 cd ~/ceph/build
-VSTART_DEST=\$HOME/ceph-vstart ../src/vstart.sh \
+# WITH_MGR=OFF above means ceph-mgr is not built; tell vstart not to start one.
+CEPH_NUM_MGR=0 VSTART_DEST=\$HOME/ceph-vstart ../src/vstart.sh \
     -n $OBJECTSTORE_ARGS \
     --without-dashboard -i "$UBUNTU_VM_IP" \
     2>&1 | tee \$HOME/ceph-vstart/vstart.log


### PR DESCRIPTION
-WITH_MGR=OFF and -WITH_LTTNG=OFF were passed to do_cmake.sh with a single dash, so cmake never set them.  The mgr has therefore been built and started by every vstart run since this script was added in 2022, only to fail loading rbd_support and telemetry because their python deps were never installed.

The librbd, rados and cephfs tests run against this cluster use the direct library API and do not need the mgr, so disable it as originally intended. Pass -DWITH_MGR=OFF (and -DWITH_LTTNG=OFF), and set CEPH_NUM_MGR=0 for vstart.sh so it does not try to start a ceph-mgr that is no longer built.

python3-prettytable is kept: it is a client CLI dependency (`ceph_daemon.py`), not a mgr one.