### PR TITLE
ceph-website-prs: use GH PR number instead of branch name

### DIFF
--- a/ceph-website-prs/build/build
+++ b/ceph-website-prs/build/build
@@ -22,8 +22,7 @@ npm ci
 
 npm run build:development
 
-# This will support "/" and "." in branch names - specific usecase being depadabot branches
-OUTPUT_DIR=$(echo "$BRANCH" | tr '/.' '-')
+OUTPUT_DIR="$ghprbPullId"
 
 if [ ! -d /opt/www/${OUTPUT_DIR} ]; then
   mkdir -p /opt/www/${OUTPUT_DIR}

--- a/ceph-website-prs/config/definitions/ceph-website-prs.yml
+++ b/ceph-website-prs/config/definitions/ceph-website-prs.yml
@@ -1,6 +1,6 @@
 - job:
     name: ceph-website-prs
-    description: This job builds PRs from github.com/ceph/ceph.io and serves them at $branch.ceph.io.
+    description: This job builds PRs from github.com/ceph/ceph.io and serves them at $prnumber.ceph.io.
     node: www
     project-type: freestyle
     defaults: global
@@ -36,7 +36,7 @@
           started-status: "Compiling site"
           success-status: "Site compiled successfully!"
           failure-status: "Site compilation failed"
-          success-comment: "Site built/updated successfully!  https://${{GIT_BRANCH}}.ceph.io"
+          success-comment: "Site built/updated successfully!  https://${{ghprbPullId}}.ceph.io"
 
     scm:
       - git:


### PR DESCRIPTION
This PR changes the identifier used for ceph.io sites built from PRs from the branch name to the GitHub PR ID.
This identifier is used to create a directory in the file system and is included in the URL to the built site as branchname.ceph.io.

This change fixes two problems:
1. Set of characters allowed for git branch names contains characters that are not allowed in directory names or DNS labels.
2. This job adds a comment in the GitHub PR after the build is successful. The comment contains URL to the built site. I did not see an obvious way to modify the branch name in the YAML definition and workarounds might be needed to get the URL to match what is being done in the build script.

PR #2579 fixed point 1 for dependabot PRs but missed all other invalid characters such as the ampersand and missed point 2.

Sites built from PRs would be at prnumber.ceph.io if this is merged, for example 1234.ceph.io. This assumes the DNS is configured with a wildcard RR and the web server is configured to serve the content from the directory indicated by the left-most DNS label of the request URL without enforcing a specific syntax for the label.