### PR TITLE
enhancement: split `Chacra` and `Pulp` upload into independent pipeline stages

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -241,15 +241,6 @@ def doCopyArtifactsStage() {
 
 // Stage 5.1 (check for chacra packages): ask shaman whether a chacra repo is ready for this build (and skip compilation if so, unless FORCE).
 def doCheckForChacraPackagesStage() {
-  withCredentials([
-    string(credentialsId: "chacractl-key", variable: "CHACRACTL_KEY"),
-    string(credentialsId: "shaman-api-key", variable: "SHAMAN_API_KEY")
-  ]) {
-    // Configures ~/.chacractl for the upload stage later in this cell.
-    sh """#!/bin/bash -ex
-      ./scripts/setup_chacractl.sh
-    """
-  }
   def os = get_os_info(env.DIST)
   // Uploads go to whichever chacra node shaman's /api/nodes/next/ hands out,
   // so `chacractl exists` against a freshly allocated node only succeeds when
@@ -538,6 +529,14 @@ def withUploadEnv(Closure body) {
 // Stage 8.1 (upload packages to Chacra): build ceph-release RPM (rpm distros) and upload packages to Chacra.
 def doUploadChacraStage() {
   def os = get_os_info(env.DIST)
+  // Point ~/.chacractl at the chacra node shaman allocates for uploads.
+  // Runs here rather than in the check stage (which asks shaman, not
+  // chacra) so that shaman having no healthy chacra nodes only fails
+  // builds that actually need to upload to chacra. CHACRACTL_KEY and
+  // SHAMAN_API_KEY come from the "upload packages" stage environment{}.
+  sh """#!/bin/bash -ex
+    ./scripts/setup_chacractl.sh
+  """
   def chacra_url = sh(
     script: "grep '^url' ~/.chacractl", returnStdout: true,
   ).trim().split('"')[1].trim().replaceAll(/\/+$/, '')

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -563,9 +563,13 @@ def doUploadPulpStage() {
     if (os.pkg_type == "rpm") {
       buildCephReleaseRpm(repo_url)
     }
+    // The shaman record's url must be the flavor-level repo root with the
+    // arch dirs (x86_64/, noarch/, SRPMS/) beneath it, matching chacra's
+    // convention: consumers like ceph.git's Containerfile append
+    // noarch/Packages/... to it to fetch the ceph-release RPM.
     sh """#!/bin/bash -ex
       ./scripts/pulp_upload.sh
-      ./scripts/notify_shaman_pulp_repo.sh ready ceph ${os.name} ${os.version_name} ${env.ARCH} ${repo_url}/${env.ARCH}/
+      ./scripts/notify_shaman_pulp_repo.sh ready ceph ${os.name} ${os.version_name} ${env.ARCH} ${repo_url}/
     """
   }
 }

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -316,40 +316,37 @@ def doArtifactsChecksStage() {
   }
 
   def cell = "${DIST}_${ARCH}_${FLAVOR}"
-  // -1 means "not checked" when that backend's upload is disabled.
-  def chacractl_rc = params.CHACRA_UPLOAD ? chacra_exists_rc[cell] : -1
-  def pulp_repo_exists = params.PULP_UPLOAD && pulp_dist_exists[cell] == true
-  def skip_reasons = []
+  def chacra_exists = chacra_exists_rc[cell] == 0
+  def pulp_exists = pulp_dist_exists[cell] == true
 
-  if (params.CHACRA_UPLOAD && chacractl_rc == 0) {
-    skip_reasons << "Chacra already has artifacts (chacractl_rc=${chacractl_rc})"
-  }
-  if (pulp_repo_exists) {
-    skip_reasons << "Pulp already has this build (distribution exists)"
-  }
+  // Compilation can only be skipped when every enabled backend already has
+  // this build; if one of them is missing it, we must compile so that its
+  // upload stage has packages to push. The upload stage of a backend that
+  // already has the build is skipped individually (see the upload stages'
+  // when{} expressions).
+  def chacra_satisfied = !params.CHACRA_UPLOAD || chacra_exists
+  def pulp_satisfied = !params.PULP_UPLOAD || pulp_exists
 
-  if (shouldSkipCompilation(chacractl_rc, pulp_repo_exists, params.CHACRA_UPLOAD, params.PULP_UPLOAD, force)) {
+  if (chacra_satisfied && pulp_satisfied) {
+    def skip_reasons = []
+    if (params.CHACRA_UPLOAD) {
+      skip_reasons << "Chacra already has this build (per shaman)"
+    }
+    if (params.PULP_UPLOAD) {
+      skip_reasons << "Pulp already has this build (distribution exists)"
+    }
     println("Skipping compilation:\n- " + skip_reasons.join("\n- "))
     println(
       "To override, use THROWAWAY=true (to skip this check) " +
       "or FORCE=true (to re-upload artifacts)."
     )
     build_matrix[cell] = false
+  } else {
+    def missing = []
+    if (params.CHACRA_UPLOAD && !chacra_exists) missing << "Chacra"
+    if (params.PULP_UPLOAD && !pulp_exists) missing << "Pulp"
+    println("Compiling: ${missing.join(' and ')} missing this build.")
   }
-}
-
-// Helper function to determine if compilation should be skipped.
-def shouldSkipCompilation(chacractl_rc, pulp_repo_exists, chacra_upload_enabled, pulp_upload_enabled, force) {
-  if (force) {
-    return false
-  }
-  if (chacra_upload_enabled && chacractl_rc == 0) {
-    return true
-  }
-  if (pulp_upload_enabled && pulp_repo_exists) {
-    return true
-  }
-  return false
 }
 
 // Stage 6 (builder container): log into container registries and pull/build/push the ceph-build container image for this matrix cell.
@@ -862,8 +859,11 @@ pipeline {
               }
               stage("upload packages to Chacra") {
                 when {
+                  // If chacra already had this build when the cell started,
+                  // compilation only ran because pulp was missing it, so
+                  // don't re-push the same build to chacra (unless FORCE).
                   expression {
-                    return params.CHACRA_UPLOAD
+                    return params.CHACRA_UPLOAD && (env.FORCE == "true" || chacra_exists_rc["${DIST}_${ARCH}_${FLAVOR}"] != 0)
                   }
                 }
                 steps {
@@ -872,8 +872,11 @@ pipeline {
               }
               stage("upload packages to Pulp") {
                 when {
+                  // If pulp already had this build when the cell started,
+                  // compilation only ran because chacra was missing it, so
+                  // don't re-push the same build to pulp (unless FORCE).
                   expression {
-                    return params.PULP_UPLOAD
+                    return params.PULP_UPLOAD && (env.FORCE == "true" || pulp_dist_exists["${DIST}_${ARCH}_${FLAVOR}"] != true)
                   }
                 }
                 steps {

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -239,24 +239,34 @@ def doCopyArtifactsStage() {
   '''
 }
 
-// Stage 5.1 (check for chacra packages): check chacra for an existing build (and skip compilation if found, unless FORCE).
+// Stage 5.1 (check for chacra packages): ask shaman whether a chacra repo is ready for this build (and skip compilation if so, unless FORCE).
 def doCheckForChacraPackagesStage() {
   withCredentials([
     string(credentialsId: "chacractl-key", variable: "CHACRACTL_KEY"),
     string(credentialsId: "shaman-api-key", variable: "SHAMAN_API_KEY")
   ]) {
+    // Configures ~/.chacractl for the upload stage later in this cell.
     sh """#!/bin/bash -ex
       ./scripts/setup_chacractl.sh
     """
-    def os = get_os_info(env.DIST)
-    def chacra_endpoint = "ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/${env.ARCH}/flavors/${env.FLAVOR}/"
-    chacra_exists_rc["${DIST}_${ARCH}_${FLAVOR}"] = sh(
-      script: """#!/bin/bash -ex
-        \$HOME/.local/bin/chacractl exists binaries/${chacra_endpoint}
-      """,
-      returnStatus: true,
-    )
   }
+  def os = get_os_info(env.DIST)
+  // Uploads go to whichever chacra node shaman's /api/nodes/next/ hands out,
+  // so `chacractl exists` against a freshly allocated node only succeeds when
+  // the rotation happens to repeat (e.g. binaries on 2.chacra, check asks
+  // 1.chacra -> false 404). Shaman's repo records are the source of truth for
+  // which node holds a build; pulp records live in the same collection, so
+  // filter on chacra_url.
+  def search_url = "https://shaman.ceph.com/api/search/?project=ceph" +
+      "&distros=${os.name}/${os.version_name}/${env.ARCH}" +
+      "&flavor=${env.FLAVOR}&ref=${env.BRANCH}&sha1=${env.SHA1}"
+  chacra_exists_rc["${DIST}_${ARCH}_${FLAVOR}"] = sh(
+    script: """#!/bin/bash -ex
+      curl -fs --max-time 30 "${search_url}" | \\
+        jq -e '[.[] | select((.chacra_url // "") | contains("chacra.ceph.com")) | select(.status == "ready")] | length > 0'
+    """,
+    returnStatus: true,
+  )
 }
 
 // Stage 5.2 (check for pulp packages): check pulp for an existing build (and skip compilation if found, unless FORCE).

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -587,10 +587,17 @@ def doContainerStage() {
   env.CONTAINER_REPO_PASSWORD = env.CONTAINER_REPO_CREDS_PSW
   def os = get_os_info(env.DIST)
   def cephver = env.VERSION.trim()
+  // Whether this cell pushed packages this run. If not (existence check
+  // skipped compilation, or THROWAWAY), build_container accepts any ready
+  // shaman repo for this sha1 instead of waiting for one with our BUILD_URL.
+  def uploaded = build_matrix["${DIST}_${ARCH}_${FLAVOR}"] == true &&
+      params.THROWAWAY == false &&
+      (params.CHACRA_UPLOAD || params.PULP_UPLOAD)
   sh """#!/bin/bash
     export DISTRO=${os.name}
     export RELEASE=${os.version}
     export cephver=${cephver}
+    export UPLOADED=${uploaded}
     if [ "\$PULP_REGISTRY_UPLOAD" == "true" ]; then
       export REMOVE_LOCAL_IMAGES=false
     fi

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -274,15 +274,13 @@ def doCheckForPulpPackagesStage() {
   def os = get_os_info(env.DIST)
 
   // pulp_upload.sh reuses branch-scoped repositories; only its per-sha1
-  // distribution (dist-ceph-<branch>-<os>-<version>-<arch>-<short_sha1>)
+  // distribution (dist-ceph-<branch>-<os>-<version>-<flavor>-<arch>-<short_sha1>)
   // proves this sha1 was uploaded. The name must mirror pulp_upload.sh:
   // ubuntu uses the codename, rpm arches use aarch64 (not arm64), and rpm
-  // lookups use --distribution while deb uses --name. Distribution names
-  // don't include the flavor (a pulp_upload.sh limitation), so this check
-  // can't tell default and debug builds of the same sha1 apart.
+  // lookups use --distribution while deb uses --name.
   def os_version = (os.name == "ubuntu") ? os.version_name : os.version
   def dist_arch = (os.pkg_type == "rpm" && env.ARCH == "arm64") ? "aarch64" : env.ARCH
-  def dist_name = "dist-ceph-${env.BRANCH}-${os.name}-${os_version}-${dist_arch}-${env.SHA1[-8..-1]}"
+  def dist_name = "dist-ceph-${env.BRANCH}-${os.name}-${os_version}-${env.FLAVOR}-${dist_arch}-${env.SHA1[-8..-1]}"
   def lookup_flag = (os.pkg_type == "rpm") ? "--distribution" : "--name"
   def pulp_dist_rc = sh(
     script: """#!/bin/bash -ex

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -534,23 +534,16 @@ def doUploadChacraStage() {
   def chacra_url = sh(
     script: "grep '^url' ~/.chacractl", returnStdout: true,
   ).trim().split('"')[1].trim().replaceAll(/\/+$/, '')
-  // Push packages to chacra.ceph.com under the 'test' ref if
-  // ceph-release-pipeline's TEST=true. Scoped with withEnv below instead of
-  // mutating env.SHA1, which is shared with the Pulp stage and with every
-  // other matrix cell.
-  def target_sha1 = env.TEST?.toBoolean() ? "test" : env.SHA1
   withUploadEnv {
     if (os.pkg_type == "rpm") {
-      def repo_url = "${chacra_url}/r/ceph/${env.BRANCH}/${target_sha1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}"
+      def repo_url = "${chacra_url}/r/ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}"
       buildCephReleaseRpm(repo_url)
     }
     // CHACRACTL_KEY/SHAMAN_API_KEY come from the "upload packages" stage
     // environment{} block, which also covers its post{} shaman updates.
-    withEnv(["SHA1=${target_sha1}"]) {
-      sh """#!/bin/bash -ex
-        export CHACRA_URL="${chacra_url}/" && ./scripts/chacra_upload.sh
-      """
-    }
+    sh """#!/bin/bash -ex
+      export CHACRA_URL="${chacra_url}/" && ./scripts/chacra_upload.sh
+    """
   }
 }
 

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -253,8 +253,11 @@ def doCheckForChacraPackagesStage() {
       "&flavor=${env.FLAVOR}&ref=${env.BRANCH}&sha1=${env.SHA1}"
   chacra_exists_rc["${DIST}_${ARCH}_${FLAVOR}"] = sh(
     script: """#!/bin/bash -ex
-      curl -fs --max-time 30 "${search_url}" | \\
-        jq -e '[.[] | select((.chacra_url // "") | contains("chacra.ceph.com")) | select(.status == "ready")] | length > 0'
+      chacra_url=\$(curl -fs --max-time 30 "${search_url}" | \\
+        jq -er '[.[] | select((.chacra_url // "") | contains("chacra.ceph.com")) | select(.status == "ready")][0].chacra_url')
+      # A shaman record can outlive the repo it points at (chacra nodes get
+      # rotated/rebuilt), so only trust it if the repo URL actually answers.
+      curl -fs -o /dev/null --max-time 30 "\$chacra_url"
     """,
     returnStatus: true,
   )

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -1,5 +1,6 @@
 import groovy.transform.Field
 
+@Field String pulp_server_url = "https://pulp.front.sepia.ceph.com"
 @Field String ceph_build_repo = "https://github.com/ceph/ceph-build"
 @Field String ceph_build_branch = "main"
 @Field String base_node_label = "gigantic"
@@ -14,6 +15,11 @@ import groovy.transform.Field
   "bullseye": "11",
 ]
 @Field Map build_matrix = [:]
+// Per-cell results of the artifact-existence checks. `env.` assignments are
+// global to the whole build and shared by every parallel matrix branch (last
+// write wins), so per-cell state must be keyed by cell, like build_matrix.
+@Field Map chacra_exists_rc = [:]
+@Field Map pulp_dist_exists = [:]
 @Field List container_distros = [
   'centos9',
   'rocky10',
@@ -233,32 +239,109 @@ def doCopyArtifactsStage() {
   '''
 }
 
-// Stage 5 (check for built packages): check chacra for an existing build (and skip compilation if found, unless FORCE) and set up the Pulp client if needed.
-def doCheckForBuiltPackagesStage() {
-  sh './scripts/setup_chacractl.sh'
-  def chacra_url = sh(
-    script: '''grep url ~/.chacractl | cut -d'"' -f2''',
-    returnStdout: true,
-  ).trim()
-  def os = get_os_info(env.DIST)
-  def chacra_endpoint = "ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/${env.ARCH}/flavors/${env.FLAVOR}/"
-  def chacractl_rc = sh(
-    script: "${env.HOME}/.local/bin/chacractl exists binaries/${chacra_endpoint}",
-    returnStatus: true,
-  )
-  if ( chacractl_rc == 0 && env.FORCE != "true" ) {
-    println("Skipping compilation since chacra already has artifacts. To override, use THROWAWAY=true (to skip this check) or FORCE=true (to re-upload artifacts).")
-    build_matrix["${env.DIST}_${env.ARCH}"] = false
+// Stage 5.1 (check for chacra packages): check chacra for an existing build (and skip compilation if found, unless FORCE).
+def doCheckForChacraPackagesStage() {
+  withCredentials([
+    string(credentialsId: "chacractl-key", variable: "CHACRACTL_KEY"),
+    string(credentialsId: "shaman-api-key", variable: "SHAMAN_API_KEY")
+  ]) {
+    sh """#!/bin/bash -ex
+      ./scripts/setup_chacractl.sh
+    """
+    def os = get_os_info(env.DIST)
+    def chacra_endpoint = "ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/${env.ARCH}/flavors/${env.FLAVOR}/"
+    chacra_exists_rc["${DIST}_${ARCH}_${FLAVOR}"] = sh(
+      script: """#!/bin/bash -ex
+        \$HOME/.local/bin/chacractl exists binaries/${chacra_endpoint}
+      """,
+      returnStatus: true,
+    )
+  }
+}
+
+// Stage 5.2 (check for pulp packages): check pulp for an existing build (and skip compilation if found, unless FORCE).
+def doCheckForPulpPackagesStage() {
+  withCredentials([
+    usernamePassword(
+      credentialsId: "pulp-auth", usernameVariable: "PULP_USERNAME", passwordVariable: "PULP_PASSWORD"
+    )
+  ]) {
+    sh """#!/bin/bash -ex
+      export PULP_SERVER_URL="${pulp_server_url}" && ./scripts/setup_pulp.sh
+    """
   }
 
-  // Set up Pulp client
-  if ( env.PULP_UPLOAD == "true" ) {
-    withCredentials([
-      usernamePassword(credentialsId: 'pulp-auth', usernameVariable: 'PULP_USERNAME', passwordVariable: 'PULP_PASSWORD')
-    ]) {
-        sh './scripts/setup_pulp.sh'
-    }
+  def os = get_os_info(env.DIST)
+
+  // pulp_upload.sh reuses branch-scoped repositories; only its per-sha1
+  // distribution (dist-ceph-<branch>-<os>-<version>-<arch>-<short_sha1>)
+  // proves this sha1 was uploaded. The name must mirror pulp_upload.sh:
+  // ubuntu uses the codename, rpm arches use aarch64 (not arm64), and rpm
+  // lookups use --distribution while deb uses --name. Distribution names
+  // don't include the flavor (a pulp_upload.sh limitation), so this check
+  // can't tell default and debug builds of the same sha1 apart.
+  def os_version = (os.name == "ubuntu") ? os.version_name : os.version
+  def dist_arch = (os.pkg_type == "rpm" && env.ARCH == "arm64") ? "aarch64" : env.ARCH
+  def dist_name = "dist-ceph-${env.BRANCH}-${os.name}-${os_version}-${dist_arch}-${env.SHA1[-8..-1]}"
+  def lookup_flag = (os.pkg_type == "rpm") ? "--distribution" : "--name"
+  def pulp_dist_rc = sh(
+    script: """#!/bin/bash -ex
+      export PATH="\$HOME/.local/bin:\$PATH"
+      pulp ${os.pkg_type} distribution show ${lookup_flag} "${dist_name}"
+    """,
+    returnStatus: true,
+  )
+  pulp_dist_exists["${DIST}_${ARCH}_${FLAVOR}"] = (pulp_dist_rc == 0)
+}
+
+// Stage 5.3 (validate artifact checks): decide whether to skip compilation based on Chacra/Pulp checks.
+def doArtifactsChecksStage() {
+  def force = env.FORCE == "true"
+  if (force) {
+    println("FORCE=true: compiling and re-uploading even if artifacts exist.")
+    return
   }
+
+  if (!params.CHACRA_UPLOAD && !params.PULP_UPLOAD) {
+    println("Neither CHACRA_UPLOAD nor PULP_UPLOAD enabled; skipping artifact existence checks.")
+    return
+  }
+
+  def cell = "${DIST}_${ARCH}_${FLAVOR}"
+  // -1 means "not checked" when that backend's upload is disabled.
+  def chacractl_rc = params.CHACRA_UPLOAD ? chacra_exists_rc[cell] : -1
+  def pulp_repo_exists = params.PULP_UPLOAD && pulp_dist_exists[cell] == true
+  def skip_reasons = []
+
+  if (params.CHACRA_UPLOAD && chacractl_rc == 0) {
+    skip_reasons << "Chacra already has artifacts (chacractl_rc=${chacractl_rc})"
+  }
+  if (pulp_repo_exists) {
+    skip_reasons << "Pulp already has this build (distribution exists)"
+  }
+
+  if (shouldSkipCompilation(chacractl_rc, pulp_repo_exists, params.CHACRA_UPLOAD, params.PULP_UPLOAD, force)) {
+    println("Skipping compilation:\n- " + skip_reasons.join("\n- "))
+    println(
+      "To override, use THROWAWAY=true (to skip this check) " +
+      "or FORCE=true (to re-upload artifacts)."
+    )
+    build_matrix["${DIST}_${ARCH}"] = false
+  }
+}
+
+// Helper function to determine if compilation should be skipped.
+def shouldSkipCompilation(chacractl_rc, pulp_repo_exists, chacra_upload_enabled, pulp_upload_enabled, force) {
+  if (force) {
+    return false
+  }
+  if (chacra_upload_enabled && chacractl_rc == 0) {
+    return true
+  }
+  if (pulp_upload_enabled && pulp_repo_exists) {
+    return true
+  }
+  return false
 }
 
 // Stage 6 (builder container): log into container registries and pull/build/push the ceph-build container image for this matrix cell.
@@ -419,80 +502,81 @@ def doBuildPostAlways() {
   }
 }
 
-// Stage 8 (upload packages): build the ceph-release rpm (for rpm distros) and upload the packages to chacra and optionally Pulp.
-def doUploadPackagesStage() {
-  def chacra_url = sh(
-    script: '''grep url ~/.chacractl | cut -d'"' -f2''',
-    returnStdout: true,
-  ).trim()
+// Stage 8.0 (prepare upload): link SRPMS for RPM uploads.
+def doPrepareUploadStage() {
   def os = get_os_info(env.DIST)
-  // Push packages to chacra.ceph.com under the 'test' ref if ceph-release-pipeline's TEST=true
-  if ( os.pkg_type == "rpm" ) {
-    env.SHA1 = env.TEST?.toBoolean() ? 'test' : env.SHA1
-  }
-  // The ceph-release RPM's /etc/yum.repos.d/ceph.repo baseurls and the repo
-  // URL reported to shaman must match where packages were actually
-  // published: pulp when PULP_UPLOAD=true, otherwise chacra.
-  // chacra_url already ends with a trailing slash.
-  def repo_base_url
-  if ( env.PULP_UPLOAD == "true" ) {
-    repo_base_url = "https://pulp.front.sepia.ceph.com/pulp/content/repos/ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}"
-  } else {
-    repo_base_url = "${chacra_url}r/ceph/${env.BRANCH}/${env.SHA1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}"
-  }
-  def spec_project_url = "${repo_base_url}/"
-  if ( os.pkg_type == "rpm" ) {
-    sh """#!/bin/bash
-        set -ex
-        cd ./dist/ceph
-        mkdir -p ./rpmbuild/SRPMS/
-        ln ceph-*.src.rpm ./rpmbuild/SRPMS/
-    """
-    def spec_text = get_ceph_release_spec_text(spec_project_url)
-    writeFile(
-      file: "dist/ceph/rpmbuild/SPECS/ceph-release.spec",
-      text: spec_text,
-    )
-    def repo_text = get_ceph_release_repo_text(repo_base_url)
-    writeFile(
-      file: "dist/ceph/rpmbuild/SOURCES/ceph.repo",
-      text: repo_text,
-    )
-    def ceph_builder_tag = "${env.SHA1[0..6]}.${env.BRANCH}.${env.DIST}.${env.ARCH}.${env.FLAVOR}"
-    def bwc_command_base = "python3 src/script/build-with-container.py --image-repo=${env.CEPH_BUILDER_IMAGE} --tag=${ceph_builder_tag} -d ${env.DIST} --image-variant=packages --ceph-version ${env.VERSION}"
-    def bwc_command = "${bwc_command_base} -e custom -- rpmbuild -bb --define \\'_topdir /ceph/rpmbuild\\' /ceph/rpmbuild/SPECS/ceph-release.spec"
-    sh """#!/bin/bash
-      set -ex
-      cd ${env.WORKSPACE}/dist/ceph
-      ${bwc_command}
+  if (os.pkg_type == "rpm") {
+    sh """#!/bin/bash -ex
+      cd "${env.WORKSPACE}/dist/ceph"
+      mkdir -p ./rpmbuild/SRPMS/
+      ln -f ceph-*.src.rpm ./rpmbuild/SRPMS/
     """
   }
-  sh """#!/bin/bash
-    export CHACRA_URL="${chacra_url}"
-    export OS_NAME="${os.name}"
-    export OS_VERSION="${os.version}"
-    export OS_VERSION_NAME="${os.version_name}"
-    export OS_PKG_TYPE="${os.pkg_type}"
-    if [ "${env.THROWAWAY}" != "true" ] && [ "${env.CHACRA_UPLOAD}" == "true" ]; then ./scripts/chacra_upload.sh; fi
-  """
+}
 
-  sh """#!/bin/bash
-    if [ "${env.THROWAWAY}" != "true" ] && [ "${env.PULP_UPLOAD}" == "true" ]; then
-      export CEPH_REPO="${env.CEPH_REPO}"
-      export CEPH_VERSION="${env.VERSION}"
-      export OS_NAME="${os.name}"
-      export OS_VERSION="${os.version}"
-      export OS_VERSION_NAME="${os.version_name}"
-      export OS_PKG_TYPE="${os.pkg_type}"
-      export SHA1="${env.SHA1}"
-      export FLAVOR="${env.FLAVOR}"
+// OS_*/CEPH_VERSION are consumed by chacra_upload.sh, pulp_upload.sh and
+// notify_shaman_pulp_repo.sh. withEnv is scoped to the current matrix cell,
+// unlike `env.FOO =` assignments, which leak across parallel cells.
+def withUploadEnv(Closure body) {
+  def os = get_os_info(env.DIST)
+  withEnv([
+    "OS_NAME=${os.name}",
+    "OS_VERSION=${os.version}",
+    "OS_VERSION_NAME=${os.version_name}",
+    "OS_PKG_TYPE=${os.pkg_type}",
+    "CEPH_VERSION=${env.VERSION}",
+  ]) {
+    body()
+  }
+}
 
+// Stage 8.1 (upload packages to Chacra): build ceph-release RPM (rpm distros) and upload packages to Chacra.
+def doUploadChacraStage() {
+  def os = get_os_info(env.DIST)
+  def chacra_url = sh(
+    script: "grep '^url' ~/.chacractl", returnStdout: true,
+  ).trim().split('"')[1].trim().replaceAll(/\/+$/, '')
+  // Push packages to chacra.ceph.com under the 'test' ref if
+  // ceph-release-pipeline's TEST=true. Scoped with withEnv below instead of
+  // mutating env.SHA1, which is shared with the Pulp stage and with every
+  // other matrix cell.
+  def target_sha1 = env.TEST?.toBoolean() ? "test" : env.SHA1
+  withUploadEnv {
+    if (os.pkg_type == "rpm") {
+      def repo_url = "${chacra_url}/r/ceph/${env.BRANCH}/${target_sha1}/${os.name}/${os.version_name}/flavors/${env.FLAVOR}"
+      buildCephReleaseRpm(repo_url)
+    }
+    // CHACRACTL_KEY/SHAMAN_API_KEY come from the "upload packages" stage
+    // environment{} block, which also covers its post{} shaman updates.
+    withEnv(["SHA1=${target_sha1}"]) {
+      sh """#!/bin/bash -ex
+        export CHACRA_URL="${chacra_url}/" && ./scripts/chacra_upload.sh
+      """
+    }
+  }
+}
+
+// Stage 8.2 (upload packages to Pulp): build ceph-release RPM (rpm distros) and upload packages to Pulp.
+def doUploadPulpStage() {
+  def os = get_os_info(env.DIST)
+  // pulp_upload.sh publishes under the codename for ubuntu and the numeric
+  // version otherwise (resolve_os_version_for_repo), so the URL reported to
+  // shaman must do the same: os.version_name would yield debian/bookworm
+  // while the content actually lives under debian/12.
+  def os_version = (os.name == "ubuntu") ? os.version_name : os.version
+  def repo_url = "${pulp_server_url}/pulp/content/repos/ceph/"
+  repo_url += "${env.BRANCH}/${env.SHA1}/${os.name}/${os_version}"
+  repo_url += "/flavors/${env.FLAVOR}"
+
+  withUploadEnv {
+    if (os.pkg_type == "rpm") {
+      buildCephReleaseRpm(repo_url)
+    }
+    sh """#!/bin/bash -ex
       ./scripts/pulp_upload.sh
-      ./scripts/notify_shaman_pulp_repo.sh ready ceph ${os.name} ${os.version_name} ${env.ARCH} ${spec_project_url}${env.ARCH}/
-    else
-      echo "Skipping pulp upload because PULP_UPLOAD=${env.PULP_UPLOAD}"
-    fi
-  """
+      ./scripts/notify_shaman_pulp_repo.sh ready ceph ${os.name} ${os.version_name} ${env.ARCH} ${repo_url}/${env.ARCH}/
+    """
+  }
 }
 
 // Stage 9 (container): build the Ceph container image via scripts/build_container.
@@ -526,6 +610,62 @@ def doRegistryUploadStage() {
       ./scripts/pulp_container_push.sh
     """
   }
+}
+
+def buildCephReleaseRpm(repo_url) {
+  def ceph_release_spec_file = "ceph-release.spec"
+  def ceph_repo_file = "ceph.repo"
+  def ceph_release_spec = "dist/ceph/rpmbuild/SPECS/${ceph_release_spec_file}"
+  def ceph_repo = "dist/ceph/rpmbuild/SOURCES/${ceph_repo_file}"
+  def ceph_release_rpm = "dist/ceph/rpmbuild/RPMS/noarch/ceph-release-1-0.el*.noarch.rpm"
+
+  sh """#!/bin/bash -ex
+    shopt -s nullglob
+    for rpm in ${ceph_release_rpm}; do
+      if [ -f "\$rpm" ]; then
+        echo "Removing existing ceph-release RPM: \$rpm"
+        rm -f "\$rpm"
+      fi
+    done
+    if [ -f "${ceph_release_spec}" ]; then
+      echo "Removing existing ceph-release spec: ${ceph_release_spec}"
+      rm -f "${ceph_release_spec}"
+    fi
+    if [ -f "${ceph_repo}" ]; then
+      echo "Removing existing ceph.repo: ${ceph_repo}"
+      rm -f "${ceph_repo}"
+    fi
+  """
+
+  def spec_text = get_ceph_release_spec_text("${repo_url}")
+  writeFile(file: ceph_release_spec, text: spec_text)
+
+  def repo_text = get_ceph_release_repo_text("${repo_url}")
+  writeFile(file: ceph_repo, text: repo_text)
+
+  echo "ceph_release_spec: ${ceph_release_spec}"
+  sh "cat ${ceph_release_spec}"
+
+  echo "ceph_repo: ${ceph_repo}"
+  sh "cat ${ceph_repo}"
+
+  def ceph_builder_tag = (
+    "${env.SHA1[0..6]}.${env.BRANCH}.${env.DIST}.${env.ARCH}.${env.FLAVOR}"
+  )
+  def bwc_command_base = (
+    "python3 src/script/build-with-container.py " +
+    "--image-repo=${env.CEPH_BUILDER_IMAGE} " +
+    "--tag=${ceph_builder_tag} -d ${DIST} " +
+    "--image-variant=packages --ceph-version ${env.VERSION}"
+  )
+  def bwc_command = (
+    "${bwc_command_base} -e custom -- rpmbuild -bb " +
+    "--define \\'_topdir /ceph/rpmbuild\\' " +
+    "/ceph/rpmbuild/SPECS/${ceph_release_spec_file}"
+  )
+  sh """#!/bin/bash -ex
+    cd $WORKSPACE/dist/ceph && ${bwc_command}
+  """
 }
 
 pipeline {
@@ -625,15 +765,39 @@ pipeline {
           }
           stage("check for built packages") {
             when {
-              environment name: 'THROWAWAY', value: 'false'
-              expression { return build_matrix["${DIST}_${ARCH}"] == true }
+              expression {
+                return build_matrix["${DIST}_${ARCH}"] == true && params.THROWAWAY == false
+              }
             }
-            environment {
-              CHACRACTL_KEY = credentials('chacractl-key')
-              SHAMAN_API_KEY = credentials('shaman-api-key')
-            }
-            steps {
-              script { doCheckForBuiltPackagesStage() }
+            stages {
+              stage("configure Chacra") {
+                when {
+                  expression {
+                    return params.CHACRA_UPLOAD
+                  }
+                }
+                steps {
+                  script { doCheckForChacraPackagesStage() }
+                }
+              }
+              stage("configure Pulp") {
+                when {
+                  expression {
+                    return params.PULP_UPLOAD
+                  }
+                }
+                steps {
+                  script { doCheckForPulpPackagesStage() }
+                }
+              }
+              stage("validate artifact checks") {
+                when {
+                  expression { params.CHACRA_UPLOAD || params.PULP_UPLOAD }
+                }
+                steps {
+                  script { doArtifactsChecksStage() }
+                }
+              }
             }
           }
           stage("builder container") {
@@ -673,16 +837,48 @@ pipeline {
             }
           }
           stage("upload packages") {
+            // Covers the steps of both upload stages and the post{} shaman
+            // status updates below; notify_shaman_pulp_repo.sh and
+            // update_shaman.sh both need SHAMAN_API_KEY.
             environment {
               CHACRACTL_KEY = credentials('chacractl-key')
               SHAMAN_API_KEY = credentials('shaman-api-key')
             }
             when {
-              expression { return build_matrix["${DIST}_${ARCH}"] == true }
+              expression {
+                return build_matrix["${DIST}_${ARCH}"] == true && params.THROWAWAY == false && (params.CHACRA_UPLOAD || params.PULP_UPLOAD)
+              }
             }
-            steps {
-              script { doUploadPackagesStage() }
+            stages {
+              stage("prepare upload") {
+                steps {
+                  script { doPrepareUploadStage() }
+                }
+              }
+              stage("upload packages to Chacra") {
+                when {
+                  expression {
+                    return params.CHACRA_UPLOAD
+                  }
+                }
+                steps {
+                  script { doUploadChacraStage() }
+                }
+              }
+              stage("upload packages to Pulp") {
+                when {
+                  expression {
+                    return params.PULP_UPLOAD
+                  }
+                }
+                steps {
+                  script { doUploadPulpStage() }
+                }
+              }
             }
+            // The shaman build status must be updated regardless of which
+            // upload backend is enabled (cve-pipeline runs with
+            // CHACRA_UPLOAD=false), so this lives on the parent stage.
             post {
               success {
                 script {

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -326,7 +326,7 @@ def doArtifactsChecksStage() {
       "To override, use THROWAWAY=true (to skip this check) " +
       "or FORCE=true (to re-upload artifacts)."
     )
-    build_matrix["${DIST}_${ARCH}"] = false
+    build_matrix[cell] = false
   }
 }
 
@@ -702,7 +702,7 @@ pipeline {
             name 'ARCH'
             values 'x86_64', 'arm64'
           }
-          axes {
+          axis {
             name 'FLAVOR'
             values 'default', 'debug'
           }
@@ -735,7 +735,7 @@ pipeline {
           stage("node") {
             steps {
               script {
-                build_matrix["${DIST}_${ARCH}"] = env.CI_COMPILE.toBoolean()
+                build_matrix["${DIST}_${ARCH}_${FLAVOR}"] = env.CI_COMPILE.toBoolean()
                 println("Building: DIST=${env.DIST} ARCH=${env.ARCH} FLAVOR=${env.FLAVOR}")
                 def node_shortname = env.NODE_NAME.split('\\+')[-1]
                 def node_url = new URI([env.JENKINS_URL, "computer", env.NODE_NAME].join("/")).normalize()
@@ -766,7 +766,7 @@ pipeline {
           stage("check for built packages") {
             when {
               expression {
-                return build_matrix["${DIST}_${ARCH}"] == true && params.THROWAWAY == false
+                return build_matrix["${DIST}_${ARCH}_${FLAVOR}"] == true && params.THROWAWAY == false
               }
             }
             stages {
@@ -807,7 +807,7 @@ pipeline {
               DOCKER_HUB_CREDS = credentials('dgalloway-docker-hub')
             }
             when {
-              expression { return build_matrix["${DIST}_${ARCH}"] == true }
+              expression { return build_matrix["${DIST}_${ARCH}_${FLAVOR}"] == true }
             }
             steps {
               script { doBuilderContainerStage() }
@@ -819,7 +819,7 @@ pipeline {
               SCCACHE_BUCKET_CREDS = credentials('ibm-cloud-sccache-bucket')
             }
             when {
-              expression { return build_matrix["${DIST}_${ARCH}"] == true }
+              expression { return build_matrix["${DIST}_${ARCH}_${FLAVOR}"] == true }
             }
             steps {
               script { doBuildStage() }
@@ -846,7 +846,7 @@ pipeline {
             }
             when {
               expression {
-                return build_matrix["${DIST}_${ARCH}"] == true && params.THROWAWAY == false && (params.CHACRA_UPLOAD || params.PULP_UPLOAD)
+                return build_matrix["${DIST}_${ARCH}_${FLAVOR}"] == true && params.THROWAWAY == false && (params.CHACRA_UPLOAD || params.PULP_UPLOAD)
               }
             }
             stages {

--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -56,12 +56,12 @@
 
       - bool:
           name: THROWAWAY
-          description: "Whether to push any binaries to Chacra or Pulp.  Overrides CHACRA_UPLOAD and PULP_UPLOAD if either are true."
+          description: "Whether to push any binaries to Chacra or Pulp. Overrides CHACRA_UPLOAD and PULP_UPLOAD if either are true."
           default: false
 
       - bool:
           name: FORCE
-          description: "Whether to push new binaries to Chacra if some are already present"
+          description: "Whether to push new binaries even if some are already present"
           default: false
 
       - bool:

--- a/ceph-release-pipeline/build/Jenkinsfile
+++ b/ceph-release-pipeline/build/Jenkinsfile
@@ -59,8 +59,8 @@ pipeline {
               string(name: "ARCHS",               value: env.ARCHS),
               string(name: "FLAVORS",             value: 'default'),
               booleanParam(name: "CI_COMPILE",    value: true),
-              booleanParam(name: "THROWAWAY",     value: env.THROWAWAY),
-              booleanParam(name: "FORCE",         value: env.FORCE),
+              booleanParam(name: "THROWAWAY",     value: env.THROWAWAY?.toBoolean()),
+              booleanParam(name: "FORCE",         value: env.FORCE?.toBoolean()),
               string(name: 'FLAVOR',              value: 'default'),
               // Release containers are built manually from signed packages so we don't need to build them here
               booleanParam(name: 'CI_CONTAINER',  value: false),
@@ -85,10 +85,10 @@ pipeline {
             parameters: [
               string(name: 'VERSION',             value: env.VERSION ?: ''),
               string(name: 'BRANCH',              value: env.BRANCH ?: ''),
-              booleanParam(name: 'FORCE_VERSION', value: env.FORCE_VERSION),
+              booleanParam(name: 'FORCE_VERSION', value: env.FORCE_VERSION?.toBoolean()),
               string(name: 'RELEASE_TYPE',        value: env.RELEASE_TYPE ?: ''),
               booleanParam(name: 'RELEASE_BUILD', value: true),
-              booleanParam(name: 'TAG',           value: env.TAG),
+              booleanParam(name: 'TAG',           value: env.TAG?.toBoolean()),
               string(name: 'TAG_PHASE',           value: 'push')
             ],
           )

--- a/ceph-release-pipeline/config/definitions/ceph-release-pipeline.yml
+++ b/ceph-release-pipeline/config/definitions/ceph-release-pipeline.yml
@@ -29,13 +29,6 @@
           description: "The version for release, e.g. 0.94.4"
 
       - bool:
-          name: TEST
-          description: |
-            If this is unchecked, then the builds will be pushed to chacra with the correct ref. This is the default.
-
-            If this is checked, then the builds will be pushed to chacra under the 'test' ref.
-
-      - bool:
           name: TAG
           description: |
             When this is checked, Jenkins will remove the previous private tag and recreate it again, changing the control files and committing again. When this is unchecked, Jenkins will not do any commit or tag operations. If you've already created the private tag separately or are re-running a build, leave this unchecked.

--- a/cve-pipeline/config/definitions/cve-pipeline.yml
+++ b/cve-pipeline/config/definitions/cve-pipeline.yml
@@ -69,7 +69,12 @@
 
       - bool:
           name: THROWAWAY
-          description: "Whether to push any binaries to Chacra or Pulp.  Overrides CHACRA_UPLOAD and PULP_UPLOAD if either are true."
+          description: "Whether to push any binaries to Chacra or Pulp. Overrides CHACRA_UPLOAD and PULP_UPLOAD if either are true."
+          default: false
+
+      - bool:
+          name: FORCE
+          description: "Whether to push new binaries even if some are already present"
           default: false
 
       - bool:

--- a/scripts/build_container
+++ b/scripts/build_container
@@ -12,27 +12,31 @@ if [[ $CI_CONTAINER == "true" && $DISTRO =~ centos|rocky|alma && "$RELEASE" =~ 8
     ready=false
     while ((loop < 15)); do
       curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=${DISTRO}/${RELEASE}/${ARCH}&sha1=${SHA1}&ref=${BRANCH}&flavor=${FLAVOR}" > shaman.status
-      if [[ ($(jq -r '.[0].status' < shaman.status) == 'ready') ]]; then
-        # If we skipped compilation, we will not have generated a shaman build,
-        # so skip validating against extra.build_url
-        if [[ ${CI_COMPILE:-true} == "false" ]]; then
-          ready=true
-          break
-        elif [[ ($(jq -r '.[0].extra.build_url' < shaman.status) == ${BUILD_URL}) ]]; then
-          ready=true
-          break
-        fi
+      # Shaman holds several repo records for the same sha1 (one per backend
+      # and per uploading job), so scan all of them instead of .[0].
+      # If this build didn't upload packages (UPLOADED=false: the artifact
+      # check found existing repos, or THROWAWAY; CI_COMPILE=false:
+      # compilation disabled), any ready record for this sha1 will do.
+      # Otherwise wait for a ready record posted by this very build.
+      if [[ ${UPLOADED:-true} == "false" || ${CI_COMPILE:-true} == "false" ]]; then
+        ready=$(jq -r '[.[] | select(.status == "ready")] | length > 0' < shaman.status)
+      else
+        ready=$(jq -r --arg build_url "${BUILD_URL}" \
+          '[.[] | select(.status == "ready" and (.extra.build_url? // "") == $build_url)] | length > 0' < shaman.status)
+      fi
+      if [[ "$ready" == "true" ]]; then
+        break
       fi
       ((loop = loop + 1))
       sleep 60
     done
 
-    if [[ "$ready" == "false" ]] ; then
+    if [[ "$ready" != "true" ]] ; then
       chacra_endpoint="ceph/${BRANCH}/${SHA1}/${DISTRO}/${RELEASE}"
       echo "FAIL: timed out waiting for shaman repo to be built:  https://shaman.ceph.com/api/repos/${chacra_endpoint}/flavors/${FLAVOR}/"
-      # don't fail the build here on purpose
-      # update_build_status "failed" "ceph" $NORMAL_DISTRO $NORMAL_DISTRO_VERSION $NORMAL_ARCH
-      # exit 1
+      # Without a ready repo the container build would install stale or
+      # missing packages, so fail instead of building a wrong image.
+      exit 1
     fi
     cd ${WORKSPACE}
     # older jobs used a versioned directory; ceph-dev-pipeline uses an unversioned dir.

--- a/scripts/pulp_upload.sh
+++ b/scripts/pulp_upload.sh
@@ -539,8 +539,14 @@ fi
 # separate process. PACKAGE_MANAGER_VERSION is included in the repo
 # record's extra metadata; the repository's API URL becomes the record's
 # chacra_url. See notify_shaman_pulp_repo.sh.
+# rpm repositories are named after the rpm arch (aarch64), not the Jenkins
+# matrix arch (arm64); see the SRPMS/noarch/aarch64/x86_64 loop above.
+_repo_arch="${ARCH}"
+if [ "$OS_PKG_TYPE" = "rpm" ] && [ "$ARCH" = "arm64" ]; then
+    _repo_arch="aarch64"
+fi
 _repo_href=$(pulp "${OS_PKG_TYPE}" repository show \
-    --name "${REPO_NAME}-${ARCH}" | jq -r '.pulp_href')
+    --name "${REPO_NAME}-${_repo_arch}" | jq -r '.pulp_href')
 {
     printf 'PACKAGE_MANAGER_VERSION=%q\n' "${PACKAGE_MANAGER_VERSION}"
     printf 'PULP_REPO_API_URL=%q\n' "${PULP_SERVER_URL}${_repo_href}"

--- a/scripts/pulp_upload.sh
+++ b/scripts/pulp_upload.sh
@@ -319,7 +319,7 @@ publish_pulp_distribution() {
     local repo_endpoint="$2"
     local repo_arch="$3"
     local package_version="$4"
-    local final_version pub_href dist_name lookup_flag
+    local final_version pub_href dist_name lookup_flag stale_dist
 
     if [ "$OS_PKG_TYPE" == "rpm" ]; then
         pub_href=$(
@@ -357,6 +357,21 @@ publish_pulp_distribution() {
         fi
     fi
 
+    # A distribution created before FLAVOR was part of the naming scheme may
+    # still own this base_path under a different name; base_paths are unique
+    # in pulp, so it has to be removed before the new distribution is created.
+    stale_dist=$(pulp "${OS_PKG_TYPE}" distribution list \
+        --base-path "${repo_endpoint}" 2> /dev/null \
+        | jq -r '.[0].name // empty' || true)
+    if [ -n "$stale_dist" ] && [ "$stale_dist" != "$dist_name" ]; then
+        log "Distribution ${stale_dist} owns base_path ${repo_endpoint}; deleting"
+        if ! pulp "${OS_PKG_TYPE}" distribution destroy \
+                "${lookup_flag}" "${stale_dist}"; then
+            log "ERROR: Failed to delete ${OS_PKG_TYPE} distribution ${stale_dist}"
+            return
+        fi
+    fi
+
     log "Creating distribution ${dist_name} " \
         "with base_path=${repo_endpoint}"
     if ! pulp "${OS_PKG_TYPE}" distribution create \
@@ -387,7 +402,10 @@ log "Uploading artifacts to Pulp repository ..."
 _OS_VERSION=$(resolve_os_version_for_repo)
 REPO_VERSIONS_TO_RETAIN=$(get_repo_versions_to_retain)
 
-REPO_NAME="${PULP_PROJECT}-${BRANCH}-${OS_NAME}-${_OS_VERSION}"
+# FLAVOR is part of the repository (and therefore distribution) name so that
+# default and debug builds of the same branch/sha1 don't share repositories
+# or clobber each other's distributions.
+REPO_NAME="${PULP_PROJECT}-${BRANCH}-${OS_NAME}-${_OS_VERSION}-${FLAVOR}"
 REPO_ENDPOINT="repos/${PULP_PROJECT}/${BRANCH}/${SHA1}/${OS_NAME}"
 REPO_ENDPOINT="${REPO_ENDPOINT}/${_OS_VERSION}/flavors/${FLAVOR}"
 

--- a/scripts/pulp_upload.sh
+++ b/scripts/pulp_upload.sh
@@ -72,9 +72,9 @@ create_pulp_repository() {
     local labels_json key value
 
     log "Checking if Pulp repository ${repo_name} already exists"
-    if pulp "${os_pkg_type}" repository show "${repo_name}" \
+    if pulp "${os_pkg_type}" repository show --name "${repo_name}" \
             > /dev/null 2>&1; then
-        log "Pulp repository ${repo_name} already exists"
+        log "WARNING: Pulp repository ${repo_name} already exists"
         return 0
     fi
 
@@ -345,6 +345,18 @@ publish_pulp_distribution() {
     log "Created ${OS_PKG_TYPE} publication: ${pub_href}"
 
     dist_name="dist-${repo_name}-${SHORT_SHA1}"
+
+    log "Checking if Pulp distribution ${dist_name} already exists"
+    if pulp "${OS_PKG_TYPE}" distribution show \
+            "${lookup_flag}" "${dist_name}" > /dev/null 2>&1; then
+        log "Pulp distribution ${dist_name} already exists; deleting"
+        if ! pulp "${OS_PKG_TYPE}" distribution destroy \
+                "${lookup_flag}" "${dist_name}"; then
+            log "ERROR: Failed to delete existing ${OS_PKG_TYPE} distribution"
+            return
+        fi
+    fi
+
     log "Creating distribution ${dist_name} " \
         "with base_path=${repo_endpoint}"
     if ! pulp "${OS_PKG_TYPE}" distribution create \

--- a/scripts/setup_chacractl.sh
+++ b/scripts/setup_chacractl.sh
@@ -4,7 +4,10 @@
 ~/.local/bin/uv tool install chacractl
 
 if [ -z "$chacra_url" ]; then
-  chacra_url=$(curl -u "$SHAMAN_API_USER:$SHAMAN_API_KEY" https://shaman.ceph.com/api/nodes/next/)
+  # -f: shaman answers 404 ("no healthy chacra nodes available") when it has
+  # no node to allocate; fail here instead of writing the HTML error page
+  # into ~/.chacractl.
+  chacra_url=$(curl -fs -u "$SHAMAN_API_USER:$SHAMAN_API_KEY" https://shaman.ceph.com/api/nodes/next/)
 fi
 cat > $HOME/.chacractl << EOF
 url = "$chacra_url"

--- a/scripts/setup_pulp.sh
+++ b/scripts/setup_pulp.sh
@@ -1,12 +1,15 @@
 #!/bin/bash -ex
 
 echo "Setting up Pulp client"
-source "$WORKSPACE/scripts/setup_uv.sh"
+if [ -z "$PULP_SERVER_URL" ] || [ -z "$PULP_USERNAME" ] || [ -z "$PULP_PASSWORD" ]; then
+    echo "PULP_SERVER_URL, PULP_USERNAME, or PULP_PASSWORD is not set"
+    exit 1
+fi
 
 export PATH="$HOME/.local/bin:$PATH"
+source "$WORKSPACE/scripts/setup_uv.sh"
 
-PULP_SERVER_URL="https://pulp.front.sepia.ceph.com"
-
+echo "Installing Pulp client"
 uv tool install pulp-cli --with pulp-cli-deb
 
 echo "Configuring Pulp client"


### PR DESCRIPTION
Refactor the ceph-dev-pipeline build job so Chacra and Pulp uploads are independently configurable and run as separate Jenkins stages.

Summary:

### Fixed in place (squashed into this PR's commit)

1. **Pulp existence check** — `pulp ... repository list` prints `[]` when nothing matches, which is a non-empty string, so `PULP_REPO_EXISTS` was always `"true"` and every matrix cell skipped compilation. The label query also could never match what pulp_upload.sh stores (`flavor=` vs the stored `flavors` key, `distro_version=noble` vs stored `24.04`, and repositories are branch-scoped so their `sha1` label belongs to whichever build created them). The check now looks up the per-sha1 **distribution by its deterministic name** and uses the exit code, mirroring pulp_upload.sh naming: ubuntu uses the codename, rpm arches use `aarch64` (not `arm64`), and rpm lookups use `--distribution` while deb uses `--name`.

2. **Parallel matrix races** — `env.FOO = ...` assignments are global to the build and shared by every parallel matrix cell (last write wins); only the axis vars themselves get stage-scoped injection. So `CHACRACTL_EXISTS_RC`, `PULP_REPO_EXISTS`, and the `OS_*`/`CEPH_VERSION` values set in "prepare upload" could be overwritten by another cell mid-flight — e.g. the noble cell sets `OS_PKG_TYPE=deb` while centos9 is between "prepare upload" and its Chacra upload. Check results now live in `@Field` maps keyed per cell (like `build_matrix`), and the upload scripts receive `OS_*` via branch-scoped `withEnv`.

3. **Shaman credentials and build status** — the old upload stage's `environment{}` block (which also covered `post{}`) was lost in the split: `update_shaman.sh` in the Chacra stage's `post{}` and `notify_shaman_pulp_repo.sh` in the Pulp stage ran with no `SHAMAN_API_KEY`. Both credentials are now bound on the parent "upload packages" stage, and the completed/failed status update moved there too — otherwise pulp-only builds (cve-pipeline runs `CHACRA_UPLOAD=false`) stayed "started" in shaman forever.

4. **Repo URL bugs** — the URL passed to notify_shaman_pulp_repo.sh was missing a `/` before the arch segment (`.../flavors/defaultx86_64/`), and used `os.version_name` where pulp publishes debian under the numeric version (`debian/bookworm` vs actual `debian/12`).

5. **`PULP_UPLOAD` default stays `false`** in ceph-dev-pipeline.yml. Defaulting it `true` makes pulp.front.sepia reachability a hard requirement of every dev *and* release build before compilation, and posts shaman repo records pointing at Sepia-internal URLs (ceph-release-pipeline doesn't pass `PULP_UPLOAD`, so it inherits this default). cve-pipeline keeps its own default of `true`. If pulp-by-default everywhere is intended, that should be its own deliberate change.

### Follow-up commits on the branch

- **`ce478f5e` key build_matrix by flavor and fix FLAVOR axis** — `build_matrix` was keyed `DIST_ARCH` but the matrix has a FLAVOR axis, so default/debug cells of the same dist/arch shared a key and one flavor's existence check cancelled the other's build. Also fixes the nested `axes {` → `axis {` declaration (both pre-date this PR).
- **`4dfe0d98` cve-pipeline: add FORCE parameter** — the Jenkinsfile consults `FORCE`; without it a CVE rebuild of an already-uploaded sha1 can never be forced.
- **`6f8da0bf` pulp_upload.sh: rpm arch for the repository handoff lookup** — the final `repository show --name ${REPO_NAME}-${ARCH}` used `arm64`, but rpm repos are created as `-aarch64`, so arm64 rpm uploads died under `set -e` after all uploads succeeded.
- **`5feb069d` ceph-release-pipeline: pass boolean parameters as booleans** — `THROWAWAY`/`FORCE`/`FORCE_VERSION`/`TAG` now go through `.toBoolean()`, since the Jenkinsfile compares `params.THROWAWAY == false` strictly.
- **`cc561756` include the flavor in pulp repository and distribution names** — previously default and debug builds of the same branch/sha1 shared repositories and produced identically named distributions, so the stale-distribution delete would clobber one flavor with the other. `FLAVOR` is now part of `REPO_NAME` (e.g. `ceph-main-centos-9-default-x86_64`, `dist-ceph-main-centos-9-default-x86_64-<sha8>`), and the Jenkinsfile existence check matches. Since base_paths are unique in pulp, a distribution created under the old naming that still owns the base_path is deleted before the new one is created. Old unflavored repositories are left in place and can be cleaned up manually; existing sha1s won't be detected by the new check and will rebuild once.
- **`c55882cc` remove the dead TEST='test' chacra ref logic** — nothing defines or forwards `TEST` to ceph-dev-pipeline, and if it were ever enabled, `env.SHA1[0..6]` on the 4-character `'test'` string throws. Removed from the Jenkinsfile and the unused `TEST` parameter dropped from ceph-release-pipeline.

### Verification

The distribution-name existence check was validated against real objects on pulp.front (rc=0 for an existing build, rc=1 for a bogus short sha1) under the *old* naming; the flavored naming shifts everything one rebuild forward but is the same mechanism. None of this has been through a live Jenkins run — suggest a `THROWAWAY=true` smoke test with `CEPH_BUILD_BRANCH=wip-pulp-upload-fixes`, then one real `PULP_UPLOAD=true` run to confirm the flavored repos/distributions land where the check expects.