### PR TITLE
Add generic-webhook-trigger to ceph/ceph PR jobs for ci-approved label

### DIFF
--- a/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
+++ b/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
@@ -55,6 +55,35 @@
           success-status: "ceph dashboard cephadm e2e tests succeeded"
           failure-status: "ceph dashboard cephadm e2e tests failed"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - git:
           url: https://github.com/ceph/ceph.git

--- a/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
+++ b/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml
@@ -49,6 +49,35 @@
           success-status: "ceph dashboard tests succeeded"
           failure-status: "ceph dashboard tests failed"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - git:
           url: https://github.com/ceph/ceph.git

--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -108,6 +108,35 @@
           success-status: 'ceph {osd-flavor} perf regression passed'
           failure-status: 'ceph {osd-flavor} perf regression failed'
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - ceph-main
       - ceph-pr

--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -46,6 +46,35 @@
           success-status: "ceph API tests succeeded"
           failure-status: "ceph API tests failed"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - git:
           url: https://github.com/ceph/ceph.git

--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -64,6 +64,35 @@
           success-status: "all commits in this PR are signed"
           failure-status: "one or more commits in this PR are not signed"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - ceph
       - ceph-build

--- a/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
+++ b/ceph-pr-docs/config/definitions/ceph-pr-docs.yml
@@ -32,6 +32,35 @@
           success-status: "OK - docs built"
           failure-status: "Docs: failed with errors"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - git:
           url: https://github.com/ceph/ceph

--- a/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
@@ -37,6 +37,35 @@
           success-status: "submodules for project are unmodified"
           failure-status: "Approval needed: modified submodules found"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - git:
           url: https://github.com/ceph/ceph.git

--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -73,6 +73,35 @@
         failure-status: "make check failed"
         white-list-target-branches:
         - main
+    - generic-webhook-trigger:
+        token-credential-id: ci-approved-trigger-token
+        print-contrib-var: true
+        post-content-params:
+          - type: JSONPath
+            key: action
+            value: $.action
+          - type: JSONPath
+            key: label
+            value: $.label.name
+          - type: JSONPath
+            key: ghprbPullId
+            value: $.pull_request.number
+          - type: JSONPath
+            key: ghprbTargetBranch
+            value: $.pull_request.base.ref
+          - type: JSONPath
+            key: ghprbSourceBranch
+            value: $.pull_request.head.ref
+          - type: JSONPath
+            key: ghprbActualCommit
+            value: $.pull_request.head.sha
+          - type: JSONPath
+            key: sha1
+            value: $.pull_request.head.sha
+        regex-filter-text: '$action $label $ghprbPullId'
+        regex-filter-expression: '^labeled ci-approved \d+$'
+        cause: 'PR #$ghprbPullId labeled ci-approved'
+
     publishers:
       - cobertura:
           report-file: "src/pybind/mgr/dashboard/frontend/coverage/cobertura-coverage.xml"

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -49,6 +49,35 @@
           success-status: "make check succeeded"
           failure-status: "make check failed"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - git:
           url: https://github.com/ceph/ceph.git

--- a/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml
+++ b/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml
@@ -54,6 +54,35 @@
           success-status: "ceph rook orchestrator e2e tests succeeded"
           failure-status: "ceph rook orchestrator e2e tests failed"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - git:
           url: https://github.com/ceph/ceph.git

--- a/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml
@@ -69,6 +69,35 @@
           success-status: "ceph-volume {method} {distro}-{objectstore}-{scenario} OK"
           failure-status: "ceph-volume {method} {distro}-{objectstore}-{scenario} failed"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - git:
           url: https://github.com/ceph/ceph.git

--- a/ceph-volume-unit-tests/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-unit-tests/config/definitions/ceph-volume-pr.yml
@@ -49,6 +49,35 @@
           success-status: "ceph-volume tox OK"
           failure-status: "ceph-volume tox failed"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - git:
           url: https://github.com/ceph/ceph

--- a/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
+++ b/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
@@ -51,6 +51,35 @@
           success-status: "ceph windows tests succeeded"
           failure-status: "ceph windows tests failed"
 
+      - generic-webhook-trigger:
+          token-credential-id: ci-approved-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: label
+              value: $.label.name
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.pull_request.number
+            - type: JSONPath
+              key: ghprbTargetBranch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: ghprbSourceBranch
+              value: $.pull_request.head.ref
+            - type: JSONPath
+              key: ghprbActualCommit
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: sha1
+              value: $.pull_request.head.sha
+          regex-filter-text: '$action $label $ghprbPullId'
+          regex-filter-expression: '^labeled ci-approved \d+$'
+          cause: 'PR #$ghprbPullId labeled ci-approved'
+
     scm:
       - git:
           url: https://github.com/ceph/ceph.git


### PR DESCRIPTION
## What

Every active job that runs on \`ceph/ceph\` pull requests via the \`github-pull-request\` (ghprb) trigger now *also* accepts a \`generic-webhook-trigger\` (modeled on \`ceph-trigger-build\`), so a build can be triggered by adding a **\`ci-approved\`** label to the PR. 13 definition files:

ceph-pull-requests, ceph-pull-requests-arm64, ceph-pr-api, ceph-pr-commits, ceph-pr-submodules, ceph-pr-docs, ceph-dashboard-pull-requests, ceph-dashboard-cephadm-e2e, ceph-perf-pull-requests, ceph-rook-e2e, ceph-volume-unit-tests, ceph-volume-cephadm-prs, ceph-windows-pull-requests

Jobs watching other repos are intentionally not included.

## How it works

- The trigger filters on \`$action $label $ghprbPullId\` matching \`^labeled ci-approved \d+$\` — it only fires when a \`ci-approved\` label is added to a **pull request**. Including \`$.pull_request.number\` in the filter prevents issue-label events from matching.
- It contributes the ghprb-equivalent variables (\`ghprbPullId\`, \`ghprbTargetBranch\`, \`ghprbSourceBranch\`, \`ghprbActualCommit\`, \`sha1\`) from the webhook payload, so existing SCM refspecs (\`+refs/pull/${ghprbPullId}/*\`) and \`${sha1}\` branch specs resolve unchanged.
- All 13 jobs share \`token-credential-id: ci-approved-trigger-token\` — the same random-secret-token model as \`ceph-trigger-build\`, so no plugin whitelist/HMAC config is needed; the unguessable token is the authentication. One \`ceph/ceph\` webhook pointed at \`/generic-webhook-trigger/invoke?token=<secret>\` (content type \`application/json\`, "Pull requests" events only) fans out to all 13 jobs when the label is added.
- The existing ghprb triggers are untouched — PR open/push/trigger-phrase behavior is unchanged; the label path is purely additive. Removing and re-adding the label re-triggers builds.

## Before this takes effect

1. Create a **Secret Text** credential in Jenkins with ID \`ci-approved-trigger-token\` holding a random token (e.g. \`pwgen 32 1\`).
2. Add the \`ceph/ceph\` webhook with that token in the URL, JSON content type, "Pull requests" events only.

## Reviewer notes

- \`sha1\` is set to \`$.pull_request.head.sha\` (the PR head), since the payload has no equivalent of ghprb's \`origin/pr/N/merge\` ref — label-triggered builds test the PR head rather than the merge preview.
- Only users with **triage+** repo access can add labels on GitHub; ceph/ceph has no outside collaborators with triage or higher.
- All modified files validated with \`jenkins-jobs test\` (JJB 6.4.2).