### PR TITLE
ceph-dev-pipeline: report started to shaman from the copy-artifacts stage

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -198,6 +198,11 @@ def doCopyArtifactsStage() {
     env.SHA1 = sha1_from_artifact
   }
   println "SHA1=${sha1_trimmed}"
+  // Report "started" to shaman as soon as SHA1 is known; a record without a
+  // sha1 is useless. CI_CONTAINER-only cells never report to shaman.
+  if ( build_matrix["${DIST}_${ARCH}_${FLAVOR}"] ) {
+    sh "./scripts/update_shaman.sh started ceph ${os.name} ${os.version_name} ${env.ARCH}"
+  }
   env.VERSION = readFile(file: "${env.WORKSPACE}/dist/version").trim()
   // In a release build, dist/other_envvars contains CEPH_REPO, and chacra_url
   // as written during ceph-source-dist but we don't to be able to define
@@ -335,6 +340,10 @@ def doArtifactsChecksStage() {
       "or FORCE=true (to re-upload artifacts)."
     )
     build_matrix[cell] = false
+    // Every enabled backend already has the packages, so this build's
+    // outcome is "completed".
+    def os = get_os_info(env.DIST)
+    sh "./scripts/update_shaman.sh completed ceph ${os.name} ${os.version_name} ${env.ARCH}"
   } else {
     def missing = []
     if (params.CHACRA_UPLOAD && !chacra_exists) missing << "Chacra"
@@ -388,7 +397,6 @@ def doBuilderContainerStage() {
 // Stage 7 (build): run the actual package build via build-with-container.py: assemble cmake/sccache/dwz flags per distro+flavor, then extract cephadm.
 def doBuildStage() {
   def os = get_os_info(env.DIST)
-  sh "./scripts/update_shaman.sh started ceph ${os.name} ${os.version_name} ${env.ARCH}"
   env.AWS_ACCESS_KEY_ID = env.SCCACHE_BUCKET_CREDS_USR
   env.AWS_SECRET_ACCESS_KEY = env.SCCACHE_BUCKET_CREDS_PSW
   def ceph_builder_tag = "${env.SHA1[0..6]}.${env.BRANCH}.${env.DIST}.${env.ARCH}.${env.FLAVOR}"
@@ -704,6 +712,10 @@ pipeline {
         agent {
           label "(installed-os-centos9||installed-os-noble)&&${ARCH}&&${base_node_label}"
         }
+        // update_shaman.sh runs from several stages and post{} handlers.
+        environment {
+          SHAMAN_API_KEY = credentials('shaman-api-key')
+        }
         when {
           beforeAgent true
           allOf {
@@ -835,10 +847,19 @@ pipeline {
             steps {
               script { doBuilderContainerStage() }
             }
+            // Builder-container failures (e.g. an uninstallable build
+            // dependency) must reach shaman too.
+            post {
+              unsuccessful {
+                script {
+                  def os = get_os_info(env.DIST)
+                  sh "./scripts/update_shaman.sh failed ceph ${os.name} ${os.version_name} ${env.ARCH}"
+                }
+              }
+            }
           }
           stage("build") {
             environment {
-              SHAMAN_API_KEY = credentials('shaman-api-key')
               SCCACHE_BUCKET_CREDS = credentials('ibm-cloud-sccache-bucket')
             }
             when {
@@ -860,12 +881,10 @@ pipeline {
             }
           }
           stage("upload packages") {
-            // Covers the steps of both upload stages and the post{} shaman
-            // status updates below; notify_shaman_pulp_repo.sh and
-            // update_shaman.sh both need SHAMAN_API_KEY.
+            // notify_shaman_pulp_repo.sh and update_shaman.sh get
+            // SHAMAN_API_KEY from the matrix-level environment{}.
             environment {
               CHACRACTL_KEY = credentials('chacractl-key')
-              SHAMAN_API_KEY = credentials('shaman-api-key')
             }
             when {
               expression {


### PR DESCRIPTION
## What

Moves the shaman "started" notification from the "build" stage to the copy-artifacts stage — the earliest point a correct record can be posted, since SHA1 is optional as a parameter and is only resolved from the setup build's artifact there. Supersedes #2639, which proposed reporting from the builder-container stage.

## Why

Shaman currently hears nothing about a cell until its "build" stage begins. A cell that fails or hangs in the artifact checks or the builder-container stage (e.g. a newly added build dependency that isn't installable on one of the distros) reports nothing, so shaman keeps showing the last known good build — a broken distro looks identical to a passing one.

## How

- **"started" posts from `doCopyArtifactsStage()`**, right after SHA1 is resolved and verified. CI_CONTAINER-only cells are skipped (they never report to shaman), matching the `build_matrix` gate the later stages already use.
- **The compile-skip path posts "completed"**: "started" now lands before the chacra/pulp existence checks, so a cell that skips compilation would otherwise leave its record dangling forever, looking like a hung build. Every enabled backend already has the packages, so "completed" is genuinely the outcome — and shaman now gets this run's URL instead of nothing.
- **The builder-container stage gets the same `unsuccessful` → "failed" handler** the build and upload stages already have (the failure mode #2639 was about).
- **`SHAMAN_API_KEY` moves to a matrix-level `environment{}`** since `update_shaman.sh` now runs from several stages and post handlers within a cell.

## Behavior changes

- Skipped-compile cells now post "completed" (previously: nothing).
- Builder-container failures now post "failed" (previously: nothing).
- "started" appears on shaman a few stages earlier per cell. A failure in the copy-artifacts stage itself, or an abort while a cell is still queued for an agent, still reports nothing — same as today.
- The `build_info` file `update_shaman.sh` writes as a side effect has no consumers in this pipeline (only legacy jobs read it via `build_utils.sh`), so moving the "started" call out of the build stage is safe.

## Testing

Not yet run on Jenkins — needs a `CEPH_BUILD_BRANCH=dev-pipeline-early-shaman-notify` run of ceph-dev-pipeline, ideally covering a normal build, a re-run that skips compile, and a builder-container failure.