### PR TITLE
ceph-release-pipeline: skip tag push for SECURITY releases

### DIFF
--- a/ansible/roles/ceph-release/tasks/main.yml
+++ b/ansible/roles/ceph-release/tasks/main.yml
@@ -7,9 +7,3 @@
     - "stage == 'push'"
     - "release != 'SECURITY'"
     - tag|bool is true
-
-# This only runs to prevent the Archive Artifacts plugin from hanging
-- import_tasks: write_sha1_file.yml
-  when:
-    - "stage == 'push'"
-    - "release == 'SECURITY'"

--- a/ansible/roles/ceph-release/tasks/write_sha1_file.yml
+++ b/ansible/roles/ceph-release/tasks/write_sha1_file.yml
@@ -2,9 +2,8 @@
 # These tasks write the version commit's sha1 to a file for
 # ceph-source-dist and ceph-dev-pipeline to later consume.
 #
-# We write it again when running the playbook with stage=push only so
-# the Archive Artifacts plugin doesn't hang indefinitely.  We don't want
-# to configure the plugin to allow an empty or missing file.
+# We write it again when running the playbook with stage=push so the
+# Archive Artifacts step (allow-empty: false) has something to archive.
 
 - name: record commit sha1
   command: git rev-parse HEAD

--- a/ceph-release-pipeline/build/Jenkinsfile
+++ b/ceph-release-pipeline/build/Jenkinsfile
@@ -86,6 +86,11 @@ pipeline {
       }
     }
     stage('push ceph release tag') {
+      // SECURITY releases live in ceph-private.git; the tag is pushed to
+      // ceph.git manually once the embargo lifts, so there's nothing to do here.
+      when {
+        not { environment name: 'RELEASE_TYPE', value: 'SECURITY' }
+      }
       steps {
         script {
           def pushTagJob = build(


### PR DESCRIPTION
## What

- Guard the existing `push ceph release tag` stage in `ceph-release-pipeline/build/Jenkinsfile` with `when { not { environment name: 'RELEASE_TYPE', value: 'SECURITY' } }` so `ceph-tag` is not triggered with `TAG_PHASE=push` for SECURITY releases.
- Drop the SECURITY-only `write_sha1_file.yml` import from `ansible/roles/ceph-release/tasks/main.yml` and tidy the stale comment in `write_sha1_file.yml`.

## Why

https://jenkins.ceph.com/job/ceph-tag/666/console (triggered by ceph-release-pipeline #50 with `RELEASE_TYPE=SECURITY`) failed with:

```
TASK [ceph-release : record commit sha1]
Unable to change directory before execution: [Errno 2] No such file or directory: b'ceph'
```

For SECURITY releases the version commit/tag live in ceph-private.git and are pushed to ceph.git manually after the embargo, so `push.yml` is already skipped for `release == 'SECURITY'`. Nothing clones `ceph/`, and the SECURITY-only sha1 hack then fails on `chdir: ceph`. We don't need to run the push phase at all for SECURITY, so skip the stage in the pipeline and remove the dead hack.

## Reviewer notes

- Jenkinsfile validated with `/pipeline-model-converter/validate` ("Jenkinsfile successfully validated").
- Takes effect for `ceph-release-pipeline` once merged to `main` (it reads the Jenkinsfile from `CEPH_BUILD_BRANCH`).
- A manual `ceph-tag` run with `TAG_PHASE=push` + `RELEASE_TYPE=SECURITY` will now no-op in ansible and fail at Archive Artifacts (`allow-empty: false`) rather than inside ansible — the pipeline no longer does that.
