### PR TITLE
ceph-dev-pipeline: discard builds/artifacts older than 90 days

### DIFF
--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -4,6 +4,12 @@
     project-type: pipeline
     quiet-period: 1
     concurrent: true
+
+    properties:
+      - build-discarder:
+          days-to-keep: 90
+          artifact-days-to-keep: 90
+
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
we were accumulating without bound and ran the Jenkins homedir disk out of space.  Let's put a limit on and see how it goes.