### PR TITLE
pulp_upload: label deb distributions with the distro codename

### DIFF
--- a/scripts/pulp_upload.sh
+++ b/scripts/pulp_upload.sh
@@ -13,7 +13,7 @@
 #   SHA1            - Git commit SHA for this build
 #   OS_NAME         - Target OS (e.g. centos, ubuntu)
 #   OS_VERSION      - Target OS version
-#   OS_VERSION_NAME - Ubuntu codename (used when OS_NAME=ubuntu)
+#   OS_VERSION_NAME - Distro codename, e.g. jammy, bookworm (used when OS_PKG_TYPE=deb)
 #   OS_PKG_TYPE     - Package format: "rpm" or "deb"
 #   FLAVOR          - Build flavor label (e.g. default, crimson)
 #   ARCH            - Target architecture (deb uploads only)
@@ -289,9 +289,16 @@ upload_deb_to_pulp() {
 #   $1 - Architecture label stored on the distribution
 #   $2 - Package manager version string for the version label
 # Prints one label element per line (key, value, key, value, ...).
+# distro_version must match what teuthology searches for: the codename for
+# deb-based distros (e.g. jammy, bookworm), the numeric version otherwise.
 get_pulp_distribution_labels() {
     local repo_arch="$1"
     local package_version="$2"
+    local distro_version="${OS_VERSION}"
+
+    if [ "$OS_PKG_TYPE" == "deb" ]; then
+        distro_version="${OS_VERSION_NAME}"
+    fi
 
     printf '%s\n' \
         project "${PULP_PROJECT}" \
@@ -301,7 +308,7 @@ get_pulp_distribution_labels() {
         arch "${repo_arch}" \
         sha1 "${SHA1}" \
         distro "${OS_NAME}" \
-        distro_version "${OS_VERSION}" \
+        distro_version "${distro_version}" \
         flavors "${FLAVOR}"
 }
 


### PR DESCRIPTION
teuthology's `PulpProject` searches Pulp distributions via `pulp_label_select` using the distro **codename** for deb-based distros (`distro_version=jammy`), matching the chacra/shaman convention. `pulp_upload.sh` was labeling distributions with the numeric version (`distro_version=22.04`) even though the base_path already uses the codename, so every Ubuntu job died in `check_packages`:

```
teuthology.exceptions.VersionNotFoundError: Failed to fetch package version from No results found for https://pulp.front.sepia.ceph.com/pulp/api/v3/distributions/deb/apt
```

(e.g. `yuriw-2026-08-10_23:39:44-smoke-wip-yuriw-cve-dryrun_tentacle-distro-default-trial/453537` — the packages exist at `.../repos/ceph/wip-yuriw-cve-dryrun_tentacle/<sha1>/ubuntu/jammy/flavors/default/x86_64/`, but the search matched zero distributions.)

This uses `OS_VERSION_NAME` for the `distro_version` label on deb builds (the Jenkinsfile passes it for both Ubuntu and Debian) so the label matches what teuthology queries for. RPM distros are unaffected; both sides already use the major version there.

Existing distributions for in-flight branches can be repaired without a rebuild:

```
pulp deb distribution label set --name <dist-name> --key distro_version --value jammy
```