### PR TITLE
bwc: correct authfile comment -- 77920 was account quota, not auth plumbing

### DIFF
--- a/scripts/bwc.sh
+++ b/scripts/bwc.sh
@@ -83,8 +83,14 @@ bwc_login() {
     if [ -z "${DOCKER_HUB_USERNAME}" ] || [ -z "${DOCKER_HUB_PASSWORD}" ]; then
         return 0
     fi
-    # Same-shell export so login and all later podman calls share one
-    # persistent authfile: https://tracker.ceph.com/issues/77920
+    # Pin auth to one persistent, deterministic path so login and all
+    # later podman calls in this shell read/write the same authfile.
+    # NOTE: this does NOT prevent the rate-limit failures tracked in
+    # https://tracker.ceph.com/issues/77920 -- those were Docker Hub
+    # *account* pull-quota exhaustion (the shared CI account being
+    # drained, e.g. by the daily sync-images run), not credentials
+    # failing to reach podman. The pulls were authenticated all along;
+    # Docker's 429 message just misleadingly says "unauthenticated".
     export REGISTRY_AUTH_FILE="${HOME}/.config/containers/auth.json"
     mkdir -p "${REGISTRY_AUTH_FILE%/*}"
     podman login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}" docker.io


### PR DESCRIPTION
The comment added in ebb51dd7 claimed the same-shell `REGISTRY_AUTH_FILE` export fixes the Docker Hub rate-limit failures in [tracker 77920](https://tracker.ceph.com/issues/77920). Investigation on 2026-08-10 disproved that theory, so this PR corrects the comment (no functional change — the export is kept as useful hygiene).

## What the investigation found

- `podman build --pull` **does** honor `REGISTRY_AUTH_FILE` — verified on toko04 (podman 4.9.3) with a throwaway authfile; debug log shows `Found credentials for docker.io/library/ubuntu in file ...`.
- CI's successful base-image pulls leave the per-IP anonymous rate bucket untouched (verified via `ratelimitpreview/test` headers while watching a live build) — the pulls are authenticated and attributed to the account. All builders share one egress IP (192.86.31.2), but that bucket is not what CI drains.
- The 2026-08-10 failures (ceph-pull-requests 191188–191192) cluster at 19:38–19:59 UTC, immediately after the daily **19:31 UTC `sync-images` run**, which skopeo-syncs every matching tag × arch of nginx/grafana/loki/promtail from docker.io using the **same shared `dgalloway-docker-hub` credential** as the build jobs — exhausting the account's pull quota in minutes. sync-images #887 itself died of the same 429 at 19:38, and has failed 3 days straight. Builds recovered exactly when the hourly quota window reset at 20:00 (191192's 3rd retry succeeded at 20:00:15).
- Docker's 429 body says "You have reached your **unauthenticated** pull rate limit" even for authenticated free-tier over-limit pulls, which is what sent the previous two fixes (aae7f2fd, ebb51dd7 / #2668) down the wrong path.

## Why not revert the export

Pinning credentials to one persistent, deterministic path is useful on its own and made this debugging tractable. Only the justification in the comment was wrong.

Actual fixes for 77920 (separate credential for sync-images, taming its tag ranges, mirroring base images to quay and using bwc `--base-image`) will come in a follow-up PR.