### PR TITLE
ceph-pr-pipeline: combine the ceph.git PR checks into one pipeline

### DIFF
--- a/ceph-pr-api/config/definitions/ceph-pr-api.yml
+++ b/ceph-pr-api/config/definitions/ceph-pr-api.yml
@@ -28,24 +28,6 @@
           name: ghprbPullId
           description: "Pull Request Number (e.g., 60421)"
 
-    triggers:
-      - github-pull-request:
-          cancel-builds-on-update: true
-          allow-whitelist-orgs-as-admins: true
-          org-list:
-            - ceph
-          white-list-target-branches: '{obj:target_branches}'
-          trigger-phrase: 'jenkins test api'
-          skip-build-phrase: '^jenkins do not test.*'
-          only-trigger-phrase: false
-          github-hooks: true
-          permit-all: false
-          auto-close-on-fail: false
-          status-context: "ceph API tests"
-          started-status: "running API tests"
-          success-status: "ceph API tests succeeded"
-          failure-status: "ceph API tests failed"
-
     scm:
       - git:
           url: https://github.com/ceph/ceph.git

--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -49,21 +49,6 @@
           name: sha1
           description: "commit id or a refname, like 'origin/pr/72/head'"
 
-    triggers:
-      - github-pull-request:
-          allow-whitelist-orgs-as-admins: true
-          org-list:
-            - ceph
-          trigger-phrase: 'jenkins test signed'
-          only-trigger-phrase: false
-          github-hooks: true
-          permit-all: false
-          auto-close-on-fail: false
-          status-context: "Signed-off-by"
-          started-status: "checking if commits are signed"
-          success-status: "all commits in this PR are signed"
-          failure-status: "one or more commits in this PR are not signed"
-
     scm:
       - ceph
       - ceph-build

