### PR TITLE
jenkins: enable Declarative script splitting to fix "Method too large" pipeline failures

### DIFF
--- a/ansible/roles/ansible-jenkins/templates/etc_default.j2
+++ b/ansible/roles/ansible-jenkins/templates/etc_default.j2
@@ -7,7 +7,7 @@ NAME=jenkins
 JAVA=/usr/bin/java
 
 # From https://jenkins.io/blog/2016/11/21/gc-tuning/
-JAVA_ARGS="-Xmx20g -Xms20g -Djava.awt.headless=true -Dhudson.model.User.SECURITY_243_FULL_DEFENSE=false -Dhudson.model.ParametersAction.keepUndefinedParameters=true -server -XX:+AlwaysPreTouch -Xloggc:/var/log/jenkins/gc-%t.log -XX:+PrintGC -XX:+PrintGCDetails -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1"
+JAVA_ARGS="-Xmx20g -Xms20g -Djava.awt.headless=true -Dhudson.model.User.SECURITY_243_FULL_DEFENSE=false -Dhudson.model.ParametersAction.keepUndefinedParameters=true -Dorg.jenkinsci.plugins.pipeline.modeldefinition.parser.RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION=true -server -XX:+AlwaysPreTouch -Xloggc:/var/log/jenkins/gc-%t.log -XX:+PrintGC -XX:+PrintGCDetails -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1"
 
 PIDFILE=/var/run/$NAME/$NAME.pid
 

--- a/ceph-dev-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-dev-pipeline-trigger/build/Jenkinsfile
@@ -1,3 +1,5 @@
+import groovy.transform.Field
+
 JOB = "ceph-dev-pipeline"
 VALID_PARAMETERS = [
   "CEPH_BUILD_BRANCH",
@@ -10,7 +12,7 @@ VALID_PARAMETERS = [
   "FLAVOR",
   "SCCACHE",
 ]
-def params = []
+@Field List build_params = []
 
 pipeline {
   agent any
@@ -33,12 +35,12 @@ pipeline {
             }
           }
           def branch = env.ref.replace("refs/heads/", "")
-          params.push(string(name: "BRANCH", value: branch))
+          build_params.push(string(name: "BRANCH", value: branch))
           println("Looking for parameters: ${VALID_PARAMETERS}")
           for (key in VALID_PARAMETERS) {
             value = paramsMap[key]
             if ( value ) {
-              params.push(string(name: key, value: value))
+              build_params.push(string(name: key, value: value))
               println("${key}=${value}")
             }
           }
@@ -50,7 +52,7 @@ pipeline {
         script {
           build(
             job: JOB,
-            parameters: params
+            parameters: build_params
           )
         }
       }


### PR DESCRIPTION
## Problem

Adding cells to the ceph-dev-pipeline build matrix (e.g. noble debug builds, #2622,
since reverted in #2641) makes every build fail at compile time:

    org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
    General error during class generation: Method too large: WorkflowScript.___cps___72076 ()Lcom/cloudbees/groovy/cps/impl/CpsFunction;

The Declarative plugin's `RuntimeASTTransformer` emits the entire `pipeline {}`
model as a single generated method, and a `matrix` block duplicates the whole
nested stage model once per cell. With 18 cells we were just under the JVM's
64KB-per-method bytecode limit; the 19th cell (noble/x86_64/debug) pushed it
over. Extracting stage bodies into helper functions (#2621) didn't help because
the per-cell model boilerplate, not the step closures, dominates the generated
method.

## Solution

Enable the script splitting transformation ([JENKINS-37984]), which makes the
transformer emit the model as many smaller methods instead of one giant one.
It's opt-in via a system property, added here to the controller's `JAVA_ARGS`
in the ansible-jenkins role:

    -Dorg.jenkinsci.plugins.pipeline.modeldefinition.parser.RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION=true

Script splitting rejects Declarative pipelines that declare top-level local
variables (they must be `@Field`). I audited every Declarative Jenkinsfile in
this repo; the only offender was ceph-dev-pipeline-trigger's `def params = []`,
fixed in the second commit (renamed to `build_params` to stop shadowing the
Declarative `params` global). ceph-dev-pipeline and ceph-trigger-build already
use `@Field` throughout and need no changes.

## Testing

Enabled on jenkins.ceph.com without a restart via the Script Console
(the property is only read at class load, so the static field has to be set
directly):

    org.jenkinsci.plugins.pipeline.modeldefinition.parser.RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION = true

With that set, [preserve-ceph-dev-pipeline-dgalloway] compiles and runs the
matrix including noble debug cells — the same Jenkinsfile that previously
failed on every build.

## Rollout

The Script Console setting does not survive a controller restart. After this
merges, run the ansible-jenkins role against the controller (restart required
for the new JAVA_ARGS) — then #2622 can be re-applied.

[JENKINS-37984]: https://issues.jenkins.io/browse/JENKINS-37984
[preserve-ceph-dev-pipeline-dgalloway]: https://jenkins.ceph.com/job/preserve-ceph-dev-pipeline-dgalloway/