### PR TITLE
bwc: pin podman auth to a persistent authfile

### DIFF
--- a/scripts/bwc.sh
+++ b/scripts/bwc.sh
@@ -83,7 +83,10 @@ bwc_login() {
     if [ -z "${DOCKER_HUB_USERNAME}" ] || [ -z "${DOCKER_HUB_PASSWORD}" ]; then
         return 0
     fi
-    podman login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}" docker.io
+    export REGISTRY_AUTH_FILE="${HOME}/.config/containers/auth.json"
+    mkdir -p "${REGISTRY_AUTH_FILE%/*}"
+    podman login --authfile "${REGISTRY_AUTH_FILE}" \
+        -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}" docker.io
 }
 
 # bwc_arch - Print the architecture of the current host in the style


### PR DESCRIPTION
podman login was writing credentials to the default location under XDG_RUNTIME_DIR (/run/user/<uid>), which is logind-managed tmpfs. The Jenkins agent runs without XDG_RUNTIME_DIR set, so the runtime dir can be torn down or re-resolved between bwc_login and the podman build it is meant to authenticate. When that happens, the base image pull inside build-with-container.py silently falls back to anonymous and hits Docker Hub's per-IP unauthenticated rate limit (toomanyrequests), e.g.:

  https://jenkins.ceph.com/job/ceph-pull-requests-arm64/99076/

Set REGISTRY_AUTH_FILE to a persistent path in $HOME and pass --authfile to podman login so login and all subsequent podman/buildah invocations in the job resolve the same credential file regardless of session state.