### PR TITLE
Revert "ceph-windows: actually disable the mgr for the vstart cluster"

### DIFF
--- a/scripts/ceph-windows/setup_ceph_vstart
+++ b/scripts/ceph-windows/setup_ceph_vstart
@@ -34,8 +34,8 @@ cd ~/ceph
     -DCMAKE_BUILD_TYPE=Release \
     -DWITH_RADOSGW=OFF \
     -DWITH_MGR_DASHBOARD_FRONTEND=OFF \
-    -DWITH_MGR=OFF \
-    -DWITH_LTTNG=OFF \
+    -WITH_MGR=OFF \
+    -WITH_LTTNG=OFF \
     -DWITH_TESTS=OFF
 cd ./build
 ninja vstart
@@ -59,8 +59,7 @@ cat > ${VSTART_DIR}/ceph-vstart.sh << EOF
 mkdir -p \$HOME/ceph-vstart/out
 
 cd ~/ceph/build
-# WITH_MGR=OFF above means ceph-mgr is not built; tell vstart not to start one.
-CEPH_NUM_MGR=0 VSTART_DEST=\$HOME/ceph-vstart ../src/vstart.sh \
+VSTART_DEST=\$HOME/ceph-vstart ../src/vstart.sh \
     -n $OBJECTSTORE_ARGS \
     --without-dashboard -i "$UBUNTU_VM_IP" \
     2>&1 | tee \$HOME/ceph-vstart/vstart.log


### PR DESCRIPTION
turns out vstart.sh depends on mgr, and windows test uses vstart.sh to start a cluter for running tests.

This reverts commit ed61da39dff87518e2779727c62d509f4a7ebd2c.