### PR TITLE
ceph-release-pipeline: use @Field for top-level variables

### DIFF
--- a/ceph-release-pipeline/build/Jenkinsfile
+++ b/ceph-release-pipeline/build/Jenkinsfile
@@ -1,7 +1,15 @@
-// Global variables to use across stages
-def CEPH_TAG_CREATE_JOB_ID, CEPH_TAG_CREATE_JOB_URL
-def PACKAGE_BUILD_ID, PACKAGE_BUILD_URL
-def CEPH_TAG_PUSH_JOB_ID, CEPH_TAG_PUSH_JOB_URL
+import groovy.transform.Field
+
+// Global variables to use across stages.
+// @Field is required because SCRIPT_SPLITTING_TRANSFORMATION is enabled on
+// jenkins.ceph.com (JENKINS-37984); plain script-level 'def' declarations
+// fail compilation with it.
+@Field def CEPH_TAG_CREATE_JOB_ID
+@Field def CEPH_TAG_CREATE_JOB_URL
+@Field def PACKAGE_BUILD_ID
+@Field def PACKAGE_BUILD_URL
+@Field def CEPH_TAG_PUSH_JOB_ID
+@Field def CEPH_TAG_PUSH_JOB_URL
 
 pipeline {
   agent any


### PR DESCRIPTION
SCRIPT_SPLITTING_TRANSFORMATION (JENKINS-37984) is enabled on jenkins.ceph.com to keep ceph-dev-pipeline under the JVM 64KB method limit. That flag rejects Declarative pipelines with script-level local variable declarations, so ceph-release-pipeline failed to compile:

  General error during semantic analysis: [JENKINS-37984]
  SCRIPT_SPLITTING_TRANSFORMATION is ... incompatible with local
  variable declarations inside a Jenkinsfile.

Annotate the cross-stage variables with @Field, same as was done for ceph-dev-pipeline-trigger in c898b349. Audited all other Declarative Jenkinsfiles in the repo; no other job has script-level variable declarations.