### PR TITLE
ceph-dev-pipeline: fix SHA1 check race between parallel matrix cells

### DIFF
--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -186,15 +186,19 @@ def doCopyArtifactsStage() {
     filter: artifact_filter,
   )
   sh 'sudo journalctl --show-cursor -n 0 --no-pager | tail -n1 | cut -d\" \" -f3 > $WORKSPACE/cursor'
-  def sha1_trimmed = env.SHA1.trim().toLowerCase()
+  // env is shared across the parallel matrix cells, and when the SHA1 parameter
+  // is empty each cell fills env.SHA1 in from the artifact below. Compare against
+  // the immutable job parameter (params.SHA1) rather than re-reading env.SHA1,
+  // otherwise a sibling cell can set env.SHA1 between our read of sha1_trimmed
+  // and the check, and we'd spuriously fail with "does not match parameter value ()".
+  def sha1_trimmed = (params.SHA1 ?: "").trim().toLowerCase()
   def sha1_props = readProperties file: "${env.WORKSPACE}/dist/sha1"
   def sha1_from_artifact = sha1_props.SHA1.trim().toLowerCase()
-  if ( env.SHA1 && sha1_from_artifact != sha1_trimmed ) {
+  if ( sha1_trimmed && sha1_from_artifact != sha1_trimmed ) {
     error message: "SHA1 from artifact (${sha1_from_artifact}) does not match parameter value (${sha1_trimmed})"
-  } else if ( ! env.SHA1 ) {
-    env.SHA1 = sha1_from_artifact
   }
-  println "SHA1=${sha1_trimmed}"
+  env.SHA1 = sha1_from_artifact
+  println "SHA1=${sha1_from_artifact}"
   env.VERSION = readFile(file: "${env.WORKSPACE}/dist/version").trim()
   // In a release build, dist/other_envvars contains CEPH_REPO, and chacra_url
   // as written during ceph-source-dist but we don't to be able to define


### PR DESCRIPTION
Fixes the intermittent failure seen in https://jenkins.ceph.com/job/ceph-dev-pipeline/8303/ (and #8292):

```
SHA1 from artifact (50202b62fe9071e2bd335e0cfff5d2f37c9ef12a) does not match parameter value ()
```

When the `SHA1` parameter is empty (ceph-dev-cron leaves it blank), each matrix cell's "copy artifacts" stage fills `env.SHA1` in from the `dist/sha1` artifact. `env` is shared across the parallel cells, so a sibling cell can set `env.SHA1` between one cell's read of `sha1_trimmed` (`""`) and its `if (env.SHA1 && ...)` check, which then spuriously fails.

Compare against the immutable job parameter (`params.SHA1`) instead, and always publish the artifact's SHA1 into `env.SHA1` (identical to the parameter when one was given).