### PR TITLE
ceph-release-containers: build umbrella+ release containers from Rocky Linux 10

### DIFF
--- a/ceph-release-containers/build/Jenkinsfile
+++ b/ceph-release-containers/build/Jenkinsfile
@@ -97,6 +97,7 @@ pipeline {
           )
           script {
             sh '''#!/bin/bash -ex
+              command -v skopeo || sudo dnf install -y skopeo
               podman login -u ${CONTAINER_REPO_CREDS_USR} -p ${CONTAINER_REPO_CREDS_PSW} ${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}
               skopeo login -u ${CONTAINER_REPO_CREDS_USR} -p ${CONTAINER_REPO_CREDS_PSW} ${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}
               cd container;

--- a/ceph-release-containers/build/Jenkinsfile
+++ b/ceph-release-containers/build/Jenkinsfile
@@ -29,6 +29,9 @@ pipeline {
               DOWNLOAD_PRERELEASE_CREDS = credentials('download.ceph.com-prerelease')
               // keep all the podman/skopeo auths in the same place
               REGISTRY_AUTH_FILE = '/home/jenkins-build/manifest.auth.json'
+              // umbrella (21) and later are based on Rocky Linux 10; earlier
+              // releases on CentOS Stream 9 (matching scripts/build_container)
+              FROM_IMAGE = "${(env.VERSION.tokenize('.')[0].toInteger() >= 21) ? 'docker.io/rockylinux/rockylinux:10' : 'quay.io/centos/centos:stream9'}"
               // the one variant value.  If I try to do this with conditional code in the steps,
               // manipulating 'env.CONTAINER_REPO', it appears as if the env instance is somehow
               // shared between the two executors, *even across different builders*.  Yes, I know

--- a/ceph-release-containers/config/definitions/ceph-release-containers.yml
+++ b/ceph-release-containers/config/definitions/ceph-release-containers.yml
@@ -9,7 +9,7 @@
         - git:
             url: https://github.com/ceph/ceph-build
             branches:
-              - main
+              - ${{CEPH_BUILD_BRANCH}}
             shallow-clone: true
             submodule:
               disable: true


### PR DESCRIPTION
The release container job never set `FROM_IMAGE`, so `container/build.sh` in ceph.git fell back to its default (`quay.io/centos/centos:stream9`) for every release.

Starting with umbrella (v21), release containers should be based on Rocky Linux 10, matching what the dev/CI pipeline already does via `scripts/build_container`.

This sets `FROM_IMAGE` explicitly from the `VERSION` parameter: Rocky 10 for major version >= 21, CentOS Stream 9 for older releases.

A companion ceph.git PR flips the `FROM_IMAGE` defaults in `container/` to Rocky 10 on main so umbrella and later default correctly even when `FROM_IMAGE` isn't passed.