### PR TITLE
kernel: install perl

### DIFF
--- a/kernel/build/setup
+++ b/kernel/build/setup
@@ -30,7 +30,7 @@ fi
 export LC_ALL=C # the following is vulnerable to i18n
 
 if test -f /etc/redhat-release ; then
-    $SUDO yum install -y bc
+    $SUDO yum install -y bc perl
     $SUDO yum install -y elfutils-libelf-devel  # for ORC unwinder
     $SUDO yum install -y flex bison  # for Kconfig
     $SUDO yum install -y dwarves
@@ -43,7 +43,7 @@ if test -f /etc/redhat-release ; then
 fi
 
 if which apt-get > /dev/null ; then
-    $SUDO apt-get install -y bc
+    $SUDO apt-get install -y bc perl
     $SUDO apt-get install -y lsb-release
     $SUDO apt-get install -y libelf-dev  # for ORC unwinder
     $SUDO apt-get install -y flex bison  # for Kconfig


### PR DESCRIPTION
perl has been required for building the Linux kernel for a long time but it's not installed explicitly.

  error: Failed build dependencies:
  	perl is needed by kernel-7.1.0_g0248d0a325dc-1.x86_64
  make[2]: *** [scripts/Makefile.package:75: binrpm-pkg] Error 11