### PR TITLE
CVE pipeline

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -475,6 +475,7 @@ def doUploadPackagesStage() {
       export FLAVOR="${env.FLAVOR}"
 
       ./scripts/pulp_upload.sh
+      ./scripts/notify_shaman_pulp_repo.sh ready ceph ${os.name} ${os.version_name} ${env.ARCH} https://pulp.front.sepia.ceph.com/pulp/content/repos/ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}/${env.ARCH}/
     else
       echo "Skipping pulp upload because PULP_UPLOAD=${env.PULP_UPLOAD}"
     fi

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -460,7 +460,7 @@ def doUploadPackagesStage() {
     export OS_VERSION="${os.version}"
     export OS_VERSION_NAME="${os.version_name}"
     export OS_PKG_TYPE="${os.pkg_type}"
-    if [ "${env.THROWAWAY}" != "true" ]; then ./scripts/chacra_upload.sh; fi
+    if [ "${env.THROWAWAY}" != "true" ] && [ "${env.CHACRA_UPLOAD}" == "true" ]; then ./scripts/chacra_upload.sh; fi
   """
 
   sh """#!/bin/bash

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -624,7 +624,8 @@ pipeline {
           }
           stage("builder container") {
             environment {
-              CONTAINER_REPO_CREDS = credentials('quay-ceph-io-ceph-ci')
+              // Use quay-int.front cred if cve-pipeline, otherwise default to quay.ceph.io cred
+              CONTAINER_REPO_CREDS = credentials("${env.JOB_NAME == 'cve-pipeline' ? 'quay-int-login' : 'quay-ceph-io-ceph-ci'}")
               DOCKER_HUB_CREDS = credentials('dgalloway-docker-hub')
             }
             when {
@@ -688,7 +689,7 @@ pipeline {
               expression { env.CI_CONTAINER == 'true' && container_distros.contains(env.DIST) }
             }
             environment {
-              CONTAINER_REPO_CREDS = credentials('quay-ceph-io-ceph-ci')
+              CONTAINER_REPO_CREDS = credentials("${env.JOB_NAME == 'cve-pipeline' ? 'quay-int-login' : 'quay-ceph-io-ceph-ci'}")
             }
             steps {
               script { doContainerStage() }

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -426,6 +426,21 @@ def doUploadPackagesStage() {
     returnStdout: true,
   ).trim()
   def os = get_os_info(env.DIST)
+  // Push packages to chacra.ceph.com under the 'test' ref if ceph-release-pipeline's TEST=true
+  if ( os.pkg_type == "rpm" ) {
+    env.SHA1 = env.TEST?.toBoolean() ? 'test' : env.SHA1
+  }
+  // The ceph-release RPM's /etc/yum.repos.d/ceph.repo baseurls and the repo
+  // URL reported to shaman must match where packages were actually
+  // published: pulp when PULP_UPLOAD=true, otherwise chacra.
+  // chacra_url already ends with a trailing slash.
+  def repo_base_url
+  if ( env.PULP_UPLOAD == "true" ) {
+    repo_base_url = "https://pulp.front.sepia.ceph.com/pulp/content/repos/ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}"
+  } else {
+    repo_base_url = "${chacra_url}r/ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}"
+  }
+  def spec_project_url = "${repo_base_url}/"
   if ( os.pkg_type == "rpm" ) {
     sh """#!/bin/bash
         set -ex
@@ -433,14 +448,12 @@ def doUploadPackagesStage() {
         mkdir -p ./rpmbuild/SRPMS/
         ln ceph-*.src.rpm ./rpmbuild/SRPMS/
     """
-    // Push packages to chacra.ceph.com under the 'test' ref if ceph-release-pipeline's TEST=true
-    env.SHA1 = env.TEST?.toBoolean() ? 'test' : env.SHA1
-    def spec_text = get_ceph_release_spec_text("${chacra_url}r/ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}/")
+    def spec_text = get_ceph_release_spec_text(spec_project_url)
     writeFile(
       file: "dist/ceph/rpmbuild/SPECS/ceph-release.spec",
       text: spec_text,
     )
-    def repo_text = get_ceph_release_repo_text("${chacra_url}/r/ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}")
+    def repo_text = get_ceph_release_repo_text(repo_base_url)
     writeFile(
       file: "dist/ceph/rpmbuild/SOURCES/ceph.repo",
       text: repo_text,
@@ -475,7 +488,7 @@ def doUploadPackagesStage() {
       export FLAVOR="${env.FLAVOR}"
 
       ./scripts/pulp_upload.sh
-      ./scripts/notify_shaman_pulp_repo.sh ready ceph ${os.name} ${os.version_name} ${env.ARCH} https://pulp.front.sepia.ceph.com/pulp/content/repos/ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}/${env.ARCH}/
+      ./scripts/notify_shaman_pulp_repo.sh ready ceph ${os.name} ${os.version_name} ${env.ARCH} ${spec_project_url}${env.ARCH}/
     else
       echo "Skipping pulp upload because PULP_UPLOAD=${env.PULP_UPLOAD}"
     fi

--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -56,13 +56,18 @@
 
       - bool:
           name: THROWAWAY
-          description: "Whether to push any binaries to Chacra"
+          description: "Whether to push any binaries to Chacra or Pulp.  Overrides CHACRA_UPLOAD and PULP_UPLOAD if either are true."
           default: false
 
       - bool:
           name: FORCE
           description: "Whether to push new binaries to Chacra if some are already present"
           default: false
+
+      - bool:
+          name: CHACRA_UPLOAD
+          description: "Whether to upload packages to Chacra"
+          default: true
 
       - bool:
           name: PULP_UPLOAD

--- a/cve-pipeline/config/definitions/cve-pipeline.yml
+++ b/cve-pipeline/config/definitions/cve-pipeline.yml
@@ -1,0 +1,128 @@
+- job:
+    name: cve-pipeline
+    properties:
+      - authorization:
+          inheritance-strategy: none
+          GROUP:ceph*security:
+            - job-read
+            - job-discover
+            - job-build
+            - job-cancel
+            - job-configure
+            - job-workspace
+            - run-replay
+            - run-update
+            - run-delete
+            - scm-tag
+    description: |
+      This Jenkins pipeline is only used to develop CVE fixes.  Its differences are:
+        - The job itself is not public-facing.  It does not inherit the RBAC under https://jenkins.ceph.com/manage/configureSecurity/
+        - ceph-dev-pipeline pushes to the internal/private pulp instance instead of a public chacra instance
+    project-type: pipeline
+    quiet-period: 1
+    concurrent: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/ceph/ceph-build
+            branches:
+              - ${{CEPH_BUILD_BRANCH}}
+            shallow-clone: true
+            submodule:
+              disable: true
+            wipe-workspace: true
+      script-path: ceph-dev-pipeline/build/Jenkinsfile
+      lightweight-checkout: true
+      do-not-fetch-tags: true
+
+    parameters:
+      - string:
+          name: BRANCH
+          description: "The branch from ceph-private.git to build"
+          default: main
+
+      - choice:
+          name: SHA1
+          description: "Intentionally blank.  ceph-dev-pipeline requires this"
+          choices:
+            - ''
+
+      - choice:
+          name: CEPH_REPO
+          choices:
+            - git@github.com:ceph/ceph-private.git
+
+      - string:
+          name: DISTROS
+          description: "A list of distros to build for. Available options are: centos9, noble, jammy, bookworm, trixie"
+          default: "noble centos9 bookworm trixie"
+
+      - string:
+          name: ARCHS
+          description: "A list of architectures to build for. Available options are: x86_64, and arm64"
+          default: "x86_64 arm64"
+
+      - bool:
+          name: CI_COMPILE
+          description: "Whether to compile and build packages"
+          default: true
+
+      - bool:
+          name: THROWAWAY
+          description: "DO NOT UNCHECK.  This will push to a chacra node publicly!"
+          default: true
+
+      - bool:
+          name: PULP_UPLOAD
+          description: "If you want packages, this must be true.  We do not push to chacra for CVE builds."
+          default: true
+
+      - choice:
+          name: FLAVORS
+          choices:
+            - default
+
+      - bool:
+          name: CI_CONTAINER
+          description: "Whether to build and push container images"
+          default: true
+
+      - string:
+          name: CONTAINER_REPO_HOSTNAME
+          description: "FQDN of container repo server (e.g. 'quay.io')"
+          default: "quay-int.front.sepia.ceph.com"
+
+      - string:
+          name: CONTAINER_REPO_ORGANIZATION
+          description: "Name of container repo organization (e.g. 'ceph-ci')"
+          default: "ceph-ci"
+
+      - bool:
+          name: DWZ
+          description: "Use dwz to make debuginfo packages smaller"
+          default: false
+
+      - bool:
+          name: SCCACHE
+          description: "Use sccache to speed up compilation"
+          default: true
+
+      - string:
+          name: SETUP_BUILD_ID
+          description: "Reuse the source distribution from this cve-source-dist build instead of creating a new one"
+          default: ""
+
+      - choice:
+          name: SETUP_JOB
+          choices:
+            - cve-source-dist
+
+      - string:
+          name: CEPH_BUILD_BRANCH
+          description: "Use the Jenkinsfile from this ceph-build branch"
+          default: main
+
+    wrappers:
+      - build-name:
+          name: "#${{BUILD_NUMBER}} ${{BRANCH}}, ${{VERSION}}"
+

--- a/cve-pipeline/config/definitions/cve-pipeline.yml
+++ b/cve-pipeline/config/definitions/cve-pipeline.yml
@@ -69,8 +69,13 @@
 
       - bool:
           name: THROWAWAY
-          description: "DO NOT UNCHECK.  This will push to a chacra node publicly!"
-          default: true
+          description: "Whether to push any binaries to Chacra or Pulp.  Overrides CHACRA_UPLOAD and PULP_UPLOAD if either are true."
+          default: false
+
+      - bool:
+          name: CHACRA_UPLOAD
+          description: "DO NOT CHECK"
+          default: false
 
       - bool:
           name: PULP_UPLOAD

--- a/cve-source-dist/config/definitions/cve-source-dist.yml
+++ b/cve-source-dist/config/definitions/cve-source-dist.yml
@@ -1,0 +1,78 @@
+- job:
+    name: cve-source-dist
+    description: This job is only called from https://jenkins.ceph.com/job/cve-pipeline.  The entire job and its artifacts are only visible to the ceph/security Github Team.
+    project-type: pipeline
+    concurrent: true
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/ceph/ceph-build
+            branches:
+              - ${{CEPH_BUILD_BRANCH}}
+            shallow-clone: true
+            submodule:
+              disable: true
+            wipe-workspace: true
+      script-path: ceph-source-dist/build/Jenkinsfile
+      lightweight-checkout: true
+      do-not-fetch-tags: true
+    properties:
+      - build-discarder:
+          days-to-keep: -1
+          num-to-keep: 100
+          artifact-days-to-keep: -1
+          artifact-num-to-keep: 50
+      - copyartifact:
+          projects: cve-pipeline
+      - authorization:
+          inheritance-strategy: none
+          GROUP:ceph*security:
+            - job-read
+            - job-discover
+            - job-build
+            - job-cancel
+            - job-configure
+            - job-workspace
+            - run-replay
+            - run-update
+            - run-delete
+            - scm-tag
+
+    parameters:
+      - choice:
+          name: CEPH_REPO
+          choices:
+            - git@github.com:ceph/ceph-private.git
+
+      - string:
+          name: BRANCH
+          description: "The Ceph branch to build"
+
+      - string:
+          name: SHA1
+          description: "The specific commit to build"
+
+      - string:
+          name: CEPH_BUILD_BRANCH
+          description: "Use the Jenkinsfile from this ceph-build branch"
+          default: main
+
+    scm:
+      - git:
+          url: ${{CEPH_REPO}}
+          # Use the SSH key attached to the ceph-jenkins GitHub account.
+          credentials-id: "jenkins-build"
+          branches:
+            - $BRANCH
+          timeout: 20
+          skip-tag: true
+          wipe-workspace: true
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true
+      - credentials-binding:
+          - text:
+              credential-id: shaman-api-key
+              variable: SHAMAN_API_KEY

--- a/scripts/notify_shaman_pulp_repo.sh
+++ b/scripts/notify_shaman_pulp_repo.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# vim: ts=4 sw=4 expandtab
+
+submit_repo_status() {
+
+    # A helper script to post (create) the status of a repo in shaman.
+    # 'state' is the repo status (e.g. 'ready').
+    # 'project' is used to post to the right url in shaman.
+    # shaman keys repos by 'chacra_url' and builds Arch rows from the 'archs'
+    # list, so the arch must be sent as a JSON array (not 'distro_arch').
+    # Mirroring chacra's repo records: 'url' is the browsable location of the
+    # actual package repo (here, the Pulp content distribution) and
+    # 'chacra_url' is the repo's API endpoint (chacra: /repos/..., pulp:
+    # /pulp/api/v3/repositories/...).
+    http_method=$1
+    state=$2
+    project=$3
+    distro=$4
+    distro_version=$5
+    arch=$6
+    url=$7
+
+    # RPM builds also ship source RPMs (the SRPMS/ subdir), so advertise a
+    # "source" arch to shaman alongside the binary arch, mirroring chacra.
+    # Binary debs have no corresponding source repo. OS_PKG_TYPE is exported
+    # by the calling Jenkins step.
+    archs="\"$arch\""
+    if [ "$OS_PKG_TYPE" = "rpm" ]; then
+        archs="${archs},\"source\""
+    fi
+
+    # package_manager_version and the repository's API URL are computed by
+    # pulp_upload.sh (a separate process) and handed off via this file in
+    # the shared workspace.
+    PACKAGE_MANAGER_VERSION=""
+    PULP_REPO_API_URL=""
+    if [ -r "$WORKSPACE/pulp_repo_info" ]; then
+        source "$WORKSPACE/pulp_repo_info"
+    fi
+
+    cat > $WORKSPACE/repo_status.json << EOF
+{
+    "url":"$url",
+    "chacra_url":"${PULP_REPO_API_URL:-$url}",
+    "status":"$state",
+    "distro":"$distro",
+    "distro_version":"$distro_version",
+    "archs":[$archs],
+    "ref":"$BRANCH",
+    "sha1":"$SHA1",
+    "flavor":"$FLAVOR",
+    "extra":{
+        "version":"$CEPH_VERSION",
+        "package_manager_version":"$PACKAGE_MANAGER_VERSION",
+        "build_url":"$BUILD_URL",
+        "root_build_cause":"$ROOT_BUILD_CAUSE",
+        "node_name":"$NODE_NAME",
+        "job_name":"$JOB_NAME"
+    }
+}
+EOF
+
+    SHAMAN_URL="https://shaman.ceph.com/api/repos/$project/"
+    # post the repo information as JSON to shaman
+    curl -X $http_method -H "Content-Type:application/json" --data "@$WORKSPACE/repo_status.json" -u $SHAMAN_API_USER:$SHAMAN_API_KEY ${SHAMAN_URL}
+}
+
+# If the script is executed (as opposed to sourced), run the function now
+if [ "$(basename -- "${0#-}")" = "$(basename -- "${BASH_SOURCE}")" ]; then
+  submit_repo_status "POST" "$@"
+fi

--- a/scripts/pulp_upload.sh
+++ b/scripts/pulp_upload.sh
@@ -26,6 +26,8 @@ source ./scripts/build_utils.sh
 export PATH="$HOME/.local/bin:$PATH"
 
 PULP_PROJECT="ceph"
+# Must match the base URL the Pulp client is configured with in setup_pulp.sh
+PULP_SERVER_URL="https://pulp.front.sepia.ceph.com"
 SHORT_SHA1=${SHA1: -8}
 
 # Log a message to stderr with a consistent prefix.
@@ -520,3 +522,14 @@ else
     log "ERROR: Unsupported OS_PKG_TYPE='${OS_PKG_TYPE}' (expected rpm or deb)"
     exit 1
 fi
+
+# Hand off repo metadata to the shaman notify step, which runs as a
+# separate process. PACKAGE_MANAGER_VERSION is included in the repo
+# record's extra metadata; the repository's API URL becomes the record's
+# chacra_url. See notify_shaman_pulp_repo.sh.
+_repo_href=$(pulp "${OS_PKG_TYPE}" repository show \
+    --name "${REPO_NAME}-${ARCH}" | jq -r '.pulp_href')
+{
+    printf 'PACKAGE_MANAGER_VERSION=%q\n' "${PACKAGE_MANAGER_VERSION}"
+    printf 'PULP_REPO_API_URL=%q\n' "${PULP_SERVER_URL}${_repo_href}"
+} > "${WORKSPACE}/pulp_repo_info"


### PR DESCRIPTION
## Summary

This adds a `cve-pipeline` (and `cve-source-dist`) job for building packages and containers from ceph-private.git entirely privately — Jenkins build logs, artifacts, packages, and containers. Packages go to the internal-only Pulp instance and containers to the internal-only Quay instance.

To avoid job duplication, the CVE jobs reuse the existing Jenkinsfiles (`cve-pipeline` → `ceph-dev-pipeline`, `cve-source-dist` → `ceph-source-dist`) and differ only in the parameters passed: `CEPH_REPO` points at ceph-private.git, uploads to public chacra are disabled, and the internal Quay credential is selected when `JOB_NAME == 'cve-pipeline'`.

Along the way, ceph-dev-pipeline gains the pieces needed for Pulp-published builds to be fully usable:

- **`CHACRA_UPLOAD` parameter** — chacra upload can now be toggled independently of Pulp upload. `THROWAWAY` still overrides both. cve-pipeline defaults it to `false` so nothing leaks to a public chacra node.
- **Shaman notification for Pulp repos** (`scripts/notify_shaman_pulp_repo.sh`) — mirrors chacra's repo records: `url` is the browsable package repo (the Pulp content distribution for the build's arch, e.g. `.../pulp/content/repos/ceph/<branch>/<sha1>/<distro>/<version>/flavors/<flavor>/<arch>/`), and `chacra_url` is the repository's API endpoint (`/pulp/api/v3/repositories/...`). `pulp_upload.sh` hands off the repository href and package manager version via `$WORKSPACE/pulp_repo_info`.
- **`ceph.repo` in the ceph-release RPM points at the right place** — when `PULP_UPLOAD=true`, the baseurls written into the ceph-release RPM's `/etc/yum.repos.d/ceph.repo` (and the spec's project URL) use the Pulp content location instead of chacra, matching the per-arch distribution layout from #2618 (`$basearch`, `noarch`, `SRPMS`).

## Notes

- Rebased on top of #2618 (Pulp repository creation with labels) and #2623 (Pulp container registry upload); the earlier commits in this branch that created repositories and fixed `BRANCH` handling in `pulp_upload.sh` were dropped as superseded.
- Review feedback addressed: `spec_project_url` is now derived from `repo_base_url` (`"${repo_base_url}/"`), fixing the unintentional `${chacra_url}r/` vs `${chacra_url}/r/` mismatch, and the shaman notify call reuses `spec_project_url` instead of repeating the hardcoded Pulp URL.
- `PULP_SERVER_URL` is hardcoded in both `setup_pulp.sh` and `pulp_upload.sh` (comment added noting they must match), and the Pulp content URL is hardcoded in the Jenkinsfile. If/when the internal CVE Pulp instance lives at a different hostname, these should become a parameter — follow-up material.
- `cve-pipeline.yml` intentionally does not define `PULP_REGISTRY_UPLOAD`; the registry-upload stage skips when unset. It can be added later if CVE builds should mirror containers into the Pulp registry.