### PR TITLE
cve-pipeline: allow specifying a private fork of ceph.git

### DIFF
--- a/cve-pipeline/config/definitions/cve-pipeline.yml
+++ b/cve-pipeline/config/definitions/cve-pipeline.yml
@@ -40,7 +40,7 @@
     parameters:
       - string:
           name: BRANCH
-          description: "The branch from ceph-private.git to build"
+          description: "The branch from CEPH_REPO to build"
           default: main
 
       - choice:
@@ -49,10 +49,10 @@
           choices:
             - ''
 
-      - choice:
+      - string:
           name: CEPH_REPO
-          choices:
-            - git@github.com:ceph/ceph-private.git
+          description: "SSH URL of the private repo to build.  Can be a GitHub Security Advisory private fork (e.g. git@github.com:ceph/ceph-ghsa-xxxx-xxxx-xxxx.git).  The ceph-jenkins GitHub account must have access to the repo."
+          default: git@github.com:ceph/ceph-private.git
 
       - string:
           name: DISTROS

--- a/cve-source-dist/config/definitions/cve-source-dist.yml
+++ b/cve-source-dist/config/definitions/cve-source-dist.yml
@@ -41,10 +41,10 @@
             - scm-tag
 
     parameters:
-      - choice:
+      - string:
           name: CEPH_REPO
-          choices:
-            - git@github.com:ceph/ceph-private.git
+          description: "SSH URL of the private repo to build.  Can be a GitHub Security Advisory private fork (e.g. git@github.com:ceph/ceph-ghsa-xxxx-xxxx-xxxx.git).  The ceph-jenkins GitHub account must have access to the repo."
+          default: git@github.com:ceph/ceph-private.git
 
       - string:
           name: BRANCH


### PR DESCRIPTION
Converts `CEPH_REPO` from a single-choice dropdown to a free-form string parameter (still defaulting to `git@github.com:ceph/ceph-private.git`) in both `cve-pipeline` and `cve-source-dist`, so CVE fixes can be built from GitHub Security Advisory temporary private forks (e.g. `git@github.com:ceph/ceph-ghsa-xxxx-xxxx-xxxx.git`) on any branch.

The `cve-source-dist` change is required, not cosmetic: `ceph-dev-pipeline/build/Jenkinsfile` forwards `CEPH_REPO` to the setup job as a string parameter, and a choice parameter there would reject any value not in its list.

Notes:
- `BRANCH` was already free-form; only its description changed.
- The release-build path in `ceph-source-dist` that hardcodes `ceph-private`/`ceph-releases` is untouched and unaffected (the CVE flow doesn't set `RELEASE_BUILD`).
- The `ceph-jenkins` GitHub account (`jenkins-build` SSH credential) must be added as a collaborator on the security advisory for its fork to be cloneable — GHSA forks don't inherit org access.
- Both job definitions are skipped by jenkins-job-builder, so a Jenkins admin must apply this manually after merge.