--- a/ceph-pr-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-pr-pipeline-trigger/build/Jenkinsfile
@@ -46,7 +46,7 @@ def phraseToChecks(String body) {
   if (body =~ /(?i)jenkins\s+test\s+make\s+check\s+arm64/) {
     return null
   }
-  if (body =~ /(?i)jenkins\s+test\s+all\b/) {
+  if (body =~ /(?i)jenkins\s+(test\s+all|retest)\b/) {
     return all_checks.keySet().join(" ")
   }
   def hits = []

--- a/ceph-pr-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-pr-pipeline-trigger/build/Jenkinsfile
@@ -31,6 +31,15 @@ import groovy.transform.Field
   "windows":          "ceph windows tests",
 ]
 
+// Target-branch whitelists, same as the old freestyle jobs'.  Keep in sync
+// with ceph-pr-pipeline/build/Jenkinsfile: the pipeline filters its legs
+// with these too (needed for manual runs), but the trigger must also know
+// them so it never posts a pending status for a context no leg will ever
+// resolve (the GHPRB jobs simply never created those contexts).
+@Field List windows_branches = ["main", "umbrella", "tentacle", "squid", "reef"]
+@Field List api_branches = ["main", "umbrella", "tentacle", "squid", /feature-.*/]
+@Field List arm64_branches = ["main"]
+
 @Field String pr = ""
 @Field String head_sha = ""
 @Field String target_branch = ""
@@ -59,6 +68,19 @@ def phraseToChecks(String body) {
   if (body =~ /(?i)jenkins\s+test\s+api/)         { hits << "api" }
   if (body =~ /(?i)jenkins\s+test\s+windows/)     { hits << "windows" }
   return hits ? hits.join(" ") : null
+}
+
+def branchAllows(String key, String branch) {
+  if (key == "api") {
+    return api_branches.any { branch ==~ it }
+  }
+  if (key == "windows") {
+    return windows_branches.contains(branch)
+  }
+  if (key == "make-check-arm64") {
+    return arm64_branches.contains(branch)
+  }
+  return true
 }
 
 def ghApi(String path) {
@@ -173,6 +195,17 @@ pipeline {
             return
           }
 
+          // Drop checks the target branch doesn't get (e.g. no API tests
+          // for reef, no arm64 off main).
+          checks = checks.tokenize(" ").findAll {
+            branchAllows(it, target_branch)
+          }.join(" ")
+          if (!checks) {
+            skip_reason = "no requested checks apply to PRs targeting ${target_branch}"
+            currentBuild.description = "PR ${pr}: skipped (${skip_reason})"
+            return
+          }
+
           def approved = pr_labels.contains(approval_label)
           def author_is_member = isOrgMember(author)
           if (event == "issue_comment") {
@@ -208,12 +241,14 @@ pipeline {
       when { expression { !skip_reason && !authorized } }
       steps {
         script {
-          // Leave every check pending so required contexts show what's
-          // blocking, and nothing runs until the label is (re-)added.
+          // Leave every applicable check pending so required contexts show
+          // what's blocking, and nothing runs until the label is (re-)added.
           all_checks.each { key, context ->
-            postStatus(context, "pending",
-              "awaiting '${approval_label}' label from a Ceph developer",
-              "${env.JOB_URL}")
+            if (branchAllows(key, target_branch)) {
+              postStatus(context, "pending",
+                "awaiting '${approval_label}' label from a Ceph developer",
+                "${env.JOB_URL}")
+            }
           }
         }
       }

--- a/ceph-pr-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-pr-pipeline-trigger/build/Jenkinsfile
@@ -23,11 +23,12 @@ import groovy.transform.Field
 // CHECKS tokens -> GitHub status contexts reported by ceph-pr-pipeline.
 // Keep in sync with the "contexts" map in ceph-pr-pipeline/build/Jenkinsfile.
 @Field Map all_checks = [
-  "signed":     "Signed-off-by",
-  "submodules": "Unmodified Submodules",
-  "make-check": "make check",
-  "api":        "ceph API tests",
-  "windows":    "ceph windows tests",
+  "signed":           "Signed-off-by",
+  "submodules":       "Unmodified Submodules",
+  "make-check":       "make check",
+  "make-check-arm64": "make check (arm64)",
+  "api":              "ceph API tests",
+  "windows":          "ceph windows tests",
 ]
 
 @Field String pr = ""
@@ -39,20 +40,22 @@ import groovy.transform.Field
 @Field String skip_reason = ""
 @Field boolean authorized = false
 
-// Map "jenkins test ..." comment phrases to CHECKS tokens.  Returns null when
-// nothing (we run) matches.  "jenkins test make check arm64" is intentionally
-// ignored: arm64 does its own build and stays in ceph-pull-requests-arm64.
+// Map comment phrases to CHECKS tokens.  Returns null when nothing matches
+// (bare "jenkins test" runs nothing -- name the check you want).
+// "jenkins retest" (with or without anything after it) re-runs everything;
+// thanks to the sha-keyed S3 cache, that skips recompilation when the PR
+// head hasn't changed.
 def phraseToChecks(String body) {
-  if (body =~ /(?i)jenkins\s+test\s+make\s+check\s+arm64/) {
-    return null
-  }
-  if (body =~ /(?i)jenkins\s+(test\s+all|retest)\b/) {
+  if (body =~ /(?i)jenkins\s+retest\b/) {
     return all_checks.keySet().join(" ")
   }
   def hits = []
   if (body =~ /(?i)jenkins\s+test\s+signed/)      { hits << "signed" }
   if (body =~ /(?i)jenkins\s+test\s+submodules/)  { hits << "submodules" }
-  if (body =~ /(?i)jenkins\s+test\s+make\s+check/){ hits << "make-check" }
+  // negative lookahead so "make check arm64" doesn't also queue the
+  // x86_64 leg; both can still be named in one comment
+  if (body =~ /(?i)jenkins\s+test\s+make\s+check(?!\s+arm64)/) { hits << "make-check" }
+  if (body =~ /(?i)jenkins\s+test\s+make\s+check\s+arm64/)     { hits << "make-check-arm64" }
   if (body =~ /(?i)jenkins\s+test\s+api/)         { hits << "api" }
   if (body =~ /(?i)jenkins\s+test\s+windows/)     { hits << "windows" }
   return hits ? hits.join(" ") : null

--- a/ceph-pr-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-pr-pipeline-trigger/build/Jenkinsfile
@@ -104,11 +104,39 @@ def isOrgMember(String user) {
   return code == "204"
 }
 
-def removeApprovalLabel() {
+// Same criterion as ceph.git's .github/workflows/author-ci-perms.yml:
+// write or admin permission on ceph/ceph.  Org membership alone is NOT
+// enough there (read-only members get the needs-ci-approval label and the
+// "CI will not run" comment), so it can't be enough here either or the two
+// systems would disagree about whose CI runs.
+def hasCiPermission(String user) {
+  def out = sh(
+    script: "curl -s -u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
+            "-H 'Accept: application/vnd.github+json' " +
+            "'${github_api}/repos/${github_repo}/collaborators/${user}/permission'",
+    returnStdout: true,
+  )
+  def permission = ""
+  try {
+    permission = readJSON(text: out).permission ?: ""
+  } catch (Exception e) {
+    echo "Could not parse permission response for ${user}"
+  }
+  if (permission) {
+    return permission in ["admin", "write"]
+  }
+  // The permission endpoint needs push access for the token; fall back to
+  // org membership rather than locking everyone out, but log it loudly
+  // because the fallback can disagree with author-ci-perms.yml.
+  echo "WARNING: permission lookup failed for ${user}; falling back to org membership"
+  return isOrgMember(user)
+}
+
+def removeLabel(String name) {
   sh(
     script: "curl -s -o /dev/null -X DELETE " +
             "-u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
-            "'${github_api}/repos/${github_repo}/issues/${pr}/labels/${approval_label}'"
+            "'${github_api}/repos/${github_repo}/issues/${pr}/labels/${name}'"
   )
 }
 
@@ -207,23 +235,27 @@ pipeline {
           }
 
           def approved = pr_labels.contains(approval_label)
-          def author_is_member = isOrgMember(author)
+          def author_trusted = hasCiPermission(author)
           if (event == "issue_comment") {
-            authorized = approved || isOrgMember(env.comment_author)
+            authorized = approved || hasCiPermission(env.comment_author)
           } else if (env.action == "labeled") {
             // Adding a label requires triage permission on ceph/ceph, so the
-            // label itself is the approval.
+            // label itself is the approval.  Clear author-ci-perms.yml's
+            // marker so the PR no longer looks blocked.
             authorized = true
+            removeLabel("needs-ci-approval")
           } else if (env.action == "synchronize") {
-            authorized = author_is_member
+            authorized = author_trusted
             if (!authorized && approved) {
               // New commits revoke a previous approval; a Ceph developer must
-              // re-add the label after reviewing the new code.
+              // re-add the label after reviewing the new code.  ceph.git's
+              // author-ci-perms.yml workflow removes it too; whichever side
+              // wins the race, the other's removal 404s harmlessly.
               echo "Removing ${approval_label}: PR was updated after approval"
-              removeApprovalLabel()
+              removeLabel(approval_label)
             }
           } else {  // opened, reopened
-            authorized = author_is_member || approved
+            authorized = author_trusted || approved
           }
           currentBuild.description =
             "PR ${pr} ${env.action ?: 'comment'} by ${author}: " +

--- a/ceph-pr-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-pr-pipeline-trigger/build/Jenkinsfile
@@ -1,0 +1,239 @@
+// Trigger job for ceph-pr-pipeline.  Replaces the GitHub Pull Request Builder
+// plugin: receives pull_request/issue_comment webhooks (via the generic
+// webhook trigger, see the JJB definition) and decides whether/what to run.
+//
+// Policy implemented here:
+//   - PR authors who are members of the "ceph" GitHub org get CI automatically.
+//   - Anyone else needs the "ci-approved" label on the PR.  Pushing new
+//     commits (including force-pushes) removes the label, cancels any running
+//     builds for the PR, and resets the status checks to pending until a Ceph
+//     developer re-adds the label.
+//   - "jenkins test <check>" comments re-run individual checks (org members
+//     always; others only while the PR carries the ci-approved label).
+//   - Any newly triggered run aborts still-running runs for the same PR.
+
+import groovy.transform.Field
+
+@Field String pipeline_job = "ceph-pr-pipeline"
+@Field String github_repo = "ceph/ceph"
+@Field String github_org = "ceph"
+@Field String approval_label = "ci-approved"
+@Field String github_api = "https://api.github.com"
+
+// CHECKS tokens -> GitHub status contexts reported by ceph-pr-pipeline.
+// Keep in sync with the "contexts" map in ceph-pr-pipeline/build/Jenkinsfile.
+@Field Map all_checks = [
+  "signed":     "Signed-off-by",
+  "submodules": "Unmodified Submodules",
+  "make-check": "make check",
+  "api":        "ceph API tests",
+  "windows":    "ceph windows tests",
+]
+
+@Field String pr = ""
+@Field String head_sha = ""
+@Field String target_branch = ""
+@Field String author = ""
+@Field List pr_labels = []
+@Field String checks = ""
+@Field String skip_reason = ""
+@Field boolean authorized = false
+
+// Map "jenkins test ..." comment phrases to CHECKS tokens.  Returns null when
+// nothing (we run) matches.  "jenkins test make check arm64" is intentionally
+// ignored: arm64 does its own build and stays in ceph-pull-requests-arm64.
+def phraseToChecks(String body) {
+  if (body =~ /(?i)jenkins\s+test\s+make\s+check\s+arm64/) {
+    return null
+  }
+  if (body =~ /(?i)jenkins\s+test\s+all\b/) {
+    return all_checks.keySet().join(" ")
+  }
+  def hits = []
+  if (body =~ /(?i)jenkins\s+test\s+signed/)      { hits << "signed" }
+  if (body =~ /(?i)jenkins\s+test\s+submodules/)  { hits << "submodules" }
+  if (body =~ /(?i)jenkins\s+test\s+make\s+check/){ hits << "make-check" }
+  if (body =~ /(?i)jenkins\s+test\s+api/)         { hits << "api" }
+  if (body =~ /(?i)jenkins\s+test\s+windows/)     { hits << "windows" }
+  return hits ? hits.join(" ") : null
+}
+
+def ghApi(String path) {
+  def text = sh(
+    script: "curl -sf -u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
+            "-H 'Accept: application/vnd.github+json' '${github_api}${path}'",
+    returnStdout: true,
+  )
+  return readJSON(text: text)
+}
+
+def isOrgMember(String user) {
+  // 204 = member.  The token's user must itself be an org member for
+  // non-public memberships to be visible.
+  def code = sh(
+    script: "curl -s -o /dev/null -w '%{http_code}' " +
+            "-u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
+            "'${github_api}/orgs/${github_org}/members/${user}'",
+    returnStdout: true,
+  ).trim()
+  return code == "204"
+}
+
+def removeApprovalLabel() {
+  sh(
+    script: "curl -s -o /dev/null -X DELETE " +
+            "-u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
+            "'${github_api}/repos/${github_repo}/issues/${pr}/labels/${approval_label}'"
+  )
+}
+
+def postStatus(String context, String state, String description, String url) {
+  writeFile(
+    file: "status.json",
+    text: groovy.json.JsonOutput.toJson([
+      state: state, context: context, description: description, target_url: url,
+    ])
+  )
+  sh(
+    script: "curl -sf -o /dev/null -X POST " +
+            "-u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
+            "-H 'Accept: application/vnd.github+json' " +
+            "-d @status.json " +
+            "'${github_api}/repos/${github_repo}/statuses/${head_sha}'"
+  )
+}
+
+// Abort running ceph-pr-pipeline builds for this PR.  Needs one-time
+// in-process script approval (Jenkins model access from a sandboxed pipeline).
+@NonCPS
+def cancelRunningPrBuilds(String pr_number) {
+  def job = jenkins.model.Jenkins.get().getItemByFullName(pipeline_job)
+  if (job == null) {
+    return
+  }
+  for (def b : job.getBuilds()) {
+    if (!b.isBuilding()) {
+      continue
+    }
+    def value = b.getAction(hudson.model.ParametersAction.class)
+        ?.getParameter("ghprbPullId")?.getValue()
+    if (value?.toString() == pr_number) {
+      println("Aborting superseded ${pipeline_job} build #${b.getNumber()}")
+      b.getExecutor()?.interrupt(hudson.model.Result.ABORTED)
+    }
+  }
+}
+
+pipeline {
+  agent { label "small" }
+  options { skipDefaultCheckout(true) }
+  environment {
+    GITHUB_STATUS_CREDS = credentials("github-status-check-token")
+  }
+  stages {
+    stage("evaluate event") {
+      steps {
+        script {
+          def event = env.X_GitHub_Event
+          if (event == "issue_comment") {
+            pr = env.issue_number
+            checks = phraseToChecks(env.comment_body ?: "")
+            if (!checks) {
+              skip_reason = "comment did not match any test phrase"
+            }
+          } else {  // pull_request
+            pr = env.pr_number
+            checks = all_checks.keySet().join(" ")
+            if (env.action == "labeled" && env.label_name != approval_label) {
+              skip_reason = "label '${env.label_name}' is not ${approval_label}"
+            }
+            // GHPRB's skip-build-phrase, kept for compatibility
+            if (!skip_reason && (env.pr_body ?: "") =~ /(?im)^jenkins do not test/) {
+              skip_reason = "PR description contains the skip-build phrase"
+            }
+          }
+          if (skip_reason) {
+            currentBuild.description = "PR ${pr}: skipped (${skip_reason})"
+            return
+          }
+
+          def pr_data = ghApi("/repos/${github_repo}/pulls/${pr}")
+          head_sha = pr_data.head.sha
+          target_branch = pr_data.base.ref
+          author = pr_data.user.login
+          pr_labels = pr_data.labels.collect { it.name }
+          if (pr_data.state != "open") {
+            skip_reason = "PR is not open"
+            currentBuild.description = "PR ${pr}: skipped (${skip_reason})"
+            return
+          }
+
+          def approved = pr_labels.contains(approval_label)
+          def author_is_member = isOrgMember(author)
+          if (event == "issue_comment") {
+            authorized = approved || isOrgMember(env.comment_author)
+          } else if (env.action == "labeled") {
+            // Adding a label requires triage permission on ceph/ceph, so the
+            // label itself is the approval.
+            authorized = true
+          } else if (env.action == "synchronize") {
+            authorized = author_is_member
+            if (!authorized && approved) {
+              // New commits revoke a previous approval; a Ceph developer must
+              // re-add the label after reviewing the new code.
+              echo "Removing ${approval_label}: PR was updated after approval"
+              removeApprovalLabel()
+            }
+          } else {  // opened, reopened
+            authorized = author_is_member || approved
+          }
+          currentBuild.description =
+            "PR ${pr} ${env.action ?: 'comment'} by ${author}: " +
+            (authorized ? "triggering [${checks}]" : "not authorized")
+        }
+      }
+    }
+    stage("cancel superseded builds") {
+      when { expression { !skip_reason } }
+      steps {
+        script { cancelRunningPrBuilds(pr) }
+      }
+    }
+    stage("await approval") {
+      when { expression { !skip_reason && !authorized } }
+      steps {
+        script {
+          // Leave every check pending so required contexts show what's
+          // blocking, and nothing runs until the label is (re-)added.
+          all_checks.each { key, context ->
+            postStatus(context, "pending",
+              "awaiting '${approval_label}' label from a Ceph developer",
+              "${env.JOB_URL}")
+          }
+        }
+      }
+    }
+    stage("trigger pipeline") {
+      when { expression { !skip_reason && authorized } }
+      steps {
+        script {
+          all_checks.each { key, context ->
+            if (checks.tokenize(" ").contains(key)) {
+              postStatus(context, "pending", "queued", "${env.JOB_URL}")
+            }
+          }
+          build(
+            job: pipeline_job,
+            wait: false,
+            parameters: [
+              string(name: "ghprbPullId", value: pr),
+              string(name: "HEAD_SHA", value: head_sha),
+              string(name: "TARGET_BRANCH", value: target_branch),
+              string(name: "CHECKS", value: checks),
+            ]
+          )
+        }
+      }
+    }
+  }
+}

--- a/ceph-pr-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-pr-pipeline-trigger/build/Jenkinsfile
@@ -125,7 +125,9 @@ def cancelRunningPrBuilds(String pr_number) {
 }
 
 pipeline {
-  agent { label "small" }
+  // Seconds of curl per event; any free executor will do, and the first
+  // "queued" statuses shouldn't wait for a small-labeled node.
+  agent any
   options { skipDefaultCheckout(true) }
   environment {
     GITHUB_STATUS_CREDS = credentials("github-status-check-token")

--- a/ceph-pr-pipeline-trigger/config/definitions/ceph-pr-pipeline-trigger.yml
+++ b/ceph-pr-pipeline-trigger/config/definitions/ceph-pr-pipeline-trigger.yml
@@ -79,6 +79,6 @@
           #  - pull_request opened/reopened/synchronize
           #  - pull_request labeled, but only for the ci-approved label
           #  - issue_comment created on a PR (issue_is_pr non-empty) containing
-          #    a "jenkins test ..." phrase
-          regex-filter-expression: "(?is)^(pull_request:(opened|reopened|synchronize):.*|pull_request:labeled:ci-approved:.*|issue_comment:created::https[^:]*:.*jenkins\\s+test\\s+.*)$"
+          #    a "jenkins test ..." or "jenkins retest" phrase
+          regex-filter-expression: "(?is)^(pull_request:(opened|reopened|synchronize):.*|pull_request:labeled:ci-approved:.*|issue_comment:created::https[^:]*:.*jenkins\\s+(re)?test\\b.*)$"
           cause: "GitHub $X_GitHub_Event ($action) for PR $pr_number$issue_number"

--- a/ceph-pr-pipeline-trigger/config/definitions/ceph-pr-pipeline-trigger.yml
+++ b/ceph-pr-pipeline-trigger/config/definitions/ceph-pr-pipeline-trigger.yml
@@ -1,0 +1,84 @@
+- job:
+    name: ceph-pr-pipeline-trigger
+    project-type: pipeline
+    quiet-period: 1
+    concurrent: true
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 1000
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/ceph/ceph-build
+            branches:
+              - main
+            shallow-clone: true
+            submodule:
+              disable: true
+            wipe-workspace: true
+      script-path: ceph-pr-pipeline-trigger/build/Jenkinsfile
+      lightweight-checkout: true
+      do-not-fetch-tags: true
+
+    # Replaces the GitHub Pull Request Builder plugin's webhook handling.
+    # Point a repo (or org) webhook at:
+    #   https://jenkins.ceph.com/generic-webhook-trigger/invoke?token=<pipeline-trigger-token>
+    # with the "pull_request" and "issue_comment" events enabled and
+    # content-type application/json.
+    #
+    # All policy (org membership, the ci-approved label, comment phrases,
+    # cancellation of superseded builds) lives in the trigger Jenkinsfile; the
+    # webhook filter below only does coarse event selection so we don't spawn
+    # a build for every comment on every issue.
+    triggers:
+      - generic-webhook-trigger:
+          token: ceph-pr-pipeline-trigger
+          token-credential-id: pipeline-trigger-token
+          print-contrib-var: true
+          silent-response: true
+          header-params:
+            - key: X_GitHub_Event
+              value: ""
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: pr_number
+              value: $.pull_request.number
+            - type: JSONPath
+              key: pr_head_sha
+              value: $.pull_request.head.sha
+            - type: JSONPath
+              key: pr_target_branch
+              value: $.pull_request.base.ref
+            - type: JSONPath
+              key: pr_author
+              value: $.pull_request.user.login
+            - type: JSONPath
+              key: pr_body
+              value: $.pull_request.body
+            - type: JSONPath
+              key: label_name
+              value: $.label.name
+            - type: JSONPath
+              key: issue_number
+              value: $.issue.number
+            - type: JSONPath
+              key: issue_is_pr
+              value: $.issue.pull_request.url
+            - type: JSONPath
+              key: comment_body
+              value: $.comment.body
+            - type: JSONPath
+              key: comment_author
+              value: $.comment.user.login
+          regex-filter-text: $X_GitHub_Event:$action:$label_name:$issue_is_pr:$comment_body
+          # Accept:
+          #  - pull_request opened/reopened/synchronize
+          #  - pull_request labeled, but only for the ci-approved label
+          #  - issue_comment created on a PR (issue_is_pr non-empty) containing
+          #    a "jenkins test ..." phrase
+          regex-filter-expression: "(?is)^(pull_request:(opened|reopened|synchronize):.*|pull_request:labeled:ci-approved:.*|issue_comment:created::https[^:]*:.*jenkins\\s+test\\s+.*)$"
+          cause: "GitHub $X_GitHub_Event ($action) for PR $pr_number$issue_number"

--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -129,8 +129,15 @@ for the same PR (covers manual runs and webhook races).  A build whose
      'method hudson.model.Job getBuilds',
      'method hudson.model.Run getNumber',
      'method hudson.model.Run isBuilding',
+     // On newer cores these resolve to the HistoricalBuild interface instead
+     'method jenkins.model.HistoricalBuild getNumber',
+     'method jenkins.model.HistoricalBuild isBuilding',
      'method hudson.model.Actionable getAction java.lang.Class',
      'method hudson.model.ParametersAction getParameter java.lang.String',
+     // StringParameterValue is the narrow variant; keep only whichever one
+     // the sandbox actually asks for (the broad ParameterValue one can read
+     // password parameters, the narrow one cannot)
+     'method hudson.model.StringParameterValue getValue',
      'method hudson.model.ParameterValue getValue',
      'method hudson.model.Run getExecutor',
      'method hudson.model.Executor interrupt hudson.model.Result',

--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -11,10 +11,12 @@ clone and (for three of them) its own multi-hour build:
 | `make check` | [ceph-pull-requests](../ceph-pull-requests/) | shared build → ctest on its own builder |
 | `ceph API tests` | [ceph-pr-api](../ceph-pr-api/) | shared build → API tests on its own builder |
 | `ceph windows tests` | [ceph-windows-pull-requests](../ceph-windows-pull-requests/) | parallel leg (different binaries, nothing to share) |
+| `make check (arm64)` | [ceph-pull-requests-arm64](../ceph-pull-requests-arm64/) | parallel leg: own build+test on one arm64 node, own cache key |
 
-`make check (arm64)` ([ceph-pull-requests-arm64](../ceph-pull-requests-arm64/))
-deliberately stays a separate job: it can never reuse the x86_64 binaries, so
-folding it in would add matrix complexity for zero savings.
+arm64 can never reuse the x86_64 binaries, so its leg does its own build --
+but it shares the pipeline's gating, cancellation, early pending statuses,
+and the S3 cache (keyed per arch), so re-runs skip the arm64 compile too.
+It builds and tests on a single node because the arm64 pool is small.
 
 The GitHub status contexts are identical to the old jobs, so **branch
 protection rules do not change**.
@@ -36,6 +38,7 @@ webhook (pull_request / issue_comment)
             ├─ Signed-off-by         (small)  GitHub API, no clone
             ├─ Unmodified Submodules (small)  GitHub API, no clone
             ├─ ceph windows tests    (libvirt) own clone + win32 build + tests
+            ├─ build and test (arm64)(arm64)  own clone, restore-or-build + tests
             └─ build and test
                  build ceph          (huge)   ONE clone, bwc -e buildtests,
                  │                            tree → S3 (skipped if cached)
@@ -83,12 +86,11 @@ Implemented in the trigger job:
   the contexts to pending.  The label must be re-added after each push —
   including force-pushes — so approval always refers to reviewed code.
 - Comment phrases (org members always; others only while the label is
-  present):
-  `jenkins retest` (all checks), `jenkins test make check`, `jenkins test api`, `jenkins test windows`,
-  `jenkins test signed`, `jenkins test submodules`, `jenkins test all`.
-  `jenkins test make check arm64` is left to the arm64 job's own GHPRB
-  trigger.  `jenkins do not test` in the PR description still skips
-  auto-builds.
+  present): `jenkins retest ...` re-runs **everything** (the S3 cache makes
+  that cheap for an unchanged head); `jenkins test <check>` runs one leg and
+  requires naming it -- `make check`, `make check arm64`, `api`, `windows`,
+  `signed`, `submodules`.  A bare `jenkins test` runs nothing.  `jenkins do
+  not test` in the PR description still skips auto-builds.
 
 ## Force-push / cancellation
 
@@ -157,8 +159,10 @@ for the same PR (covers manual runs and webhook races).  A build whose
    `https://jenkins.ceph.com/generic-webhook-trigger/invoke?token=<pipeline-trigger-token>`
    for `pull_request` + `issue_comment` events, content type
    `application/json`.
-5. Flip: disable the GHPRB triggers on the five old jobs (keep the jobs for a
-   while for manual reruns/rollback), and remove `STATUS_PREFIX`.
+5. Flip: disable the GHPRB triggers on the six old jobs -- including
+   ceph-pull-requests-arm64, whose check now runs in the pipeline -- (keep
+   the jobs for a while for manual reruns/rollback), and remove
+   `STATUS_PREFIX`.
 6. Add an S3 lifecycle rule expiring `pr-builds/*` after ~7 days (the cache
    is per-PR-head-sha and only useful for re-runs).  Consider a dedicated
    bucket instead of `ceph-sccache` if quota is a concern.

--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -115,9 +115,34 @@ for the same PR (covers manual runs and webhook races).  A build whose
    label removal, and org membership read), `github-readonly-token`,
    `dgalloway-docker-hub`, `ibm-cloud-sccache-bucket`,
    `ceph_win_ci_private_key`.
-2. Deploy the two jobs with JJB.  First runs will prompt for in-process
-   script approvals (the abort-superseded-builds helpers touch
-   `Jenkins.get()` / `rawBuild`); approve them once.
+2. Deploy the two jobs with JJB.  The abort-superseded-builds helpers touch
+   the Jenkins model (`Jenkins.get()` / `rawBuild`), which the sandbox
+   rejects until approved.  Rather than approving one signature per failed
+   run, pre-approve the lot in Manage Jenkins → Script Console:
+
+   ```groovy
+   import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval
+
+   [
+     'method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild',
+     'method hudson.model.Run getParent',
+     'method hudson.model.Job getBuilds',
+     'method hudson.model.Run getNumber',
+     'method hudson.model.Run isBuilding',
+     'method hudson.model.Actionable getAction java.lang.Class',
+     'method hudson.model.ParametersAction getParameter java.lang.String',
+     'method hudson.model.ParameterValue getValue',
+     'method hudson.model.Run getExecutor',
+     'method hudson.model.Executor interrupt hudson.model.Result',
+     'staticField hudson.model.Result ABORTED',
+     'staticMethod jenkins.model.Jenkins get',
+     'method jenkins.model.Jenkins getItemByFullName java.lang.String',
+   ].each { ScriptApproval.get().approveSignature(it) }
+   ```
+
+   If a run still hits a rejection (signature strings can vary slightly by
+   plugin version), approve the exact string it reports at Manage Jenkins →
+   In-process Script Approval and re-run.
 3. Test side by side with the old jobs: run `ceph-pr-pipeline` manually with
    a real PR number and `STATUS_PREFIX=pipeline/` — statuses appear as e.g.
    `pipeline/make check` and the required contexts are untouched.

--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -90,8 +90,10 @@ webhook (pull_request / issue_comment)
    `https://jenkins.ceph.com/generic-webhook-trigger/invoke?token=<pipeline-trigger-token>`
    for `pull_request` + `issue_comment`, content type `application/json`.
 5. Flip: disable the GHPRB triggers on the six old jobs, drop `STATUS_PREFIX`.
-6. Add an S3 lifecycle rule expiring `pr-builds/*` after ~7 days, and
-   (optional) seed reference mirrors for `CEPH_REFERENCE_REPO`.
+6. The cache lives in the dedicated `ceph-pr-builds` bucket (same COS
+   instance as ceph-sccache, so the same credential works) with a
+   bucket-wide 21-day expiry lifecycle rule.  Optionally seed reference
+   mirrors for `CEPH_REFERENCE_REPO`.
 
 ## Known gaps
 

--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -1,0 +1,154 @@
+# ceph-pr-pipeline
+
+One declarative Jenkins pipeline for the ceph.git PR checks that were
+previously five independent freestyle jobs, each doing its own 4-5 minute
+clone and (for three of them) its own multi-hour build:
+
+| Status context | Old job | In the pipeline |
+| --- | --- | --- |
+| `Signed-off-by` | [ceph-pr-commits](../ceph-pr-commits/) | GitHub-API check, no clone, seconds |
+| `Unmodified Submodules` | [ceph-pr-submodules](../ceph-pr-submodules/) | GitHub-API check, no clone, seconds |
+| `make check` | [ceph-pull-requests](../ceph-pull-requests/) | shared build → ctest on its own builder |
+| `ceph API tests` | [ceph-pr-api](../ceph-pr-api/) | shared build → API tests on its own builder |
+| `ceph windows tests` | [ceph-windows-pull-requests](../ceph-windows-pull-requests/) | parallel leg (different binaries, nothing to share) |
+
+`make check (arm64)` ([ceph-pull-requests-arm64](../ceph-pull-requests-arm64/))
+deliberately stays a separate job: it can never reuse the x86_64 binaries, so
+folding it in would add matrix complexity for zero savings.
+
+The GitHub status contexts are identical to the old jobs, so **branch
+protection rules do not change**.
+
+- Job definitions (JJB): [ceph-pr-pipeline.yml](config/definitions/ceph-pr-pipeline.yml),
+  [ceph-pr-pipeline-trigger.yml](../ceph-pr-pipeline-trigger/config/definitions/ceph-pr-pipeline-trigger.yml)
+- Pipeline: [Jenkinsfile](build/Jenkinsfile)
+- Trigger: [ceph-pr-pipeline-trigger/build/Jenkinsfile](../ceph-pr-pipeline-trigger/build/Jenkinsfile)
+- Helper scripts: [pr_checks.sh](build/pr_checks.sh) (API-based quick checks),
+  [s3_cache.sh](build/s3_cache.sh) (build-tree handoff/cache)
+
+## Flow
+
+```
+webhook (pull_request / issue_comment)
+  └─ ceph-pr-pipeline-trigger        gating, cancellation, label handling
+       └─ ceph-pr-pipeline
+            prepare                  (small)  resolve PR, classify changed files
+            ├─ Signed-off-by         (small)  GitHub API, no clone
+            ├─ Unmodified Submodules (small)  GitHub API, no clone
+            ├─ ceph windows tests    (libvirt) own clone + win32 build + tests
+            └─ build and test
+                 build ceph          (huge)   ONE clone, bwc -e buildtests,
+                 │                            tree → S3 (skipped if cached)
+                 ├─ make check       (noble)  tree ← S3, bwc -e tests
+                 └─ ceph API tests   (huge)   tree ← S3, run-backend-api-tests
+```
+
+- **One checkout.** Only the build node and the windows node clone ceph.git.
+  The quick checks and the test legs never clone at all.  Set
+  `CEPH_REFERENCE_REPO` to a local mirror path (maintainable via ansible/cron
+  on the builders) to cut the remaining clones from ~5 minutes to seconds; the
+  git plugin ignores the path on builders that don't have it.
+- **One build.** `build-with-container.py -e buildtests` compiles ceph *with*
+  tests (a superset of what the API tests need — the old ceph-pr-api job
+  built its own tree with `WITH_TESTS=OFF`).  The tree is compiled inside the
+  `DISTRO_BASE` container, so it runs identically on whichever builder the
+  test legs land on.
+- **Binary cache / re-runs.**  The built tree (source + `build/`) is
+  zstd-tarred and uploaded to S3 keyed by `pr-builds/<PR>/<head sha>.tar.zst`.
+  Any re-run for the same head sha — e.g. `jenkins test api` after a flaky
+  failure — skips compilation entirely and reuses the cached tree
+  (`FORCE_BUILD=true` overrides).  sccache still accelerates genuinely new
+  builds.
+- **Statuses.**  Each leg posts pending/success/failure for its own context
+  directly via the GitHub API (`github-status-check-token`); there is no
+  GHPRB plugin involvement.  A failed build posts failure to both `make
+  check` and `ceph API tests` so nothing is left hanging at "queued".
+- **Docs-only PRs** (and container-only, `.github`-only; plus qa-only for
+  windows) skip the heavy legs and report success for their contexts, same as
+  the old jobs.  Signed-off-by switches to the doc-title check for docs-only
+  PRs, mirroring ceph-pr-commits.
+
+## Gating (replaces GHPRB's org whitelist)
+
+Implemented in the trigger job:
+
+- PR author in the **ceph GitHub org** → CI runs automatically on open,
+  reopen and every push.
+- Anyone else → all five contexts are set to pending
+  ("awaiting 'ci-approved' label…") and nothing runs until a Ceph developer
+  adds the **`ci-approved` label** (adding labels requires triage permission,
+  so the label itself is the authorization).
+- **Every push to an approved PR revokes the approval**: the trigger removes
+  `ci-approved`, cancels any running pipeline builds for that PR, and resets
+  the contexts to pending.  The label must be re-added after each push —
+  including force-pushes — so approval always refers to reviewed code.
+- Comment phrases (org members always; others only while the label is
+  present):
+  `jenkins test make check`, `jenkins test api`, `jenkins test windows`,
+  `jenkins test signed`, `jenkins test submodules`, `jenkins test all`.
+  `jenkins test make check arm64` is left to the arm64 job's own GHPRB
+  trigger.  `jenkins do not test` in the PR description still skips
+  auto-builds.
+
+## Force-push / cancellation
+
+A new webhook delivery for a PR (push or retest) makes the trigger abort any
+still-running `ceph-pr-pipeline` builds for that PR number before starting a
+new one, and the pipeline's prepare stage also aborts older builds of itself
+for the same PR (covers manual runs and webhook races).  A build whose
+`HEAD_SHA` no longer matches the PR head aborts itself as superseded.
+
+## Why not GitHub Actions (or a GHA/Jenkins combo)?
+
+- Every heavy check needs our own hardware (huge builders, libvirt hosts);
+  GHA could only ever be a trigger shim in front of Jenkins.
+- `.github/workflows` live in ceph.git per target branch and would need
+  backporting to every stable branch; ceph-build config applies to all
+  branches on merge.
+- Gating/cancellation policy would exist in two systems and drift.
+
+## Rollout
+
+1. Create the `pipeline-trigger-token` secret text credential (any random
+   string) if not already present, and confirm these exist:
+   `github-status-check-token` (needs `repo:status` **and** issues write for
+   label removal, and org membership read), `github-readonly-token`,
+   `dgalloway-docker-hub`, `ibm-cloud-sccache-bucket`,
+   `ceph_win_ci_private_key`.
+2. Deploy the two jobs with JJB.  First runs will prompt for in-process
+   script approvals (the abort-superseded-builds helpers touch
+   `Jenkins.get()` / `rawBuild`); approve them once.
+3. Test side by side with the old jobs: run `ceph-pr-pipeline` manually with
+   a real PR number and `STATUS_PREFIX=pipeline/` — statuses appear as e.g.
+   `pipeline/make check` and the required contexts are untouched.
+4. Add the repo (or org) webhook:
+   `https://jenkins.ceph.com/generic-webhook-trigger/invoke?token=<pipeline-trigger-token>`
+   for `pull_request` + `issue_comment` events, content type
+   `application/json`.
+5. Flip: disable the GHPRB triggers on the five old jobs (keep the jobs for a
+   while for manual reruns/rollback), and remove `STATUS_PREFIX`.
+6. Add an S3 lifecycle rule expiring `pr-builds/*` after ~7 days (the cache
+   is per-PR-head-sha and only useful for re-runs).  Consider a dedicated
+   bucket instead of `ceph-sccache` if quota is a concern.
+7. Optional: seed `/home/jenkins-build/ceph-mirror.git` on the builders and
+   set `CEPH_REFERENCE_REPO` accordingly.
+
+## Known gaps / TODO
+
+- The dashboard-frontend cobertura coverage publishing from
+  ceph-pull-requests is not wired up yet (needs the coverage plugin's
+  pipeline step).
+- The API tests now run **inside the build container** (jammy by default)
+  instead of directly on a noble host; `run-backend-api-tests.sh` in a
+  rootless-podman container needs validating on a real PR before the flip.
+  Daemon-heavy make check tests already run in that container, so this is
+  expected to work.
+- Squid-targeted PRs: the old `ceph-api-squid` job ran on jammy *hosts*; here
+  everything is containerized so the host OS no longer matters, but squid PRs
+  should be spot-checked.
+- The GHPRB "rebuild" button semantics are replaced by re-running the
+  pipeline build (Jenkins "Rebuild" with the same parameters works and will
+  hit the binary cache).
+- `build-with-container.py` names its container `ceph_build`, so two legs of
+  the same (or different) PRs must not share a builder concurrently; with
+  one executor per builder — the current farm setup — this cannot happen.

--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -1,146 +1,77 @@
 # ceph-pr-pipeline
 
-One declarative Jenkins pipeline for the ceph.git PR checks that were
-previously five independent freestyle jobs, each doing its own 4-5 minute
-clone and (for three of them) its own multi-hour build:
+One pipeline for all ceph.git PR checks, replacing the GitHub Pull Request
+Builder plugin and six freestyle jobs.  ceph.git is cloned once and built once
+(x86_64, with tests); the test legs run on separate builders from the shared
+build tree.  The GitHub status contexts are unchanged, so branch protection
+rules don't change.
 
-| Status context | Old job | In the pipeline |
+| Status context | Replaces | How it runs now |
 | --- | --- | --- |
-| `Signed-off-by` | [ceph-pr-commits](../ceph-pr-commits/) | GitHub-API check, no clone, seconds |
-| `Unmodified Submodules` | [ceph-pr-submodules](../ceph-pr-submodules/) | GitHub-API check, no clone, seconds |
+| `Signed-off-by` | [ceph-pr-commits](../ceph-pr-commits/) | GitHub API only, no clone, seconds |
+| `Unmodified Submodules` | [ceph-pr-submodules](../ceph-pr-submodules/) | GitHub API only, no clone, seconds |
 | `make check` | [ceph-pull-requests](../ceph-pull-requests/) | shared build → ctest on its own builder |
 | `ceph API tests` | [ceph-pr-api](../ceph-pr-api/) | shared build → API tests on its own builder |
-| `ceph windows tests` | [ceph-windows-pull-requests](../ceph-windows-pull-requests/) | parallel leg (different binaries, nothing to share) |
-| `make check (arm64)` | [ceph-pull-requests-arm64](../ceph-pull-requests-arm64/) | parallel leg: own build+test on one arm64 node, own cache key |
-
-arm64 can never reuse the x86_64 binaries, so its leg does its own build --
-but it shares the pipeline's gating, cancellation, early pending statuses,
-and the S3 cache (keyed per arch), so re-runs skip the arm64 compile too.
-It builds and tests on a single node because the arm64 pool is small.
-
-The GitHub status contexts are identical to the old jobs, so **branch
-protection rules do not change**.
-
-- Job definitions (JJB): [ceph-pr-pipeline.yml](config/definitions/ceph-pr-pipeline.yml),
-  [ceph-pr-pipeline-trigger.yml](../ceph-pr-pipeline-trigger/config/definitions/ceph-pr-pipeline-trigger.yml)
-- Pipeline: [Jenkinsfile](build/Jenkinsfile)
-- Trigger: [ceph-pr-pipeline-trigger/build/Jenkinsfile](../ceph-pr-pipeline-trigger/build/Jenkinsfile)
-- Helper scripts: [pr_checks.sh](build/pr_checks.sh) (API-based quick checks),
-  [s3_cache.sh](build/s3_cache.sh) (build-tree handoff/cache)
+| `ceph windows tests` | [ceph-windows-pull-requests](../ceph-windows-pull-requests/) | parallel leg, own (win32) build |
+| `make check (arm64)` | [ceph-pull-requests-arm64](../ceph-pull-requests-arm64/) | parallel leg, build+test on one arm64 node |
 
 ## Flow
 
 ```
 webhook (pull_request / issue_comment)
-  └─ ceph-pr-pipeline-trigger        gating, cancellation, label handling
+  └─ ceph-pr-pipeline-trigger         gating, cancellation, label handling
        └─ ceph-pr-pipeline
-            prepare                  (small)  resolve PR, classify changed files
-            ├─ Signed-off-by         (small)  GitHub API, no clone
-            ├─ Unmodified Submodules (small)  GitHub API, no clone
-            ├─ ceph windows tests    (libvirt) own clone + win32 build + tests
-            ├─ build and test (arm64)(arm64)  own clone, restore-or-build + tests
+            prepare                   resolve PR, classify files, post pending statuses
+            ├─ Signed-off-by          GitHub API
+            ├─ Unmodified Submodules  GitHub API
+            ├─ ceph windows tests     (libvirt) own clone + build + tests
+            ├─ build and test (arm64) (arm64)  restore-or-build + tests
             └─ build and test
-                 build ceph          (huge)   ONE clone, bwc -e buildtests,
-                 │                            tree → S3 (skipped if cached)
-                 ├─ make check       (noble)  tree ← S3, bwc -e tests
-                 └─ ceph API tests   (huge)   tree ← S3, run-backend-api-tests
+                 build ceph           (huge)  ONE clone, bwc -e buildtests, tree → S3
+                 ├─ make check        tree ← S3, bwc -e tests
+                 └─ ceph API tests    tree ← S3, run-backend-api-tests (in container)
 ```
 
-- **One checkout.** Only the build node and the windows node clone ceph.git.
-  The quick checks and the test legs never clone at all.  Set
-  `CEPH_REFERENCE_REPO` to a local mirror path (maintainable via ansible/cron
-  on the builders) to cut the remaining clones from ~5 minutes to seconds; the
-  git plugin ignores the path on builders that don't have it.
-- **One build.** `build-with-container.py -e buildtests` compiles ceph *with*
-  tests (a superset of what the API tests need — the old ceph-pr-api job
-  built its own tree with `WITH_TESTS=OFF`).  The tree is compiled inside the
-  `DISTRO_BASE` container, so it runs identically on whichever builder the
-  test legs land on.
-- **Binary cache / re-runs.**  The built tree (source + `build/`) is
-  zstd-tarred and uploaded to S3 keyed by `pr-builds/<PR>/<head sha>.tar.zst`.
-  Any re-run for the same head sha — e.g. `jenkins test api` after a flaky
-  failure — skips compilation entirely and reuses the cached tree
-  (`FORCE_BUILD=true` overrides).  sccache still accelerates genuinely new
-  builds.
-- **Statuses.**  Each leg posts pending/success/failure for its own context
-  directly via the GitHub API (`github-status-check-token`); there is no
-  GHPRB plugin involvement.  A failed build posts failure to both `make
-  check` and `ceph API tests` so nothing is left hanging at "queued".
-- **Docs-only PRs** (and container-only, `.github`-only; plus qa-only for
-  windows) skip the heavy legs and report success for their contexts, same as
-  the old jobs.  Signed-off-by switches to the doc-title check for docs-only
-  PRs, mirroring ceph-pr-commits.
+- **Cache:** build trees are zstd-tarred to S3 as
+  `pr-builds/<PR>/<head sha>.<arch>.tar.zst`.  Re-runs for an unchanged head
+  sha skip compilation (`FORCE_BUILD=true` overrides).
+- **Statuses:** each leg posts its own context via the GitHub API.  Pending
+  is posted from `prepare` before legs wait for executors; canceled/failed
+  runs finalize any still-pending contexts.  Docs/container/gha-only PRs
+  (plus qa-only for windows/arm64) report success without building.
+- **Checkout time:** set `CEPH_REFERENCE_REPO` to a local ceph.git mirror on
+  the builders to cut the remaining clones to seconds.
 
-## Gating (replaces GHPRB's org whitelist)
+## Gating
 
-Implemented in the trigger job:
-
-- PR author in the **ceph GitHub org** → CI runs automatically on open,
-  reopen and every push.
-- Anyone else → all five contexts are set to pending
-  ("awaiting 'ci-approved' label…") and nothing runs until a Ceph developer
-  adds the **`ci-approved` label** (adding labels requires triage permission,
-  so the label itself is the authorization).
-- **Every push to an approved PR revokes the approval**: the trigger removes
-  `ci-approved`, cancels any running pipeline builds for that PR, and resets
-  the contexts to pending.  The label must be re-added after each push —
-  including force-pushes — so approval always refers to reviewed code.
-- Comment phrases (org members always; others only while the label is
-  present): `jenkins retest ...` re-runs **everything** (the S3 cache makes
-  that cheap for an unchanged head); `jenkins test <check>` runs one leg and
-  requires naming it -- `make check`, `make check arm64`, `api`, `windows`,
-  `signed`, `submodules`.  A bare `jenkins test` runs nothing.  `jenkins do
-  not test` in the PR description still skips auto-builds.
-
-## Force-push / cancellation
-
-A new webhook delivery for a PR (push or retest) makes the trigger abort any
-still-running `ceph-pr-pipeline` builds for that PR number before starting a
-new one, and the pipeline's prepare stage also aborts older builds of itself
-for the same PR (covers manual runs and webhook races).  A build whose
-`HEAD_SHA` no longer matches the PR head aborts itself as superseded.
-
-## Why not GitHub Actions (or a GHA/Jenkins combo)?
-
-- Every heavy check needs our own hardware (huge builders, libvirt hosts);
-  GHA could only ever be a trigger shim in front of Jenkins.
-- `.github/workflows` live in ceph.git per target branch and would need
-  backporting to every stable branch; ceph-build config applies to all
-  branches on merge.
-- Gating/cancellation policy would exist in two systems and drift.
+- PR author in the ceph org: CI runs automatically.
+- Otherwise: all contexts wait as pending until a Ceph developer adds the
+  `ci-approved` label.  **Every push removes the label**, cancels running
+  builds, and resets statuses — it must be re-added for the new code.
+- Comment phrases (org members always, others only while labeled):
+  `jenkins retest ...` re-runs everything; `jenkins test <check>` runs one of
+  `make check`, `make check arm64`, `api`, `windows`, `signed`, `submodules`.
+  Bare `jenkins test` runs nothing.
 
 ## Rollout
 
-1. Create the `pipeline-trigger-token` secret text credential (any random
-   string) if not already present, and confirm these exist:
-   `github-status-check-token` (needs `repo:status` **and** issues write for
-   label removal, and org membership read), `github-readonly-token`,
-   `dgalloway-docker-hub`, `ibm-cloud-sccache-bucket`,
-   `ceph_win_ci_private_key`.
-2. Deploy the two jobs with JJB.  The abort-superseded-builds helpers touch
-   the Jenkins model (`Jenkins.get()` / `rawBuild`), which the sandbox
-   rejects until approved.  Rather than approving one signature per failed
-   run, pre-approve the lot in Manage Jenkins → Script Console:
+1. Credentials: `pipeline-trigger-token`, `github-status-check-token`
+   (repo:status + issues write + org read), `github-readonly-token`,
+   `dgalloway-docker-hub`, `ibm-cloud-sccache-bucket`, `ceph_win_ci_private_key`.
+2. Deploy both jobs with JJB, then pre-approve the sandbox signatures in
+   Manage Jenkins → Script Console:
 
    ```groovy
    import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval
-
    [
      'method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild',
      'method hudson.model.Run getParent',
      'method hudson.model.Job getBuilds',
-     'method hudson.model.Run getNumber',
-     'method hudson.model.Run isBuilding',
-     // On newer cores these resolve to the HistoricalBuild interface instead
      'method jenkins.model.HistoricalBuild getNumber',
      'method jenkins.model.HistoricalBuild isBuilding',
      'method hudson.model.Actionable getAction java.lang.Class',
      'method hudson.model.ParametersAction getParameter java.lang.String',
-     // StringParameterValue is the narrow variant; keep only whichever one
-     // the sandbox actually asks for (the broad ParameterValue one can read
-     // password parameters, the narrow one cannot)
      'method hudson.model.StringParameterValue getValue',
-     'method hudson.model.ParameterValue getValue',
      'method hudson.model.Run getExecutor',
      'method hudson.model.Executor interrupt hudson.model.Result',
      'staticField hudson.model.Result ABORTED',
@@ -149,42 +80,22 @@ for the same PR (covers manual runs and webhook races).  A build whose
    ].each { ScriptApproval.get().approveSignature(it) }
    ```
 
-   If a run still hits a rejection (signature strings can vary slightly by
-   plugin version), approve the exact string it reports at Manage Jenkins →
-   In-process Script Approval and re-run.
-3. Test side by side with the old jobs: run `ceph-pr-pipeline` manually with
-   a real PR number and `STATUS_PREFIX=pipeline/` — statuses appear as e.g.
-   `pipeline/make check` and the required contexts are untouched.
-4. Add the repo (or org) webhook:
+   (If a run reports a differently-resolved signature, approve exactly what
+   it prints at In-process Script Approval.)
+3. Test side by side: run `ceph-pr-pipeline` manually with a PR number and
+   `STATUS_PREFIX=pipeline/` so required contexts are untouched.
+4. Add the webhook:
    `https://jenkins.ceph.com/generic-webhook-trigger/invoke?token=<pipeline-trigger-token>`
-   for `pull_request` + `issue_comment` events, content type
-   `application/json`.
-5. Flip: disable the GHPRB triggers on the six old jobs -- including
-   ceph-pull-requests-arm64, whose check now runs in the pipeline -- (keep
-   the jobs for a while for manual reruns/rollback), and remove
-   `STATUS_PREFIX`.
-6. Add an S3 lifecycle rule expiring `pr-builds/*` after ~7 days (the cache
-   is per-PR-head-sha and only useful for re-runs).  Consider a dedicated
-   bucket instead of `ceph-sccache` if quota is a concern.
-7. Optional: seed `/home/jenkins-build/ceph-mirror.git` on the builders and
-   set `CEPH_REFERENCE_REPO` accordingly.
+   for `pull_request` + `issue_comment`, content type `application/json`.
+5. Flip: disable the GHPRB triggers on the six old jobs, drop `STATUS_PREFIX`.
+6. Add an S3 lifecycle rule expiring `pr-builds/*` after ~7 days, and
+   (optional) seed reference mirrors for `CEPH_REFERENCE_REPO`.
 
-## Known gaps / TODO
+## Known gaps
 
-- The dashboard-frontend cobertura coverage publishing from
-  ceph-pull-requests is not wired up yet (needs the coverage plugin's
-  pipeline step).
-- The API tests now run **inside the build container** (jammy by default)
-  instead of directly on a noble host; `run-backend-api-tests.sh` in a
-  rootless-podman container needs validating on a real PR before the flip.
-  Daemon-heavy make check tests already run in that container, so this is
-  expected to work.
-- Squid-targeted PRs: the old `ceph-api-squid` job ran on jammy *hosts*; here
-  everything is containerized so the host OS no longer matters, but squid PRs
-  should be spot-checked.
-- The GHPRB "rebuild" button semantics are replaced by re-running the
-  pipeline build (Jenkins "Rebuild" with the same parameters works and will
-  hit the binary cache).
-- `build-with-container.py` names its container `ceph_build`, so two legs of
-  the same (or different) PRs must not share a builder concurrently; with
-  one executor per builder — the current farm setup — this cannot happen.
+- API tests now run inside the build container (was: bare noble host);
+  validate on a real PR before the flip.
+- Dashboard-frontend cobertura publishing is not wired up yet.
+- A hard kill (double abort) skips `post{}`, so statuses stay pending.
+- `build-with-container.py` names its container `ceph_build`: one leg per
+  builder at a time (true today with single-executor builders).

--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -84,7 +84,7 @@ Implemented in the trigger job:
   including force-pushes — so approval always refers to reviewed code.
 - Comment phrases (org members always; others only while the label is
   present):
-  `jenkins test make check`, `jenkins test api`, `jenkins test windows`,
+  `jenkins retest` (all checks), `jenkins test make check`, `jenkins test api`, `jenkins test windows`,
   `jenkins test signed`, `jenkins test submodules`, `jenkins test all`.
   `jenkins test make check arm64` is left to the arm64 job's own GHPRB
   trigger.  `jenkins do not test` in the PR description still skips

--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -44,9 +44,11 @@ webhook (pull_request / issue_comment)
 
 ## Gating
 
-- PR author in the ceph org: CI runs automatically.
-- Otherwise: all contexts wait as pending until a Ceph developer adds the
-  `ci-approved` label.  **Every push removes the label**, cancels running
+- PR author with write/admin on ceph/ceph (the same check as ceph.git's
+  `author-ci-perms.yml` workflow, which labels/comments on such PRs): CI
+  runs automatically.
+- Otherwise: all applicable contexts wait as pending until a Ceph developer
+  adds the `ci-approved` label (which also clears `needs-ci-approval`).  **Every push removes the label**, cancels running
   builds, and resets statuses — it must be re-added for the new code.
 - Comment phrases (org members always, others only while labeled):
   `jenkins retest ...` re-runs everything; `jenkins test <check>` runs one of

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -390,8 +390,10 @@ pipeline {
     SCCACHE_BUCKET_CREDS = credentials("ibm-cloud-sccache-bucket")
   }
   stages {
+    // agent any, not small: this stage is seconds of curl and posts the
+    // early pending statuses, so grab whatever executor frees up first.
     stage("prepare") {
-      agent { label "small" }
+      agent any
       steps {
         script { doPrepare() }
       }

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -166,6 +166,23 @@ def doPrepare() {
   run_windows = wantCheck("windows") && !windows_skip &&
       windows_branches.contains(env.ghprbTargetBranch)
 
+  // Post pending for every leg that will run NOW, from the small node we're
+  // already holding, so the PR shows all its checks within seconds of the
+  // build starting -- even for legs that will then sit in the queue waiting
+  // for a huge/libvirt executor.  Each leg updates its own description
+  // ("building", "running") as it progresses.
+  [
+    "signed": run_signed,
+    "submodules": run_submodules,
+    "make-check": run_make_check,
+    "api": run_api,
+    "windows": run_windows,
+  ].each { key, will_run ->
+    if (will_run) {
+      postStatus(key, "pending", "queued, waiting for an available builder")
+    }
+  }
+
   // Anything skipped for a doc/container/gha/qa-only PR is reported as
   // success (these contexts are required by branch protection).
   if (wantCheck("make-check") && !run_make_check) {
@@ -231,7 +248,19 @@ EOF
   '''
 }
 
+// The test legs' contexts stay pending through the shared build; keep their
+// descriptions honest about which phase they're actually in.
+def postTestLegStatuses(String description) {
+  if (run_make_check) {
+    postStatus("make-check", "pending", description)
+  }
+  if (run_api) {
+    postStatus("api", "pending", description)
+  }
+}
+
 def doBuild() {
+  postTestLegStatuses("building ceph (shared build)")
   checkoutCephBuild()
   sh "./scripts/setup_container_runtime.sh"
   if (params.FORCE_BUILD) {
@@ -414,6 +443,9 @@ pipeline {
                 script {
                   try {
                     doBuild()
+                    // Covers the gap between the build finishing and the test
+                    // legs acquiring their own executors.
+                    postTestLegStatuses("build ready, waiting for an available test builder")
                   } catch (Exception e) {
                     // The test legs never start, so their contexts would sit
                     // at "queued" forever without this.

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -130,12 +130,15 @@ def abortOlderBuilds() {
   }
 }
 
+// Plain git, not the checkout step: the git plugin adds a "Git Build Data"
+// entry to the build page for every repo it touches, and this helper clone
+// on every node made the build look like it was about ceph-build.git.  With
+// plain git the only Git Build Data left is ceph.git's PR merge revision.
 def checkoutCephBuild() {
-  checkout scmGit(
-    branches: [[name: params.CEPH_BUILD_BRANCH]],
-    userRemoteConfigs: [[url: ceph_build_repo]],
-    extensions: [[$class: 'CleanBeforeCheckout']],
-  )
+  sh """#!/bin/bash -ex
+    rm -rf ceph-build
+    git clone --depth 1 --no-tags -b "${params.CEPH_BUILD_BRANCH}" ${ceph_build_repo} ceph-build
+  """
 }
 
 // One shallow checkout of the PR merge ref into ./ceph.  Point
@@ -145,6 +148,7 @@ def checkoutCephPr() {
   sh "rm -rf ceph"
   checkout scmGit(
     branches: [[name: "origin/pr/${params.ghprbPullId}/merge"]],
+    browser: [$class: 'GithubWeb', repoUrl: 'https://github.com/ceph/ceph'],
     userRemoteConfigs: [[
       url: ceph_repo,
       refspec: "+refs/pull/${params.ghprbPullId}/*:refs/remotes/origin/pr/${params.ghprbPullId}/*",
@@ -182,7 +186,7 @@ def doPrepare() {
   checkoutCephBuild()
   sh """#!/bin/bash -ex
     export GITHUB_USER=\$GITHUB_RO_CREDS_USR GITHUB_PASS=\$GITHUB_RO_CREDS_PSW
-    bash ./ceph-pr-pipeline/build/pr_checks.sh classify
+    bash ./ceph-build/ceph-pr-pipeline/build/pr_checks.sh classify
   """
   def changes = readProperties(file: "pr_changes.properties")
   env.DOCS_ONLY = changes.DOCS_ONLY
@@ -236,7 +240,7 @@ def doSignedCheck() {
   withStatus("signed", "commit signature check") {
     sh """#!/bin/bash -ex
       export GITHUB_USER=\$GITHUB_RO_CREDS_USR GITHUB_PASS=\$GITHUB_RO_CREDS_PSW
-      bash ./ceph-pr-pipeline/build/pr_checks.sh signed
+      bash ./ceph-build/ceph-pr-pipeline/build/pr_checks.sh signed
     """
   }
 }
@@ -246,7 +250,7 @@ def doSubmodulesCheck() {
   withStatus("submodules", "submodule check") {
     sh """#!/bin/bash -ex
       export GITHUB_USER=\$GITHUB_RO_CREDS_USR GITHUB_PASS=\$GITHUB_RO_CREDS_PSW
-      bash ./ceph-pr-pipeline/build/pr_checks.sh submodules
+      bash ./ceph-build/ceph-pr-pipeline/build/pr_checks.sh submodules
     """
   }
 }
@@ -255,9 +259,9 @@ def doSubmodulesCheck() {
 // S3 cache functions, with the cache key for this PR+sha.
 def bwcPreamble() {
   return """#!/bin/bash -ex
-    source ./scripts/build_utils.sh
-    source ./scripts/bwc.sh
-    source ./ceph-pr-pipeline/build/s3_cache.sh
+    source ./ceph-build/scripts/build_utils.sh
+    source ./ceph-build/scripts/bwc.sh
+    source ./ceph-build/ceph-pr-pipeline/build/s3_cache.sh
     export CACHE_ENDPOINT="${cache_endpoint}"
     export CACHE_BUCKET="${cache_bucket}"
     export CACHE_KEY="pr-builds/${params.ghprbPullId}/${env.HEAD_SHA}.tar.zst"
@@ -296,7 +300,7 @@ def postTestLegStatuses(String description) {
 def doBuild() {
   postTestLegStatuses("building ceph (shared build)")
   checkoutCephBuild()
-  sh "./scripts/setup_container_runtime.sh"
+  sh "./ceph-build/scripts/setup_container_runtime.sh"
   if (params.FORCE_BUILD) {
     echo "FORCE_BUILD=true: building even if a cached build exists"
   } else {
@@ -334,7 +338,7 @@ def doBuild() {
 
 def restoreBuildTree() {
   checkoutCephBuild()
-  sh "./scripts/setup_container_runtime.sh"
+  sh "./ceph-build/scripts/setup_container_runtime.sh"
   sh(
     label: "download build tree from cache",
     script: bwcPreamble() + """
@@ -392,15 +396,15 @@ def doWindowsTests() {
     // concatenated these into one shell); check_docs_pr_only is handled by
     // the prepare stage instead.
     sh """#!/bin/bash -ex
-      source ./scripts/build_utils.sh
-      source ./scripts/ceph-windows/setup_libvirt
-      source ./scripts/ceph-windows/setup_libvirt_ubuntu_vm
-      source ./scripts/ceph-windows/win32_build
-      source ./scripts/ceph-windows/cleanup_libvirt_ubuntu_vm
-      source ./scripts/ceph-windows/setup_libvirt_ubuntu_vm
-      source ./scripts/ceph-windows/setup_libvirt_windows_vm
-      source ./scripts/ceph-windows/setup_ceph_vstart
-      source ./scripts/ceph-windows/run_tests
+      source ./ceph-build/scripts/build_utils.sh
+      source ./ceph-build/scripts/ceph-windows/setup_libvirt
+      source ./ceph-build/scripts/ceph-windows/setup_libvirt_ubuntu_vm
+      source ./ceph-build/scripts/ceph-windows/win32_build
+      source ./ceph-build/scripts/ceph-windows/cleanup_libvirt_ubuntu_vm
+      source ./ceph-build/scripts/ceph-windows/setup_libvirt_ubuntu_vm
+      source ./ceph-build/scripts/ceph-windows/setup_libvirt_windows_vm
+      source ./ceph-build/scripts/ceph-windows/setup_ceph_vstart
+      source ./ceph-build/scripts/ceph-windows/run_tests
     """
   }
 }
@@ -461,8 +465,8 @@ pipeline {
             always {
               archiveArtifacts(artifacts: "artifacts/**", allowEmptyArchive: true)
               sh """#!/bin/bash
-                source ./scripts/build_utils.sh
-                source ./scripts/ceph-windows/cleanup
+                source ./ceph-build/scripts/build_utils.sh
+                source ./ceph-build/scripts/ceph-windows/cleanup
               """
             }
           }
@@ -517,8 +521,8 @@ pipeline {
                           doMakeCheck()
                         } finally {
                           sh """#!/bin/bash
-                            source ./scripts/build_utils.sh 2>/dev/null || true
-                            bash ./ceph-pull-requests/build/kill-tests || true
+                            source ./ceph-build/scripts/build_utils.sh 2>/dev/null || true
+                            bash ./ceph-build/ceph-pull-requests/build/kill-tests || true
                             podman rm -f ceph_build 2>/dev/null || true
                             podman unshare chown -R 0:0 "\$WORKSPACE"/ceph 2>/dev/null || true
                           """

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -9,8 +9,9 @@
 // branch protection rules naming them) are unchanged.
 //
 // Triggered by ceph-pr-pipeline-trigger (webhooks) or manually with just a
-// PR number.  make check (arm64) intentionally stays in its own job: it can
-// never share x86_64 binaries, so combining it would buy nothing.
+// PR number.  make check (arm64) runs as its own parallel leg: it can never
+// share the x86_64 binaries, so it builds and tests on a single arm64 node,
+// with its own arch-keyed entry in the S3 cache for re-runs.
 
 import groovy.transform.Field
 
@@ -23,21 +24,24 @@ import groovy.transform.Field
 
 // CHECKS tokens -> GitHub status contexts.  Keep in sync with the trigger.
 @Field Map contexts = [
-  "signed":     "Signed-off-by",
-  "submodules": "Unmodified Submodules",
-  "make-check": "make check",
-  "api":        "ceph API tests",
-  "windows":    "ceph windows tests",
+  "signed":           "Signed-off-by",
+  "submodules":       "Unmodified Submodules",
+  "make-check":       "make check",
+  "make-check-arm64": "make check (arm64)",
+  "api":              "ceph API tests",
+  "windows":          "ceph windows tests",
 ]
 
 // Target-branch restrictions, same as the old freestyle jobs' whitelists.
 @Field List windows_branches = ["main", "umbrella", "tentacle", "squid", "reef"]
 @Field List api_branches = ["main", "umbrella", "tentacle", "squid", /feature-.*/]
+@Field List arm64_branches = ["main"]
 
 // Set by the prepare stage.
 @Field boolean run_signed = false
 @Field boolean run_submodules = false
 @Field boolean run_make_check = false
+@Field boolean run_make_check_arm64 = false
 @Field boolean run_api = false
 @Field boolean run_windows = false
 @Field boolean build_cached = false
@@ -107,6 +111,7 @@ def finalizePendingStatuses(String state, String description) {
     "signed": run_signed,
     "submodules": run_submodules,
     "make-check": run_make_check,
+    "make-check-arm64": run_make_check_arm64,
     "api": run_api,
     "windows": run_windows,
   ].findAll { key, will_run -> will_run && !leg_finalized[key] }.keySet()
@@ -202,14 +207,17 @@ def doPrepare() {
   // windows additionally skips qa/-only changes.  Same as the old jobs.
   def heavy_skip = [changes.DOCS_ONLY, changes.CONTAINER_ONLY, changes.GHA_ONLY]
       .contains("true")
-  def windows_skip = heavy_skip || changes.QA_ONLY == "true"
+  // windows and arm64 additionally skip qa/-only changes
+  def qa_skip = heavy_skip || changes.QA_ONLY == "true"
 
   run_signed = wantCheck("signed")
   run_submodules = wantCheck("submodules")
   run_make_check = wantCheck("make-check") && !heavy_skip
+  run_make_check_arm64 = wantCheck("make-check-arm64") && !qa_skip &&
+      arm64_branches.contains(env.ghprbTargetBranch)
   run_api = wantCheck("api") && !heavy_skip &&
       api_branches.any { env.ghprbTargetBranch ==~ it }
-  run_windows = wantCheck("windows") && !windows_skip &&
+  run_windows = wantCheck("windows") && !qa_skip &&
       windows_branches.contains(env.ghprbTargetBranch)
 
   // Post pending for every leg that will run NOW, from the small node we're
@@ -221,6 +229,7 @@ def doPrepare() {
     "signed": run_signed,
     "submodules": run_submodules,
     "make-check": run_make_check,
+    "make-check-arm64": run_make_check_arm64,
     "api": run_api,
     "windows": run_windows,
   ].each { key, will_run ->
@@ -234,10 +243,14 @@ def doPrepare() {
   if (wantCheck("make-check") && !run_make_check) {
     postStatus("make-check", "success", "no need to run make check")
   }
+  if (wantCheck("make-check-arm64") && qa_skip &&
+      arm64_branches.contains(env.ghprbTargetBranch)) {
+    postStatus("make-check-arm64", "success", "no need to run make check")
+  }
   if (wantCheck("api") && heavy_skip) {
     postStatus("api", "success", "no need to run API tests")
   }
-  if (wantCheck("windows") && windows_skip &&
+  if (wantCheck("windows") && qa_skip &&
       windows_branches.contains(env.ghprbTargetBranch)) {
     postStatus("windows", "success", "no need to run windows tests")
   }
@@ -266,17 +279,22 @@ def doSubmodulesCheck() {
 }
 
 // Shell preamble shared by the build/test legs: ceph-build helpers plus the
-// S3 cache functions, with the cache key for this PR+sha.
-def bwcPreamble() {
+// S3 cache functions, with the cache key for this PR+sha+arch.  Docker Hub
+// creds are exported here (not just in the build stage) because any leg may
+// have to build the bwc builder container image on a node that has never
+// seen this PR's image, and the base image pull must not go anonymous.
+def bwcPreamble(String arch) {
   return """#!/bin/bash -ex
     source ./ceph-build/scripts/build_utils.sh
     source ./ceph-build/scripts/bwc.sh
     source ./ceph-build/ceph-pr-pipeline/build/s3_cache.sh
     export CACHE_ENDPOINT="${cache_endpoint}"
     export CACHE_BUCKET="${cache_bucket}"
-    export CACHE_KEY="pr-builds/${params.ghprbPullId}/${env.HEAD_SHA}.tar.zst"
+    export CACHE_KEY="pr-builds/${params.ghprbPullId}/${env.HEAD_SHA}.${arch}.tar.zst"
     export AWS_ACCESS_KEY_ID="\$SCCACHE_BUCKET_CREDS_USR"
     export AWS_SECRET_ACCESS_KEY="\$SCCACHE_BUCKET_CREDS_PSW"
+    export DOCKER_HUB_USERNAME="\$DOCKER_HUB_CREDS_USR"
+    export DOCKER_HUB_PASSWORD="\$DOCKER_HUB_CREDS_PSW"
     export GIT_BRANCH="origin/pr/${params.ghprbPullId}/merge"
     export NPMCACHE="\${HOME}/npmcache"
   """
@@ -316,7 +334,7 @@ def doBuild() {
     echo "FORCE_BUILD=true: building even if a cached build exists"
   } else {
     build_cached = sh(
-      script: bwcPreamble() + "s3_setup\ns3_cache_exists",
+      script: bwcPreamble("x86_64") + "s3_setup\ns3_cache_exists",
       returnStatus: true,
     ) == 0
   }
@@ -327,9 +345,7 @@ def doBuild() {
   checkoutCephPr()
   sh(
     label: "build ceph (with tests)",
-    script: bwcPreamble() + """
-      export DOCKER_HUB_USERNAME="\$DOCKER_HUB_CREDS_USR"
-      export DOCKER_HUB_PASSWORD="\$DOCKER_HUB_CREDS_PSW"
+    script: bwcPreamble("x86_64") + """
       cd ceph
       ${writeBwcEnvFile()}
       bwc_login
@@ -340,7 +356,7 @@ def doBuild() {
   )
   sh(
     label: "upload build tree to cache",
-    script: bwcPreamble() + """
+    script: bwcPreamble("x86_64") + """
       s3_setup
       s3_cache_put ceph
     """
@@ -353,7 +369,7 @@ def restoreBuildTree() {
   sh "./ceph-build/scripts/setup_container_runtime.sh"
   sh(
     label: "download build tree from cache",
-    script: bwcPreamble() + """
+    script: bwcPreamble("x86_64") + """
       rm -rf ceph
       s3_setup
       s3_cache_get ceph
@@ -361,27 +377,88 @@ def restoreBuildTree() {
   )
 }
 
+// Incremental "build tests" (a near-no-op on a restored or just-built tree)
+// plus the ctest run, failing the leg on any failed test.
+def makeCheckTestsShell(String arch) {
+  return bwcPreamble(arch) + """
+    cd ceph
+    ${writeBwcEnvFile()}
+    bwc_login
+    bwc 4 -e tests
+    sleep 5
+    ps -ef | grep -v jnlp | grep ceph || true
+
+    # "bwc -e tests" exits 0 even when individual tests fail so the CTest
+    # results always get published; fail the leg ourselves.
+    test_xml="\$(find build/Testing -name Test.xml 2>/dev/null)"
+    if [ -n "\$test_xml" ] && grep -q 'Status="failed"' \$test_xml; then
+        echo "CTest reported one or more failed tests."
+        exit 1
+    fi
+  """
+}
+
 def doMakeCheck() {
   restoreBuildTree()
   withStatus("make-check", "make check") {
-    sh(
-      label: "run make check",
-      script: bwcPreamble() + """
-        cd ceph
-        ${writeBwcEnvFile()}
-        bwc 4 -e tests
-        sleep 5
-        ps -ef | grep -v jnlp | grep ceph || true
+    sh(label: "run make check", script: makeCheckTestsShell("x86_64"))
+  }
+}
 
-        # "bwc -e tests" exits 0 even when individual tests fail so the CTest
-        # results always get published; fail the leg ourselves.
-        test_xml="\$(find build/Testing -name Test.xml 2>/dev/null)"
-        if [ -n "\$test_xml" ] && grep -q 'Status="failed"' \$test_xml; then
-            echo "CTest reported one or more failed tests."
-            exit 1
-        fi
-      """
-    )
+// arm64 can't share the x86_64 binaries, so it builds and tests on a single
+// arm64 node (the pool is too small to bother shipping the tarball between
+// builders) -- but it uses the same S3 cache, so a re-run for an unchanged
+// head sha skips the build and goes straight to ctest.
+def doMakeCheckArm64() {
+  logNode()
+  checkoutCephBuild()
+  sh "./ceph-build/scripts/setup_container_runtime.sh"
+  withStatus("make-check-arm64", "make check (arm64)") {
+    def cached = false
+    if (params.FORCE_BUILD) {
+      echo "FORCE_BUILD=true: building even if a cached build exists"
+    } else {
+      cached = sh(
+        script: bwcPreamble("arm64") + "s3_setup\ns3_cache_exists",
+        returnStatus: true,
+      ) == 0
+    }
+    if (cached) {
+      postStatus("make-check-arm64", "pending", "restoring the cached arm64 build")
+      sh(
+        label: "download build tree from cache",
+        script: bwcPreamble("arm64") + """
+          rm -rf ceph
+          s3_setup
+          s3_cache_get ceph
+        """
+      )
+    } else {
+      postStatus("make-check-arm64", "pending", "building ceph (arm64)")
+      checkoutCephPr()
+      sh(
+        label: "build ceph (arm64, with tests)",
+        script: bwcPreamble("arm64") + """
+          cd ceph
+          ${writeBwcEnvFile()}
+          bwc_login
+          bwc_populate_npm_cache
+          bwc 4 -e buildtests
+          npm_cache_info
+        """
+      )
+      // Upload before running the tests so a failed run still leaves a
+      // cached build for "jenkins test make check arm64" to reuse.
+      sh(
+        label: "upload build tree to cache",
+        script: bwcPreamble("arm64") + """
+          s3_setup
+          s3_cache_put ceph
+        """
+      )
+    }
+    postStatus("make-check-arm64", "pending", "running make check (arm64)")
+    sh(label: "run make check (arm64)", script: makeCheckTestsShell("arm64"))
   }
 }
 
@@ -392,7 +469,7 @@ def doApiTests() {
     // custom command runs as root in the container, hence plain apt-get).
     sh(
       label: "run dashboard API tests",
-      script: bwcPreamble() + """
+      script: bwcPreamble("x86_64") + """
         cd ceph
         bwc 3 -e custom -- "apt-get update && apt-get install -y python3-scipy python3-routes && cd src/pybind/mgr/dashboard && timeout 7200 ./run-backend-api-tests.sh"
       """
@@ -437,8 +514,11 @@ pipeline {
     GITHUB_STATUS_CREDS = credentials("github-status-check-token")
     GITHUB_RO_CREDS = credentials("github-readonly-token")
     // Pipeline-level so the scripted-parallel test legs (which can't use a
-    // stage environment{} block) get the S3 cache credentials too.
+    // stage environment{} block) get these too: any leg may need the S3
+    // cache, and any leg may have to (re)build the bwc container image,
+    // which pulls the base image from Docker Hub.
     SCCACHE_BUCKET_CREDS = credentials("ibm-cloud-sccache-bucket")
+    DOCKER_HUB_CREDS = credentials("dgalloway-docker-hub")
   }
   stages {
     // agent any, not small: this stage is seconds of curl and posts the
@@ -465,6 +545,27 @@ pipeline {
             script { doSubmodulesCheck() }
           }
         }
+        stage("build and test (arm64)") {
+          when { beforeAgent true; expression { run_make_check_arm64 } }
+          agent { label "arm64 && (installed-os-noble || centos9)" }
+          steps {
+            script { doMakeCheckArm64() }
+          }
+          post {
+            always {
+              sh """#!/bin/bash
+                bash ./ceph-build/ceph-pull-requests-arm64/build/kill-tests || true
+                podman rm -f ceph_build 2>/dev/null || true
+                podman unshare chown -R 0:0 "\$WORKSPACE"/ceph 2>/dev/null || true
+              """
+              xunit(
+                thresholds: [failed(failureThreshold: "0", unstableThreshold: "0")],
+                tools: [CTest(pattern: "ceph/build/Testing/**/Test.xml",
+                              skipNoTestFiles: true, failIfNotNew: false)]
+              )
+            }
+          }
+        }
         stage("ceph windows tests") {
           when { beforeAgent true; expression { run_windows } }
           agent { label "x86_64 && (installed-os-noble || installed-os-jammy) && libvirt" }
@@ -489,9 +590,6 @@ pipeline {
           stages {
             stage("build ceph") {
               agent { label "huge && x86_64 && installed-os-noble && !smithi" }
-              environment {
-                DOCKER_HUB_CREDS = credentials("dgalloway-docker-hub")
-              }
               steps {
                 script {
                   try {

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -20,7 +20,11 @@ import groovy.transform.Field
 @Field String ceph_repo = "https://github.com/ceph/ceph.git"
 @Field String ceph_build_repo = "https://github.com/ceph/ceph-build"
 @Field String cache_endpoint = "https://s3.us-south.cloud-object-storage.appdomain.cloud"
-@Field String cache_bucket = "ceph-sccache"
+// Dedicated bucket (same COS instance as ceph-sccache, so the existing
+// ibm-cloud-sccache-bucket credential works): keeps the pipeline's few huge
+// short-lived objects out of sccache's object store, gives it its own
+// bucket-wide 21-day expiry, and makes bucket usage == pipeline usage.
+@Field String cache_bucket = "ceph-pr-builds"
 
 // CHECKS tokens -> GitHub status contexts.  Keep in sync with the trigger.
 @Field Map contexts = [

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -1,0 +1,489 @@
+// ceph-pr-pipeline: one pipeline for the ceph.git PR checks that used to be
+// five freestyle jobs (ceph-pr-commits, ceph-pr-submodules,
+// ceph-pull-requests, ceph-pr-api, ceph-windows-pull-requests).
+//
+// The ceph tree is checked out and compiled (with tests) ONCE; the make check
+// and API test legs then run on separate builders from the shared build tree,
+// which is moved between builders (and cached for re-runs) via S3.  Each leg
+// posts its own GitHub commit status, so the five status contexts (and any
+// branch protection rules naming them) are unchanged.
+//
+// Triggered by ceph-pr-pipeline-trigger (webhooks) or manually with just a
+// PR number.  make check (arm64) intentionally stays in its own job: it can
+// never share x86_64 binaries, so combining it would buy nothing.
+
+import groovy.transform.Field
+
+@Field String github_repo = "ceph/ceph"
+@Field String github_api = "https://api.github.com"
+@Field String ceph_repo = "https://github.com/ceph/ceph.git"
+@Field String ceph_build_repo = "https://github.com/ceph/ceph-build"
+@Field String cache_endpoint = "https://s3.us-south.cloud-object-storage.appdomain.cloud"
+@Field String cache_bucket = "ceph-sccache"
+
+// CHECKS tokens -> GitHub status contexts.  Keep in sync with the trigger.
+@Field Map contexts = [
+  "signed":     "Signed-off-by",
+  "submodules": "Unmodified Submodules",
+  "make-check": "make check",
+  "api":        "ceph API tests",
+  "windows":    "ceph windows tests",
+]
+
+// Target-branch restrictions, same as the old freestyle jobs' whitelists.
+@Field List windows_branches = ["main", "umbrella", "tentacle", "squid", "reef"]
+@Field List api_branches = ["main", "umbrella", "tentacle", "squid", /feature-.*/]
+
+// Set by the prepare stage.
+@Field boolean run_signed = false
+@Field boolean run_submodules = false
+@Field boolean run_make_check = false
+@Field boolean run_api = false
+@Field boolean run_windows = false
+@Field boolean build_cached = false
+
+def wantCheck(String key) {
+  return params.CHECKS.tokenize(" ").contains(key)
+}
+
+def postStatus(String key, String state, String description) {
+  writeFile(file: "status.json", text: groovy.json.JsonOutput.toJson([
+    state: state,
+    context: "${params.STATUS_PREFIX}${contexts[key]}",
+    description: description,
+    target_url: env.BUILD_URL,
+  ]))
+  sh(
+    label: "GitHub status: ${contexts[key]} -> ${state}",
+    script: "curl -sf -o /dev/null -X POST " +
+            "-u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
+            "-H 'Accept: application/vnd.github+json' -d @status.json " +
+            "'${github_api}/repos/${github_repo}/statuses/${env.HEAD_SHA}'"
+  )
+}
+
+// Run a leg with pending/success/failure statuses around it.
+def withStatus(String key, String label, Closure body) {
+  postStatus(key, "pending", "running ${label}")
+  try {
+    body()
+    postStatus(key, "success", "${label} succeeded")
+  } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+    postStatus(key, "error", "${label} aborted")
+    throw e
+  } catch (Exception e) {
+    postStatus(key, "failure", "${label} failed")
+    throw e
+  }
+}
+
+// Abort older still-running builds of this job for the same PR (the trigger
+// also does this, but manual/raced runs are covered here).  Needs one-time
+// in-process script approval.
+@NonCPS
+def abortOlderBuilds() {
+  def me = currentBuild.rawBuild
+  for (def b : me.getParent().getBuilds()) {
+    if (b.getNumber() >= me.getNumber() || !b.isBuilding()) {
+      continue
+    }
+    def value = b.getAction(hudson.model.ParametersAction.class)
+        ?.getParameter("ghprbPullId")?.getValue()
+    if (value?.toString() == params.ghprbPullId) {
+      println("Aborting superseded build #${b.getNumber()}")
+      b.getExecutor()?.interrupt(hudson.model.Result.ABORTED)
+    }
+  }
+}
+
+def checkoutCephBuild() {
+  checkout scmGit(
+    branches: [[name: params.CEPH_BUILD_BRANCH]],
+    userRemoteConfigs: [[url: ceph_build_repo]],
+    extensions: [[$class: 'CleanBeforeCheckout']],
+  )
+}
+
+// One shallow checkout of the PR merge ref into ./ceph.  Point
+// CEPH_REFERENCE_REPO at a local mirror to cut the 4-5 minute clone down to
+// seconds (the git plugin silently skips a reference path that doesn't exist).
+def checkoutCephPr() {
+  sh "rm -rf ceph"
+  checkout scmGit(
+    branches: [[name: "origin/pr/${params.ghprbPullId}/merge"]],
+    userRemoteConfigs: [[
+      url: ceph_repo,
+      refspec: "+refs/pull/${params.ghprbPullId}/*:refs/remotes/origin/pr/${params.ghprbPullId}/*",
+    ]],
+    extensions: [
+      [$class: 'RelativeTargetDirectory', relativeTargetDir: 'ceph'],
+      [$class: 'CloneOption', shallow: true, noTags: true, honorRefspec: true,
+       timeout: 20, reference: params.CEPH_REFERENCE_REPO ?: ''],
+    ],
+  )
+}
+
+def doPrepare() {
+  abortOlderBuilds()
+  def pr_data = readJSON(text: sh(
+    script: "curl -sf -u \$GITHUB_RO_CREDS_USR:\$GITHUB_RO_CREDS_PSW " +
+            "-H 'Accept: application/vnd.github+json' " +
+            "'${github_api}/repos/${github_repo}/pulls/${params.ghprbPullId}'",
+    returnStdout: true,
+  ))
+  if (params.HEAD_SHA && params.HEAD_SHA != pr_data.head.sha) {
+    // The PR moved between the webhook and this build starting; the trigger
+    // has (or will have) started a build for the new head.
+    error("PR head is now ${pr_data.head.sha}, this build is for ${params.HEAD_SHA}; superseded")
+  }
+  env.HEAD_SHA = pr_data.head.sha
+  env.ghprbTargetBranch = pr_data.base.ref
+  env.ghprbActualCommit = env.HEAD_SHA
+  currentBuild.description = """\
+    <a href="https://github.com/${github_repo}/pull/${params.ghprbPullId}">PR ${params.ghprbPullId}</a>
+    (${pr_data.base.ref}) @ ${env.HEAD_SHA[0..7]}<br />
+    CHECKS=${params.CHECKS}
+  """.stripIndent()
+
+  checkoutCephBuild()
+  sh """#!/bin/bash -ex
+    export GITHUB_USER=\$GITHUB_RO_CREDS_USR GITHUB_PASS=\$GITHUB_RO_CREDS_PSW
+    bash ./ceph-pr-pipeline/build/pr_checks.sh classify
+  """
+  def changes = readProperties(file: "pr_changes.properties")
+  env.DOCS_ONLY = changes.DOCS_ONLY
+  // docs/, container/ or .github/-only changes need no binaries at all;
+  // windows additionally skips qa/-only changes.  Same as the old jobs.
+  def heavy_skip = [changes.DOCS_ONLY, changes.CONTAINER_ONLY, changes.GHA_ONLY]
+      .contains("true")
+  def windows_skip = heavy_skip || changes.QA_ONLY == "true"
+
+  run_signed = wantCheck("signed")
+  run_submodules = wantCheck("submodules")
+  run_make_check = wantCheck("make-check") && !heavy_skip
+  run_api = wantCheck("api") && !heavy_skip &&
+      api_branches.any { env.ghprbTargetBranch ==~ it }
+  run_windows = wantCheck("windows") && !windows_skip &&
+      windows_branches.contains(env.ghprbTargetBranch)
+
+  // Anything skipped for a doc/container/gha/qa-only PR is reported as
+  // success (these contexts are required by branch protection).
+  if (wantCheck("make-check") && !run_make_check) {
+    postStatus("make-check", "success", "no need to run make check")
+  }
+  if (wantCheck("api") && heavy_skip) {
+    postStatus("api", "success", "no need to run API tests")
+  }
+  if (wantCheck("windows") && windows_skip &&
+      windows_branches.contains(env.ghprbTargetBranch)) {
+    postStatus("windows", "success", "no need to run windows tests")
+  }
+}
+
+def doSignedCheck() {
+  checkoutCephBuild()
+  withStatus("signed", "commit signature check") {
+    sh """#!/bin/bash -ex
+      export GITHUB_USER=\$GITHUB_RO_CREDS_USR GITHUB_PASS=\$GITHUB_RO_CREDS_PSW
+      bash ./ceph-pr-pipeline/build/pr_checks.sh signed
+    """
+  }
+}
+
+def doSubmodulesCheck() {
+  checkoutCephBuild()
+  withStatus("submodules", "submodule check") {
+    sh """#!/bin/bash -ex
+      export GITHUB_USER=\$GITHUB_RO_CREDS_USR GITHUB_PASS=\$GITHUB_RO_CREDS_PSW
+      bash ./ceph-pr-pipeline/build/pr_checks.sh submodules
+    """
+  }
+}
+
+// Shell preamble shared by the build/test legs: ceph-build helpers plus the
+// S3 cache functions, with the cache key for this PR+sha.
+def bwcPreamble() {
+  return """#!/bin/bash -ex
+    source ./scripts/build_utils.sh
+    source ./scripts/bwc.sh
+    source ./ceph-pr-pipeline/build/s3_cache.sh
+    export CACHE_ENDPOINT="${cache_endpoint}"
+    export CACHE_BUCKET="${cache_bucket}"
+    export CACHE_KEY="pr-builds/${params.ghprbPullId}/${env.HEAD_SHA}.tar.zst"
+    export AWS_ACCESS_KEY_ID="\$SCCACHE_BUCKET_CREDS_USR"
+    export AWS_SECRET_ACCESS_KEY="\$SCCACHE_BUCKET_CREDS_PSW"
+    export GIT_BRANCH="origin/pr/${params.ghprbPullId}/merge"
+    export NPMCACHE="\${HOME}/npmcache"
+  """
+}
+
+def writeBwcEnvFile() {
+  return '''
+    NPROC=$(nproc)
+    cat > .env << EOF
+NPROC=${NPROC}
+MAX_PARALLEL_JOBS=${NPROC}
+WITH_CRIMSON=true
+WITH_RBD_RWL=true
+JENKINS_HOME=${JENKINS_HOME}
+REWRITE_COVERAGE_ROOTDIR=${PWD}/src/pybind/mgr/dashboard/frontend
+EOF
+  '''
+}
+
+def doBuild() {
+  checkoutCephBuild()
+  sh "./scripts/setup_container_runtime.sh"
+  if (params.FORCE_BUILD) {
+    echo "FORCE_BUILD=true: building even if a cached build exists"
+  } else {
+    build_cached = sh(
+      script: bwcPreamble() + "s3_setup\ns3_cache_exists",
+      returnStatus: true,
+    ) == 0
+  }
+  if (build_cached) {
+    echo "Reusing the cached build for ${env.HEAD_SHA} (FORCE_BUILD=true to rebuild)"
+    return
+  }
+  checkoutCephPr()
+  sh(
+    label: "build ceph (with tests)",
+    script: bwcPreamble() + """
+      export DOCKER_HUB_USERNAME="\$DOCKER_HUB_CREDS_USR"
+      export DOCKER_HUB_PASSWORD="\$DOCKER_HUB_CREDS_PSW"
+      cd ceph
+      ${writeBwcEnvFile()}
+      bwc_login
+      bwc_populate_npm_cache
+      bwc 4 -e buildtests
+      npm_cache_info
+    """
+  )
+  sh(
+    label: "upload build tree to cache",
+    script: bwcPreamble() + """
+      s3_setup
+      s3_cache_put ceph
+    """
+  )
+}
+
+def restoreBuildTree() {
+  checkoutCephBuild()
+  sh "./scripts/setup_container_runtime.sh"
+  sh(
+    label: "download build tree from cache",
+    script: bwcPreamble() + """
+      rm -rf ceph
+      s3_setup
+      s3_cache_get ceph
+    """
+  )
+}
+
+def doMakeCheck() {
+  restoreBuildTree()
+  withStatus("make-check", "make check") {
+    sh(
+      label: "run make check",
+      script: bwcPreamble() + """
+        cd ceph
+        ${writeBwcEnvFile()}
+        bwc 4 -e tests
+        sleep 5
+        ps -ef | grep -v jnlp | grep ceph || true
+
+        # "bwc -e tests" exits 0 even when individual tests fail so the CTest
+        # results always get published; fail the leg ourselves.
+        test_xml="\$(find build/Testing -name Test.xml 2>/dev/null)"
+        if [ -n "\$test_xml" ] && grep -q 'Status="failed"' \$test_xml; then
+            echo "CTest reported one or more failed tests."
+            exit 1
+        fi
+      """
+    )
+  }
+}
+
+def doApiTests() {
+  restoreBuildTree()
+  withStatus("api", "ceph API tests") {
+    // Runs inside the same build container the tree was compiled in (the
+    // custom command runs as root in the container, hence plain apt-get).
+    sh(
+      label: "run dashboard API tests",
+      script: bwcPreamble() + """
+        cd ceph
+        bwc 3 -e custom -- "apt-get update && apt-get install -y python3-scipy python3-routes && cd src/pybind/mgr/dashboard && timeout 7200 ./run-backend-api-tests.sh"
+      """
+    )
+  }
+}
+
+def doWindowsTests() {
+  checkoutCephBuild()
+  checkoutCephPr()
+  withStatus("windows", "ceph windows tests") {
+    // Same script chain as the old ceph-windows-pull-requests job (which
+    // concatenated these into one shell); check_docs_pr_only is handled by
+    // the prepare stage instead.
+    sh """#!/bin/bash -ex
+      source ./scripts/build_utils.sh
+      source ./scripts/ceph-windows/setup_libvirt
+      source ./scripts/ceph-windows/setup_libvirt_ubuntu_vm
+      source ./scripts/ceph-windows/win32_build
+      source ./scripts/ceph-windows/cleanup_libvirt_ubuntu_vm
+      source ./scripts/ceph-windows/setup_libvirt_ubuntu_vm
+      source ./scripts/ceph-windows/setup_libvirt_windows_vm
+      source ./scripts/ceph-windows/setup_ceph_vstart
+      source ./scripts/ceph-windows/run_tests
+    """
+  }
+}
+
+pipeline {
+  agent none
+  options {
+    skipDefaultCheckout(true)
+    timeout(time: 8, unit: "HOURS")
+    timestamps()
+  }
+  environment {
+    TERM = "xterm"
+    ghprbPullId = "${params.ghprbPullId}"
+    ghprbGhRepository = "ceph/ceph"
+    DISTRO_BASE = "${params.DISTRO_BASE}"
+    GITHUB_STATUS_CREDS = credentials("github-status-check-token")
+    GITHUB_RO_CREDS = credentials("github-readonly-token")
+    // Pipeline-level so the scripted-parallel test legs (which can't use a
+    // stage environment{} block) get the S3 cache credentials too.
+    SCCACHE_BUCKET_CREDS = credentials("ibm-cloud-sccache-bucket")
+  }
+  stages {
+    stage("prepare") {
+      agent { label "small" }
+      steps {
+        script { doPrepare() }
+      }
+    }
+    stage("run checks") {
+      parallel {
+        stage("Signed-off-by") {
+          when { beforeAgent true; expression { run_signed } }
+          agent { label "small" }
+          steps {
+            script { doSignedCheck() }
+          }
+        }
+        stage("Unmodified Submodules") {
+          when { beforeAgent true; expression { run_submodules } }
+          agent { label "small" }
+          steps {
+            script { doSubmodulesCheck() }
+          }
+        }
+        stage("ceph windows tests") {
+          when { beforeAgent true; expression { run_windows } }
+          agent { label "x86_64 && (installed-os-noble || installed-os-jammy) && libvirt" }
+          environment {
+            CEPH_WIN_CI_KEY = credentials("ceph_win_ci_private_key")
+          }
+          steps {
+            script { doWindowsTests() }
+          }
+          post {
+            always {
+              archiveArtifacts(artifacts: "artifacts/**", allowEmptyArchive: true)
+              sh """#!/bin/bash
+                source ./scripts/build_utils.sh
+                source ./scripts/ceph-windows/cleanup
+              """
+            }
+          }
+        }
+        stage("build and test") {
+          when { beforeAgent true; expression { run_make_check || run_api } }
+          stages {
+            stage("build ceph") {
+              agent { label "huge && x86_64 && installed-os-noble && !smithi" }
+              environment {
+                DOCKER_HUB_CREDS = credentials("dgalloway-docker-hub")
+              }
+              steps {
+                script {
+                  try {
+                    doBuild()
+                  } catch (Exception e) {
+                    // The test legs never start, so their contexts would sit
+                    // at "queued" forever without this.
+                    if (run_make_check) {
+                      postStatus("make-check", "failure", "the ceph build failed")
+                    }
+                    if (run_api) {
+                      postStatus("api", "failure", "the ceph build failed")
+                    }
+                    throw e
+                  }
+                }
+              }
+              post {
+                always {
+                  sh 'podman unshare chown -R 0:0 "$WORKSPACE"/ceph 2>/dev/null || true'
+                }
+              }
+            }
+            stage("run tests") {
+              agent none
+              steps {
+                script {
+                  def legs = [:]
+                  if (run_make_check) {
+                    legs["make check"] = {
+                      node("x86_64 && installed-os-noble && !smithi") {
+                        try {
+                          doMakeCheck()
+                        } finally {
+                          sh """#!/bin/bash
+                            source ./scripts/build_utils.sh 2>/dev/null || true
+                            bash ./ceph-pull-requests/build/kill-tests || true
+                            podman rm -f ceph_build 2>/dev/null || true
+                            podman unshare chown -R 0:0 "\$WORKSPACE"/ceph 2>/dev/null || true
+                          """
+                          xunit(
+                            thresholds: [failed(failureThreshold: "0", unstableThreshold: "0")],
+                            tools: [CTest(pattern: "ceph/build/Testing/**/Test.xml",
+                                          skipNoTestFiles: true, failIfNotNew: false)]
+                          )
+                        }
+                      }
+                    }
+                  }
+                  if (run_api) {
+                    legs["ceph API tests"] = {
+                      node("huge && x86_64 && installed-os-noble && !smithi") {
+                        try {
+                          doApiTests()
+                        } finally {
+                          archiveArtifacts(artifacts: "ceph/build/out/*.log",
+                                           allowEmptyArchive: true)
+                          sh """#!/bin/bash
+                            podman rm -f ceph_build 2>/dev/null || true
+                            podman unshare chown -R 0:0 "\$WORKSPACE"/ceph 2>/dev/null || true
+                          """
+                        }
+                      }
+                    }
+                  }
+                  if (legs) {
+                    parallel legs
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -49,6 +49,13 @@ def wantCheck(String key) {
   return params.CHECKS.tokenize(" ").contains(key)
 }
 
+// First thing on every node: say where we're running (node names look like
+// "172.21.2.22+braggi22").
+def logNode() {
+  def shortname = env.NODE_NAME.split('\\+')[-1]
+  echo "Running on ${shortname} (${env.JENKINS_URL}computer/${env.NODE_NAME}/)"
+}
+
 def postStatus(String key, String state, String description) {
   // Nothing to post against until prepare has resolved the head sha (e.g. a
   // build aborted while still in prepare).
@@ -162,6 +169,7 @@ def checkoutCephPr() {
 }
 
 def doPrepare() {
+  logNode()
   abortOlderBuilds()
   def pr_data = readJSON(text: sh(
     script: "curl -sf -u \$GITHUB_RO_CREDS_USR:\$GITHUB_RO_CREDS_PSW " +
@@ -236,6 +244,7 @@ def doPrepare() {
 }
 
 def doSignedCheck() {
+  logNode()
   checkoutCephBuild()
   withStatus("signed", "commit signature check") {
     sh """#!/bin/bash -ex
@@ -246,6 +255,7 @@ def doSignedCheck() {
 }
 
 def doSubmodulesCheck() {
+  logNode()
   checkoutCephBuild()
   withStatus("submodules", "submodule check") {
     sh """#!/bin/bash -ex
@@ -298,6 +308,7 @@ def postTestLegStatuses(String description) {
 }
 
 def doBuild() {
+  logNode()
   postTestLegStatuses("building ceph (shared build)")
   checkoutCephBuild()
   sh "./ceph-build/scripts/setup_container_runtime.sh"
@@ -337,6 +348,7 @@ def doBuild() {
 }
 
 def restoreBuildTree() {
+  logNode()
   checkoutCephBuild()
   sh "./ceph-build/scripts/setup_container_runtime.sh"
   sh(
@@ -389,6 +401,7 @@ def doApiTests() {
 }
 
 def doWindowsTests() {
+  logNode()
   checkoutCephBuild()
   checkoutCephPr()
   withStatus("windows", "ceph windows tests") {

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -41,12 +41,23 @@ import groovy.transform.Field
 @Field boolean run_api = false
 @Field boolean run_windows = false
 @Field boolean build_cached = false
+// context key -> true once a terminal (non-pending) status was posted, so the
+// abort/failure sweep in post{} only finalizes contexts still left pending.
+@Field Map leg_finalized = [:]
 
 def wantCheck(String key) {
   return params.CHECKS.tokenize(" ").contains(key)
 }
 
 def postStatus(String key, String state, String description) {
+  // Nothing to post against until prepare has resolved the head sha (e.g. a
+  // build aborted while still in prepare).
+  if (!env.HEAD_SHA) {
+    return
+  }
+  if (state != "pending") {
+    leg_finalized[key] = true
+  }
   writeFile(file: "status.json", text: groovy.json.JsonOutput.toJson([
     state: state,
     context: "${params.STATUS_PREFIX}${contexts[key]}",
@@ -74,6 +85,29 @@ def withStatus(String key, String label, Closure body) {
   } catch (Exception e) {
     postStatus(key, "failure", "${label} failed")
     throw e
+  }
+}
+
+// Post a terminal status for every selected context that never got one, so a
+// canceled/failed run doesn't leave checks pending on the PR forever.  Runs
+// from post{}, which has no agent, so it grabs one itself; best-effort by
+// nature (a hard kill skips post{} entirely).
+def finalizePendingStatuses(String state, String description) {
+  if (!env.HEAD_SHA) {
+    return
+  }
+  def pending = [
+    "signed": run_signed,
+    "submodules": run_submodules,
+    "make-check": run_make_check,
+    "api": run_api,
+    "windows": run_windows,
+  ].findAll { key, will_run -> will_run && !leg_finalized[key] }.keySet()
+  if (!pending) {
+    return
+  }
+  node {
+    pending.each { postStatus(it, state, description) }
   }
 }
 
@@ -448,6 +482,10 @@ pipeline {
                     // Covers the gap between the build finishing and the test
                     // legs acquiring their own executors.
                     postTestLegStatuses("build ready, waiting for an available test builder")
+                  } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+                    // Canceled, not failed; the post{aborted} sweep posts the
+                    // right thing for the never-started test legs.
+                    throw e
                   } catch (Exception e) {
                     // The test legs never start, so their contexts would sit
                     // at "queued" forever without this.
@@ -518,6 +556,14 @@ pipeline {
           }
         }
       }
+    }
+  }
+  post {
+    aborted {
+      script { finalizePendingStatuses("error", "canceled") }
+    }
+    failure {
+      script { finalizePendingStatuses("error", "did not run: the pipeline failed earlier") }
     }
   }
 }

--- a/ceph-pr-pipeline/build/pr_checks.sh
+++ b/ceph-pr-pipeline/build/pr_checks.sh
@@ -28,29 +28,26 @@ gh_api() {
 }
 
 # Paginate a list endpoint ($1, e.g. "pulls/123/files") and emit one combined
-# JSON array on stdout.  The commits endpoint caps at 250 entries and files at
-# 3000, same limits the GHPRB-era shallow-clone checks effectively had.
+# JSON array on stdout.  Pages are flattened to one-element-per-line NDJSON
+# (jq -c '.[]') and reassembled with jq -s, which is valid regardless of how
+# many elements each page has.  The commits endpoint caps at 250 entries and
+# files at 3000, same limits the GHPRB-era shallow-clone checks effectively
+# had.
 gh_api_list() {
     local endpoint=$1
     local page=1
-    local sep=""
-    echo "["
-    while true; do
-        local chunk
-        chunk=$(gh_api "${GH_API}/${endpoint}?per_page=100&page=${page}")
-        local count
-        count=$(echo "$chunk" | jq 'length')
-        if [ "$count" -gt 0 ]; then
-            echo -n "$sep"
-            echo "$chunk" | jq '.[]'
-            sep=","
-        fi
-        if [ "$count" -lt 100 ]; then
-            break
-        fi
-        page=$((page+1))
-    done
-    echo "]"
+    local chunk count
+    {
+        while true; do
+            chunk=$(gh_api "${GH_API}/${endpoint}?per_page=100&page=${page}")
+            echo "$chunk" | jq -c '.[]'
+            count=$(echo "$chunk" | jq 'length')
+            if [ "$count" -lt 100 ]; then
+                break
+            fi
+            page=$((page+1))
+        done
+    } | jq -s '.'
 }
 
 changed_files() {

--- a/ceph-pr-pipeline/build/pr_checks.sh
+++ b/ceph-pr-pipeline/build/pr_checks.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+#
+# GitHub-API-based PR checks for ceph-pr-pipeline.  These reimplement the
+# checks from ceph-pr-commits (Signed-off-by) and ceph-pr-submodules
+# (Unmodified Submodules) plus the docs/container/gha/qa-only classification
+# from build_utils.sh, using only the GitHub API -- no 4-5 minute ceph.git
+# clone needed, so these statuses come back in seconds.
+#
+# Usage: pr_checks.sh <classify|signed|submodules>
+#
+# Required environment:
+#   ghprbPullId       - PR number
+#   ghprbTargetBranch - PR target branch (e.g. main)
+#   GITHUB_USER/GITHUB_PASS - GitHub API credentials (read-only is fine)
+# classify writes $WORKSPACE/pr_changes.properties (DOCS_ONLY=..., etc.).
+# signed additionally reads DOCS_ONLY (exported by the pipeline from the
+# classify stage) to decide which check to apply, mirroring ceph-pr-commits.
+
+set -o errexit
+set -o pipefail
+
+GH_REPO=${GH_REPO:-"ceph/ceph"}
+GH_API="https://api.github.com/repos/${GH_REPO}"
+
+gh_api() {
+    curl -sf -u "${GITHUB_USER}:${GITHUB_PASS}" \
+        -H "Accept: application/vnd.github+json" "$@"
+}
+
+# Paginate a list endpoint ($1, e.g. "pulls/123/files") and emit one combined
+# JSON array on stdout.  The commits endpoint caps at 250 entries and files at
+# 3000, same limits the GHPRB-era shallow-clone checks effectively had.
+gh_api_list() {
+    local endpoint=$1
+    local page=1
+    local sep=""
+    echo "["
+    while true; do
+        local chunk
+        chunk=$(gh_api "${GH_API}/${endpoint}?per_page=100&page=${page}")
+        local count
+        count=$(echo "$chunk" | jq 'length')
+        if [ "$count" -gt 0 ]; then
+            echo -n "$sep"
+            echo "$chunk" | jq '.[]'
+            sep=","
+        fi
+        if [ "$count" -lt 100 ]; then
+            break
+        fi
+        page=$((page+1))
+    done
+    echo "]"
+}
+
+changed_files() {
+    gh_api_list "pulls/${ghprbPullId}/files" | jq -r '.[].filename'
+}
+
+pr_commits() {
+    # Non-merge commits only, like `git log --no-merges`.
+    gh_api_list "pulls/${ghprbPullId}/commits" \
+        | jq '[.[] | select((.parents | length) == 1)]'
+}
+
+# Mirror the *_pr_only helpers in scripts/build_utils.sh.
+only_matching() {
+    local -n patterns=$1
+    local matched
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        matched=false
+        for pat in "${patterns[@]}"; do
+            # shellcheck disable=SC2053
+            if [[ "$f" == $pat ]]; then
+                matched=true
+                break
+            fi
+        done
+        if [ "$matched" = false ]; then
+            return 1
+        fi
+    done <<< "$2"
+    return 0
+}
+
+do_classify() {
+    local files
+    files="$(changed_files)"
+    echo "Changed files:"
+    echo "$files"
+
+    local docs_patterns=(
+        'doc/*' 'admin/*' 'src/sample.ceph.conf' 'CodingStyle' '*.rst' '*.md'
+        'COPYING*' 'README.*' 'SubmittingPatches' '.readthedocs.yml'
+        'PendingReleaseNotes'
+    )
+    local container_patterns=(
+        'container/*' 'Dockerfile.build'
+        'src/script/buildcontainer-setup.sh' 'src/script/build-with-container.py'
+    )
+    local gha_patterns=( '.github/*' )
+    local qa_patterns=( 'qa/*' )
+
+    local docs_only=false container_only=false gha_only=false qa_only=false
+    if [ -n "$files" ]; then
+        only_matching docs_patterns "$files" && docs_only=true
+        only_matching container_patterns "$files" && container_only=true
+        only_matching gha_patterns "$files" && gha_only=true
+        only_matching qa_patterns "$files" && qa_only=true
+    fi
+
+    tee "${WORKSPACE}/pr_changes.properties" << EOF
+DOCS_ONLY=${docs_only}
+CONTAINER_ONLY=${container_only}
+GHA_ONLY=${gha_only}
+QA_ONLY=${qa_only}
+EOF
+}
+
+do_signed() {
+    local commits
+    commits="$(pr_commits)"
+    local wrong
+
+    if [ "${DOCS_ONLY}" = true ]; then
+        # Docs-only PRs: commit titles must start with "doc" (or
+        # "<target>: doc" on stable branches).  See ceph-pr-commits.
+        local doc_regex='^doc'
+        if [ "${ghprbTargetBranch}" != "main" ]; then
+            doc_regex="^(${ghprbTargetBranch}: )?doc"
+        fi
+        wrong=$(echo "$commits" | jq -r --arg re "$doc_regex" \
+            '.[] | select((.commit.message | split("\n")[0] | test($re)) | not)
+                 | .sha[0:12] + " " + (.commit.message | split("\n")[0])')
+        if [ -n "$wrong" ]; then
+            echo "The following commits only touch files under doc/ but their titles"
+            echo "do not start with 'doc'.  See the 'Submitting Patches' guide:"
+            echo "https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst#commit-title"
+            echo "$wrong"
+            return 1
+        fi
+        echo "All commit titles look good."
+        return 0
+    fi
+
+    wrong=$(echo "$commits" | jq -r \
+        '.[] | select((.commit.message
+                       | test("Signed-off-by: \\S.* <[^@]+@[^@]+\\.[^@]+>")) | not)
+             | .sha[0:12] + " " + (.commit.message | split("\n")[0])')
+    if [ -n "$wrong" ]; then
+        echo "The following commits are not signed.  Please sign all commits as"
+        echo "described in the 'Submitting Patches' guide:"
+        echo "https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst#1-sign-your-work"
+        echo "$wrong"
+        return 1
+    fi
+    echo "All commits are signed."
+    return 0
+}
+
+do_submodules() {
+    # Submodule paths as of the target branch.
+    local submodule_paths
+    submodule_paths=$(gh_api "${GH_API}/contents/.gitmodules?ref=${ghprbTargetBranch}" \
+        | jq -r '.content' | base64 -d \
+        | awk -F ' *= *' '$1 ~ /path$/ { print $2 }')
+    echo "Submodule paths on ${ghprbTargetBranch}:"
+    echo "$submodule_paths"
+
+    local files modified=""
+    files="$(changed_files)"
+    while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        if echo "$files" | grep -qx "$path"; then
+            modified="$modified $path"
+        fi
+    done <<< "$submodule_paths"
+
+    if [ -z "$modified" ]; then
+        echo "No submodules modified."
+        return 0
+    fi
+
+    echo "Project has modified submodules:${modified}"
+    local commits
+    commits="$(pr_commits)"
+    for path in $modified; do
+        local magic_word
+        magic_word="$(basename "$path") submodule"
+        if echo "$commits" | jq -e --arg w "$magic_word" \
+            '.[] | select(.commit.message | contains($w))' > /dev/null; then
+            echo "'${magic_word}' found in a commit message; change is planned."
+        else
+            echo "please include '${magic_word}' in your commit message, if this change is intentional."
+            return 1
+        fi
+    done
+    return 0
+}
+
+case "$1" in
+    classify)   do_classify ;;
+    signed)     do_signed ;;
+    submodules) do_submodules ;;
+    *)
+        echo "usage: $0 <classify|signed|submodules>" >&2
+        exit 2
+        ;;
+esac

--- a/ceph-pr-pipeline/build/s3_cache.sh
+++ b/ceph-pr-pipeline/build/s3_cache.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Build-tree cache for ceph-pr-pipeline.  The build stage compiles ceph (with
+# tests) once, tars up the checkout+build tree, and uploads it to S3; the test
+# legs (make check, API tests) download it on their own builders instead of
+# rebuilding.  Because objects are keyed by PR head sha, a re-run of any leg
+# for the same sha reuses the existing build instead of compiling again.
+#
+# Requires build_utils.sh to be sourced first (create_venv_dir /
+# install_python_packages).
+#
+# Environment:
+#   CACHE_ENDPOINT - S3 endpoint URL
+#   CACHE_BUCKET   - bucket name
+#   CACHE_KEY      - object key, e.g. pr-builds/12345/<head sha>.tar.zst
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY - bucket credentials
+
+s3_setup() {
+    if ! command -v zstd > /dev/null; then
+        sudo apt-get install -y zstd || sudo yum install -y zstd
+    fi
+    if [ -z "$AWSCLI" ]; then
+        local pkgs=( "awscli" )
+        local venv
+        venv=$(create_venv_dir)
+        install_python_packages "$venv" "pkgs[@]"
+        AWSCLI=${venv}/bin/aws
+    fi
+}
+
+s3_cache_exists() {
+    $AWSCLI --endpoint-url "$CACHE_ENDPOINT" \
+        s3api head-object --bucket "$CACHE_BUCKET" --key "$CACHE_KEY"
+}
+
+# $1 - directory to archive (e.g. ceph)
+s3_cache_put() {
+    local dir=$1
+    local tarball
+    tarball=$(mktemp -p "$WORKSPACE" cache-XXXX.tar.zst)
+    # zstd -3 with all cores: fast enough to not matter next to the build,
+    # small enough to move between builders quickly.
+    tar -C "$dir" --use-compress-program="zstd -T0 -3" -cf "$tarball" .
+    ls -lh "$tarball"
+    $AWSCLI --endpoint-url "$CACHE_ENDPOINT" --cli-connect-timeout 60 \
+        s3 cp --no-progress "$tarball" "s3://${CACHE_BUCKET}/${CACHE_KEY}"
+    rm -f "$tarball"
+}
+
+# $1 - directory to extract into (created if missing)
+s3_cache_get() {
+    local dir=$1
+    mkdir -p "$dir"
+    $AWSCLI --endpoint-url "$CACHE_ENDPOINT" --cli-connect-timeout 60 \
+        s3 cp --no-progress "s3://${CACHE_BUCKET}/${CACHE_KEY}" - \
+        | tar -C "$dir" --use-compress-program="zstd -T0 -d" -xf -
+}

--- a/ceph-pr-pipeline/config/definitions/ceph-pr-pipeline.yml
+++ b/ceph-pr-pipeline/config/definitions/ceph-pr-pipeline.yml
@@ -45,8 +45,8 @@
 
       - string:
           name: CHECKS
-          default: "signed submodules make-check api windows"
-          description: "Which checks to run (space-separated): signed, submodules, make-check, api, windows"
+          default: "signed submodules make-check make-check-arm64 api windows"
+          description: "Which checks to run (space-separated): signed, submodules, make-check, make-check-arm64, api, windows"
 
       - string:
           name: DISTRO_BASE

--- a/ceph-pr-pipeline/config/definitions/ceph-pr-pipeline.yml
+++ b/ceph-pr-pipeline/config/definitions/ceph-pr-pipeline.yml
@@ -1,0 +1,79 @@
+- job:
+    name: ceph-pr-pipeline
+    description: |
+      Combined PR checks for ceph.git: Signed-off-by, Unmodified Submodules,
+      make check, ceph API tests and ceph windows tests in one pipeline with a
+      single ceph checkout and a single (shared) x86_64 build.
+      Normally triggered by ceph-pr-pipeline-trigger; to run manually, just
+      set ghprbPullId.
+    project-type: pipeline
+    quiet-period: 1
+    concurrent: true
+
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 300
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/ceph/ceph-build
+            branches:
+              - ${{CEPH_BUILD_BRANCH}}
+            shallow-clone: true
+            submodule:
+              disable: true
+            wipe-workspace: true
+      script-path: ceph-pr-pipeline/build/Jenkinsfile
+      lightweight-checkout: true
+      do-not-fetch-tags: true
+
+    parameters:
+      - string:
+          name: ghprbPullId
+          description: "the GitHub pull id, like '72' in 'ceph/pull/72'"
+
+      - string:
+          name: HEAD_SHA
+          description: "Expected PR head sha (set by the trigger).  Leave empty to use the current head; if set and the PR has moved on, the build aborts as superseded."
+
+      - string:
+          name: TARGET_BRANCH
+          default: main
+          description: "PR target branch (informational; the pipeline re-resolves it from the GitHub API)"
+
+      - string:
+          name: CHECKS
+          default: "signed submodules make-check api windows"
+          description: "Which checks to run (space-separated): signed, submodules, make-check, api, windows"
+
+      - string:
+          name: DISTRO_BASE
+          default: jammy
+          description: "the distribution used to create the container that builds and hosts the tests (see build-with-container.py for supported values)"
+
+      - bool:
+          name: FORCE_BUILD
+          default: false
+          description: "Compile even if a cached build tree already exists for this PR head sha"
+
+      - string:
+          name: STATUS_PREFIX
+          default: ""
+          description: "Prefix for the GitHub status contexts (e.g. 'pipeline/' while testing side by side with the old GHPRB jobs, so required contexts aren't touched)"
+
+      - string:
+          name: CEPH_REFERENCE_REPO
+          default: ""
+          description: "Path to a local ceph.git reference/mirror repo on the builders to speed up cloning (ignored where it doesn't exist)"
+
+      - string:
+          name: CEPH_BUILD_BRANCH
+          default: main
+          description: "Use the Jenkinsfile from this ceph-build branch"
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true

--- a/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml
@@ -22,21 +22,6 @@
           name: sha1
           description: "commit id or a refname, like 'origin/pr/72/head'"
 
-    triggers:
-      - github-pull-request:
-          allow-whitelist-orgs-as-admins: true
-          org-list:
-            - ceph
-          trigger-phrase: 'jenkins test submodules'
-          only-trigger-phrase: false
-          github-hooks: true
-          permit-all: false
-          auto-close-on-fail: false
-          status-context: "Unmodified Submodules"
-          started-status: "checking if PR has modified submodules"
-          success-status: "submodules for project are unmodified"
-          failure-status: "Approval needed: modified submodules found"
-
     scm:
       - git:
           url: https://github.com/ceph/ceph.git

--- a/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
+++ b/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml
@@ -55,24 +55,6 @@
         honor-refspec: true
         timeout: 20
         wipe-workspace: true
-    triggers:
-    - github-pull-request:
-        cancel-builds-on-update: true
-        allow-whitelist-orgs-as-admins: true
-        org-list:
-        - ceph
-        trigger-phrase: 'jenkins test make check arm64'
-        skip-build-phrase: '^jenkins do not test.*'
-        only-trigger-phrase: false
-        github-hooks: true
-        permit-all: false
-        auto-close-on-fail: false
-        status-context: "make check (arm64)"
-        started-status: "running make check"
-        success-status: "make check succeeded"
-        failure-status: "make check failed"
-        white-list-target-branches:
-        - main
     publishers:
       - cobertura:
           report-file: "src/pybind/mgr/dashboard/frontend/coverage/cobertura-coverage.xml"

--- a/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
+++ b/ceph-pull-requests/config/definitions/ceph-pull-requests.yml
@@ -32,23 +32,6 @@
           default: jammy
           description: "the distribution used to create the container that builds and hosts the tests (see build-with-container.py for supported values)"
 
-    triggers:
-      - github-pull-request:
-          cancel-builds-on-update: true
-          allow-whitelist-orgs-as-admins: true
-          org-list:
-            - ceph
-          trigger-phrase: 'jenkins test make check'
-          skip-build-phrase: '^jenkins do not test.*'
-          only-trigger-phrase: false
-          github-hooks: true
-          permit-all: false
-          auto-close-on-fail: false
-          status-context: "make check"
-          started-status: "running make check"
-          success-status: "make check succeeded"
-          failure-status: "make check failed"
-
     scm:
       - git:
           url: https://github.com/ceph/ceph.git

--- a/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
+++ b/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml
@@ -28,29 +28,6 @@
           name: ghprbPullId
           description: "The GitHub pull request id, like '72' in 'ceph/pull/72'"
 
-    triggers:
-      - github-pull-request:
-          cancel-builds-on-update: true
-          allow-whitelist-orgs-as-admins: true
-          org-list:
-            - ceph
-          white-list-target-branches:
-            - main
-            - umbrella
-            - tentacle
-            - squid
-            - reef
-          trigger-phrase: 'jenkins test windows'
-          skip-build-phrase: '^jenkins do not test.*'
-          only-trigger-phrase: false
-          github-hooks: true
-          permit-all: false
-          auto-close-on-fail: false
-          status-context: "ceph windows tests"
-          started-status: "running ceph windows tests"
-          success-status: "ceph windows tests succeeded"
-          failure-status: "ceph windows tests failed"
-
     scm:
       - git:
           url: https://github.com/ceph/ceph.git


### PR DESCRIPTION
Replaces the GitHub Pull Request Builder plugin and six freestyle jobs
(ceph-pr-commits, ceph-pr-submodules, ceph-pull-requests,
ceph-pull-requests-arm64, ceph-pr-api, ceph-windows-pull-requests) with a
webhook trigger job and one pipeline. The GitHub status contexts are
unchanged, so branch protection rules don't change.

## What it does

- **One clone, one build.** ceph.git is checked out once and compiled once
  (x86_64, `bwc -e buildtests`); make check and the API tests run on separate
  builders from the shared tree, moved via a zstd tarball in S3. Signed-off-by
  and Unmodified Submodules are reimplemented against the GitHub API and never
  clone at all. Windows and arm64 run as parallel legs with their own builds
  (their binaries were never shareable); arm64 restores-or-builds on a single
  node.
- **Binary cache.** Tarballs are keyed by `pr-builds/<PR>/<head sha>.<arch>`,
  so any re-run for an unchanged head skips compilation (`FORCE_BUILD`
  overrides).
- **Gating.** ceph-org authors build automatically; everyone else needs the
  `ci-approved` label. Every push removes the label, cancels running builds
  for the PR, and resets statuses to pending — it must be re-added for the new
  code.
- **Phrases.** `jenkins retest ...` re-runs everything (cheap for an unchanged
  head); `jenkins test <check>` runs one named leg; bare `jenkins test` runs
  nothing.
- **Statuses.** Each leg posts its own context. Pending is posted seconds into
  the run, before legs wait for executors; canceled/failed runs finalize any
  still-pending contexts so nothing hangs at "queued" on GitHub.

## Rollout

Designed to run side by side with the old jobs (`STATUS_PREFIX` keeps test
statuses away from the required contexts). See
[ceph-pr-pipeline/README.md](ceph-pr-pipeline/README.md) for the checklist:
credentials, one-time sandbox signature approvals, webhook, flip.

## Validated so far

- Quick checks tested against real PRs (including the multi-file JSON
  pagination fix in 70c3695a)
- Manual pipeline runs on jenkins.ceph.com through prepare/quick-checks/build
- Still to validate before the flip: API tests inside the build container,
  windows leg on a known-good libvirt node, arm64 leg, cobertura publishing
  (not wired yet)