### PR TITLE
tcmu-runner: remove centos7 and centos8

### DIFF
--- a/tcmu-runner/config/definitions/tcmu-runner.yml
+++ b/tcmu-runner/config/definitions/tcmu-runner.yml
@@ -24,8 +24,8 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: centos7, centos8, centos9, rocky10"
-          default: "centos7 centos8 centos9 rocky10"
+          description: "A list of distros to build for. Available options are: centos9, rocky10"
+          default: "centos9 rocky10"
 
       - string:
           name: ARCHS
@@ -50,8 +50,7 @@ If this is checked, then the binaries will be built and pushed to chacra even if
        # DIST onto the centos9 node label instead of a matching AVAILABLE_DIST.
        combination-filter: |
          ARCH == AVAILABLE_ARCH &&
-         ((DIST == AVAILABLE_DIST && DIST != "rocky10") || (DIST == "rocky10" && AVAILABLE_DIST == "centos9")) &&
-         (ARCH == "x86_64" || (ARCH == "arm64" && ["centos8", "centos9", "rocky10"].contains(DIST)))
+         ((DIST == AVAILABLE_DIST && DIST != "rocky10") || (DIST == "rocky10" && AVAILABLE_DIST == "centos9"))
     axes:
       - axis:
           type: label-expression
@@ -68,8 +67,6 @@ If this is checked, then the binaries will be built and pushed to chacra even if
           type: label-expression
           name: AVAILABLE_DIST
           values:
-            - centos7
-            - centos8
             - centos9
       - axis:
           type: dynamic


### PR DESCRIPTION
## What

Removes centos7 and centos8 from the tcmu-runner matrix job, leaving centos9 and rocky10:

- `DISTROS` parameter default and description now list only `centos9 rocky10`
- `AVAILABLE_DIST` axis drops `centos7` and `centos8` (rocky10 has no entry because it builds in a container on centos9 nodes)
- The combination-filter keeps the rocky10-onto-centos9 routing but drops the arm64 clause — with centos7 gone, every remaining distro builds on both arches

## Notes for reviewers

Rebased on main after the rocky10 support from #2627 landed. The build scripts (`build/setup`, `build/build_rpm`) detect the distro at runtime and needed no changes. `tcmu-runner-trigger` has no distro references.