### PR TITLE
ceph-perf: fix Rocky/EL10 Python package setup

### DIFF
--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -227,14 +227,31 @@
           . /etc/os-release || ID=ubuntu
           case $ID in
           debian|ubuntu)
-              sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y python3-yaml python3-lxml python3-prettytable python3-matplotlib cython3
+              sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y python3-yaml python3-lxml python3-prettytable python3-matplotlib cython3 git
               ;;
           centos|rhel|rocky|almalinux)
               # llvm/gcc-toolset are EL8/9-oriented; ignore on Rocky 10+ where modules differ.
               sudo dnf copr remove tchaikov/llvm-toolset-10 || true
               sudo dnf module enable -y llvm-toolset || true
               sudo dnf install -y llvm-toolset || true
-              sudo dnf install -y python3-pyyaml python3-lxml python3-prettytable python3-matplotlib python3-Cython
+              # Repos needed on EL for CBT Python RPMs:
+              # - CRB/PowerTools: python3-cython (EL9/10)
+              # - EPEL: python3-matplotlib (EL10 AppStream does not ship it)
+              # config-manager comes from dnf-plugins-core; without it the
+              # enable steps below would no-op and python3-cython would fail.
+              sudo dnf install -y dnf-plugins-core
+              sudo dnf config-manager --set-enabled crb 2>/dev/null || \
+                sudo dnf config-manager --set-enabled powertools 2>/dev/null || \
+                sudo dnf config-manager --set-enabled PowerTools 2>/dev/null || true
+              if ! rpm -q epel-release >/dev/null 2>&1; then
+                  major=${{VERSION_ID%%.*}}
+                  sudo dnf install -y epel-release || \
+                    sudo dnf install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${{major}}.noarch.rpm"
+              fi
+              # Prefer lowercase python3-cython (EL10+); capital-C still works via Provides
+              # when CRB is enabled, but keep the modern name as the primary request.
+              sudo dnf install -y python3-pyyaml python3-lxml python3-prettytable \
+                python3-matplotlib python3-cython git
               sudo dnf update -y libarchive || true
               gcc_toolset_ver=13
               # so clang is able to find gcc-toolset-${{gcc_toolset_ver}} which is listed as a
@@ -247,7 +264,8 @@
               fi
               ;;
           fedora)
-              sudo yum install -y python3-pyyaml python3-lxml python3-prettytable python3-matplotlib python3-Cython clang
+              sudo yum install -y python3-pyyaml python3-lxml python3-prettytable \
+                python3-matplotlib python3-cython clang git
               ;;
           *)
               echo "unknown distro: $ID"
@@ -259,9 +277,15 @@
           for p in crimson-osd ceph-osd ceph-mon ceph-mgr rados ; do
               sudo pkill -9 -x "$p" || true
           done
-          virtualenv -q --python python3 ${{WORKSPACE}}/gh-venv
+          # Rocky/EL10 does not ship the virtualenv CLI; prefer stdlib venv and
+          # fall back if ensurepip/venv support is missing (if-test avoids set -e).
+          if python3 -m venv "${{WORKSPACE}}/gh-venv"; then
+              :
+          else
+              virtualenv -q --python python3 "${{WORKSPACE}}/gh-venv"
+          fi
           . ${{WORKSPACE}}/gh-venv/bin/activate
-          pip install setuptools
+          pip install -U pip setuptools wheel
           pip install cython
           # cbt imports mdutils; not listed in ceph/cbt master requirements.txt
           pip install -r ${{WORKSPACE}}/cbt/requirements.txt mdutils


### PR DESCRIPTION
Performance nodes are Rocky 10. Setup failed because python3-Cython is not in AppStream (python3-cython is in CRB) and python3-matplotlib is only in EPEL. Enable CRB/PowerTools and epel-release before installing those RPMs, and prefer python3 -m venv since the virtualenv CLI is not shipped on EL10.