### PR TITLE
podman auth: export REGISTRY_AUTH_FILE in every podman-invoking shell

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -346,26 +346,20 @@ def doArtifactsChecksStage() {
 // Stage 6 (builder container): log into container registries and pull/build/push the ceph-build container image for this matrix cell.
 def doBuilderContainerStage() {
   env.CEPH_BUILDER_IMAGE = "${env.CONTAINER_REPO_HOSTNAME}/${env.CONTAINER_REPO_ORGANIZATION}/ceph-build"
-  // Pin podman auth to a persistent authfile. The agent runs as a systemd
-  // service with no login session and no XDG_RUNTIME_DIR, so podman derives
-  // the default auth.json location from ambient node state at each
-  // invocation, landing in runtime tmpfs the job doesn't control.
-  // Credentials written by podman login here have been observed unavailable
-  // to podman build in the same job minutes later, so the base image pull
-  // goes anonymous and hits Docker Hub's rate limit (toomanyrequests,
-  // https://tracker.ceph.com/issues/77920). Set via env so every subsequent
-  // sh step (pull/build/push here, and build-with-container.py in the build
-  // stage) resolves the same file.
-  env.REGISTRY_AUTH_FILE = "${env.HOME}/.config/containers/auth.json"
+  // Every podman-running sh block exports REGISTRY_AUTH_FILE itself so login
+  // and all later pulls (incl. podman build inside build-with-container.py)
+  // share one persistent authfile: https://tracker.ceph.com/issues/77920
   sh '''#!/bin/bash
     set -ex
+    export REGISTRY_AUTH_FILE="${HOME}/.config/containers/auth.json"
     mkdir -p "${REGISTRY_AUTH_FILE%/*}"
-    podman login --authfile ${REGISTRY_AUTH_FILE} -u ${CONTAINER_REPO_CREDS_USR} -p ${CONTAINER_REPO_CREDS_PSW} ${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}
-    podman login --authfile ${REGISTRY_AUTH_FILE} -u ${DOCKER_HUB_CREDS_USR} -p ${DOCKER_HUB_CREDS_PSW} docker.io
+    podman login -u ${CONTAINER_REPO_CREDS_USR} -p ${CONTAINER_REPO_CREDS_PSW} ${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}
+    podman login -u ${DOCKER_HUB_CREDS_USR} -p ${DOCKER_HUB_CREDS_PSW} docker.io
   '''
   def ceph_builder_tag_short = "${env.BRANCH}.${env.DIST}.${env.ARCH}.${env.FLAVOR}"
   def ceph_builder_tag = "${env.SHA1[0..6]}.${ceph_builder_tag_short}"
   sh """#!/bin/bash -ex
+    export REGISTRY_AUTH_FILE="\${HOME}/.config/containers/auth.json"
     podman pull ${env.CEPH_BUILDER_IMAGE}:${ceph_builder_tag} || \
     podman pull ${env.CEPH_BUILDER_IMAGE}:${ceph_builder_tag_short} || \
     true
@@ -373,6 +367,7 @@ def doBuilderContainerStage() {
   def withCrimson = !(env.BRANCH in ['tentacle', 'squid', 'reef'])
   sh """#!/bin/bash
     set -ex
+    export REGISTRY_AUTH_FILE="\${HOME}/.config/containers/auth.json"
     echo > .env
     echo "WITH_CRIMSON=${withCrimson}" >> .env
     cd dist/ceph
@@ -380,6 +375,7 @@ def doBuilderContainerStage() {
     podman tag ${env.CEPH_BUILDER_IMAGE}:${ceph_builder_tag} ${env.CEPH_BUILDER_IMAGE}:${ceph_builder_tag_short}
   """
   sh """#!/bin/bash -ex
+    export REGISTRY_AUTH_FILE="\${HOME}/.config/containers/auth.json"
     podman push ${env.CEPH_BUILDER_IMAGE}:${ceph_builder_tag_short}
     podman push ${env.CEPH_BUILDER_IMAGE}:${ceph_builder_tag}
   """
@@ -473,18 +469,21 @@ def doBuildStage() {
     echo "CEPH_EXTRA_CMAKE_ARGS=${ceph_extra_cmake_args}" >> .env
   """
   sh """#!/bin/bash -ex
+    export REGISTRY_AUTH_FILE="\${HOME}/.config/containers/auth.json"
     cd dist/ceph
     ln ../ceph-${env.VERSION}.tar.bz2 .
     ${bwc_command}
   """
   if ( os.pkg_type == "deb" ) {
     sh """#!/bin/bash -ex
+      export REGISTRY_AUTH_FILE="\${HOME}/.config/containers/auth.json"
       cd dist/ceph
       ${bwc_command_base} -e custom -- "dpkg-deb --fsys-tarfile /ceph/debs/*/pool/main/c/ceph/cephadm_${env.VERSION}*.deb | tar -x -f - --strip-components=3 ./usr/sbin/cephadm"
       ln ./cephadm ../../
     """
   } else if ( env.DIST =~ /^(centos|rhel|rocky|fedora).*/ ) {
     sh """#!/bin/bash -ex
+      export REGISTRY_AUTH_FILE="\${HOME}/.config/containers/auth.json"
       cd dist/ceph
       ${bwc_command_base} -e custom -- "rpm2cpio /ceph/rpmbuild/RPMS/noarch/cephadm-*.rpm | cpio -i --to-stdout *sbin/cephadm > cephadm"
       ln ./cephadm ../../

--- a/scripts/bwc.sh
+++ b/scripts/bwc.sh
@@ -83,10 +83,11 @@ bwc_login() {
     if [ -z "${DOCKER_HUB_USERNAME}" ] || [ -z "${DOCKER_HUB_PASSWORD}" ]; then
         return 0
     fi
+    # Same-shell export so login and all later podman calls share one
+    # persistent authfile: https://tracker.ceph.com/issues/77920
     export REGISTRY_AUTH_FILE="${HOME}/.config/containers/auth.json"
     mkdir -p "${REGISTRY_AUTH_FILE%/*}"
-    podman login --authfile "${REGISTRY_AUTH_FILE}" \
-        -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}" docker.io
+    podman login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}" docker.io
 }
 
 # bwc_arch - Print the architecture of the current host in the style


### PR DESCRIPTION
## What

Three commits:

1. **Revert** the #2656 merge (ceph-dev-pipeline `--authfile` logins + Groovy `env.REGISTRY_AUTH_FILE`)
2. **Revert** aae7f2fd (bwc.sh `--authfile`)
3. **Fix**: every sh block that invokes podman or build-with-container.py — builder container stage login/pull/build/push, build stage bwc runs, and `bwc_login` — exports `REGISTRY_AUTH_FILE="$HOME/.config/containers/auth.json"` itself. Plain `podman login`, no flags.

## Why

https://tracker.ceph.com/issues/77920 recurred on 2026-07-22 **with #2656 deployed**: login wrote docker.io creds to `$HOME/.config/containers/auth.json`, and the `FROM docker.io/ubuntu:22.04` pull inside `podman build` (spawned by build-with-container.py) still pulled anonymously → `toomanyrequests`.

Debug run on a builder pinned it:

```
$ env -u XDG_RUNTIME_DIR REGISTRY_AUTH_FILE=$HOME/.config/containers/auth.json \
    podman build --pull --no-cache --log-level=debug -f /tmp/df /tmp 2>&1 | grep -iE 'credential|account='
msg="Found credentials for docker.io/library/ubuntu in credential helper containers-auth.json in file /home/jenkins-build/.config/containers/auth.json"
msg="GET https://auth.docker.io/token?account=dgalloway&..."
```

`podman build`'s base-image pull honors `REGISTRY_AUTH_FILE` **when it's actually in the process environment** — so on 2026-07-22 it wasn't. Hence:

- `--authfile` on the login alone is worse than nothing: it steers credentials into a file later pulls never consult.
- Groovy env threading demonstrably failed to deliver the variable to the bwc subprocess.
- A same-shell `export` reaches podman by plain process inheritance and can't be silently dropped. `podman login` honors it for writes, so login and all later reads use the same persistent file by construction. Repeated verbatim per block on purpose: self-sufficient and greppable.

Also retracts aae7f2fd's logind-teardown rationale: a week of auditd on `/run/user/<uid>/containers/` showed every auth.json write was podman's own atomic tmp+rename, unbroken inode chain, no external deletions.

Fixes: https://tracker.ceph.com/issues/77920