### PR TITLE
ceph-perf: run run-cbt under bash on Jenkins

### DIFF
--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -49,6 +49,7 @@
     name: run-cbt
     builders:
       - shell: |
+          #!/bin/bash
           set -euxo pipefail
           cd {src-dir}
           git submodule update --init --recursive


### PR DESCRIPTION
Jenkins invokes shell steps as /bin/sh -xe when there is no shebang. On Noble that is dash, which rejects set -o pipefail. Add #!/bin/bash so Jenkins runs the run-cbt builder with bash.