### PR TITLE
ceph-dev-pipeline: fix ceph-release RPM for release builds

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -112,7 +112,6 @@ baseurl=${repo_base_url}/\\$basearch
 enabled=1
 gpgcheck=0
 type=rpm-md
-gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 [Ceph-noarch]
 name=Ceph noarch packages
@@ -120,7 +119,6 @@ baseurl=${repo_base_url}/noarch
 enabled=1
 gpgcheck=0
 type=rpm-md
-gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 [ceph-source]
 name=Ceph source packages
@@ -128,7 +126,6 @@ baseurl=${repo_base_url}/SRPMS
 enabled=1
 gpgcheck=0
 type=rpm-md
-gpgkey=https://download.ceph.com/keys/autobuild.asc
 '''
 
 @NonCPS

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -54,7 +54,7 @@ def get_os_info(dist) {
 @Field String ceph_release_spec_template = '''
 Name:           ceph-release
 Version:        1
-Release:        0%{?dist}
+Release:        ${release_number}%{?dist}
 Summary:        Ceph Development repository configuration
 Group:          System Environment/Base
 License:        GPLv2
@@ -110,37 +110,37 @@ install -pm 644 %{SOURCE0} \
 name=Ceph packages for \\$basearch
 baseurl=${repo_base_url}/\\$basearch
 enabled=1
-gpgcheck=0
+gpgcheck=${gpgcheck}
 type=rpm-md
-
+${gpgkey_line}
 [Ceph-noarch]
 name=Ceph noarch packages
 baseurl=${repo_base_url}/noarch
 enabled=1
-gpgcheck=0
+gpgcheck=${gpgcheck}
 type=rpm-md
-
+${gpgkey_line}
 [ceph-source]
 name=Ceph source packages
 baseurl=${repo_base_url}/SRPMS
 enabled=1
-gpgcheck=0
+gpgcheck=${gpgcheck}
 type=rpm-md
-'''
+${gpgkey_line}'''
 
 @NonCPS
-def get_ceph_release_spec_text(project_url) {
+def get_ceph_release_spec_text(project_url, release_number) {
   def engine = new groovy.text.SimpleTemplateEngine()
   def template = engine.createTemplate(ceph_release_spec_template)
-  def text = template.make(["project_url": project_url])
+  def text = template.make(["project_url": project_url, "release_number": release_number])
   return text.toString()
 }
 
 @NonCPS
-def get_ceph_release_repo_text(base_url) {
+def get_ceph_release_repo_text(base_url, gpgcheck, gpgkey_line) {
   def engine = new groovy.text.SimpleTemplateEngine()
   def template = engine.createTemplate(ceph_release_repo_template)
-  def text = template.make(["repo_base_url": base_url])
+  def text = template.make(["repo_base_url": base_url, "gpgcheck": gpgcheck, "gpgkey_line": gpgkey_line])
   return text.toString()
 }
 
@@ -637,7 +637,7 @@ def buildCephReleaseRpm(repo_url) {
   def ceph_repo_file = "ceph.repo"
   def ceph_release_spec = "dist/ceph/rpmbuild/SPECS/${ceph_release_spec_file}"
   def ceph_repo = "dist/ceph/rpmbuild/SOURCES/${ceph_repo_file}"
-  def ceph_release_rpm = "dist/ceph/rpmbuild/RPMS/noarch/ceph-release-1-0.el*.noarch.rpm"
+  def ceph_release_rpm = "dist/ceph/rpmbuild/RPMS/noarch/ceph-release-1-*.el*.noarch.rpm"
 
   sh """#!/bin/bash -ex
     shopt -s nullglob
@@ -657,10 +657,24 @@ def buildCephReleaseRpm(repo_url) {
     fi
   """
 
-  def spec_text = get_ceph_release_spec_text("${repo_url}")
+  // Release builds must match what ceph.git's container/Containerfile
+  // expects: it installs ceph-release-1-${IS_RELEASE} (1 for releases, 0 for
+  // CI/dev) and rewrites http://download.ceph.com/ baseurls in ceph.repo to
+  // the authenticated prerelease URL, so the RPM has to carry Release: 1 and
+  // point at download.ceph.com (signed, gpgcheck=1) rather than at the
+  // dev repo it was uploaded to.
+  def os = get_os_info(env.DIST)
+  def release_build = env.RELEASE_BUILD?.trim() == "true"
+  def release_number = release_build ? "1" : "0"
+  def spec_url = release_build ? "http://download.ceph.com/" : "${repo_url}"
+  def repo_base_url = release_build ? "http://download.ceph.com/rpm-${env.BRANCH}/el${os.version}" : "${repo_url}"
+  def gpgcheck = release_build ? "1" : "0"
+  def gpgkey_line = release_build ? "gpgkey=https://download.ceph.com/keys/release.asc\n" : ""
+
+  def spec_text = get_ceph_release_spec_text(spec_url, release_number)
   writeFile(file: ceph_release_spec, text: spec_text)
 
-  def repo_text = get_ceph_release_repo_text("${repo_url}")
+  def repo_text = get_ceph_release_repo_text(repo_base_url, gpgcheck, gpgkey_line)
   writeFile(file: ceph_repo, text: repo_text)
 
   echo "ceph_release_spec: ${ceph_release_spec}"


### PR DESCRIPTION
## Problem

[ceph-release-containers #35](https://jenkins.ceph.com/view/all/job/ceph-release-containers/35/console) failed with:

```
curl: (22) The requested URL returned error: 404
error: skipping https://****@download.ceph.com/prerelease/ceph/rpm-umbrella/el9//noarch/ceph-release-1-1.el9.noarch.rpm - transfer failed
```

The prerelease repo actually contains `ceph-release-1-0.el9.noarch.rpm`.

ceph.git's [container/Containerfile](https://github.com/ceph/ceph/blob/main/container/Containerfile#L127) installs `ceph-release-1-${IS_RELEASE}.${EL_VER}.noarch.rpm` with `IS_RELEASE=1` for release container builds, matching the historical convention from `build_ceph_release_rpm()` in `scripts/build_utils.sh` (`Release: 1` for official releases, `0` for dev builds). But the ceph-release spec template in the ceph-dev-pipeline Jenkinsfile hardcodes `Release: 0%{?dist}` for every build, so releases built through `ceph-release-pipeline` → `ceph-dev-pipeline` publish `ceph-release-1-0`.

There was also a second, silent problem: the generated `ceph.repo` always points at the chacra/pulp dev repo. The Containerfile's `sed` only rewrites `http://download.ceph.com/` baseurls to the authenticated prerelease URL, so even with the right NVR, a release container would have installed unsigned dev packages from chacra/pulp instead of the signed prerelease packages.

## Fix

**Commit 1** drops the `gpgkey=https://download.ceph.com/keys/autobuild.asc` lines from the dev repo template. Nothing uses the autobuild key anymore: dev packages are uploaded unsigned, the repo files chacra itself serves have no gpgkey line (and `[trusted=yes]` on the apt side), `gpgcheck=0` means dnf never fetches the key, and the key is a 2011 DSA-1024 key that el9's crypto policy refuses to import anyway.

**Commit 2**: when `RELEASE_BUILD=true`, `buildCephReleaseRpm()` (used by both the chacra and pulp upload paths) mirrors the old `build_ceph_release_rpm()` release behavior:

- `Release: 1%{?dist}` → `ceph-release-1-1.el9.noarch.rpm`
- `baseurl=http://download.ceph.com/rpm-$BRANCH/el$VER/...` (so the Containerfile sed rewrites it to the prerelease URL during prerelease container builds, and it points at the final signed repo once released)
- `gpgcheck=1` with `gpgkey=https://download.ceph.com/keys/release.asc`

Dev/CI builds are unchanged (`Release: 0`, chacra/pulp baseurl, `gpgcheck=0`, no gpgkey line). Also widened the pre-build cleanup glob from `ceph-release-1-0.el*` to `ceph-release-1-*.el*` so stale RPMs of either flavor get removed.