### PR TITLE
ceph-release-containers: clone from ceph-releases.git so SECURITY releases build

### DIFF
--- a/ceph-release-containers/build/Jenkinsfile
+++ b/ceph-release-containers/build/Jenkinsfile
@@ -1,5 +1,12 @@
 // vim: ts=2 sw=2 expandtab
-ceph_repo = "https://github.com/ceph/ceph.git"
+import groovy.transform.Field
+
+// ceph-tag pushes the release version commit and v${VERSION} tag to
+// ceph-releases.git for every RELEASE_TYPE.  For SECURITY releases that is
+// the *only* place the commit exists until the embargo lifts (the push to
+// ceph.git is skipped), so clone from ceph-releases.git rather than ceph.git.
+@Field String ceph_repo = "git@github.com:ceph/ceph-releases.git"
+@Field String ceph_repo_credentials = "jenkins-build"
 
 pipeline {
   agent any
@@ -49,7 +56,7 @@ pipeline {
               dir('ceph') {
                 checkout scmGit(
                   branches: [[ name: env.SHA1 ]],
-                  userRemoteConfigs: [[ url: ceph_repo ]],
+                  userRemoteConfigs: [[ url: ceph_repo, credentialsId: ceph_repo_credentials ]],
                   sparseCheckout: [[ path: 'container' ]],
                   extensions: [
                     [ $class: 'WipeWorkspace' ],
@@ -89,7 +96,7 @@ pipeline {
         dir('ceph') {
           checkout scmGit(
             branches: [[ name: env.SHA1 ]],
-            userRemoteConfigs: [[ url: ceph_repo ]],
+            userRemoteConfigs: [[ url: ceph_repo, credentialsId: ceph_repo_credentials ]],
             sparseCheckout: [[ path: 'container' ]],
             extensions: [
               [ $class: 'WipeWorkspace' ],

--- a/ceph-release-containers/config/definitions/ceph-release-containers.yml
+++ b/ceph-release-containers/config/definitions/ceph-release-containers.yml
@@ -26,7 +26,7 @@
 
       - string:
           name: SHA1
-          description: "SHA1 of the commit to build"
+          description: "SHA1 of the commit to build, as reported by ceph-release-pipeline (must exist in ceph-releases.git; works for SECURITY releases too)"
 
       - string:
           name: VERSION


### PR DESCRIPTION
## Problem

https://jenkins.ceph.com/view/all/job/ceph-release-containers/45/ (v20.2.4, a SECURITY release) failed in both matrix cells with:

```
ERROR: Couldn't find any revision to build. Verify the repository and branch configuration for this job.
```

The job checks out `${SHA1}` from public `https://github.com/ceph/ceph.git`. For `RELEASE_TYPE=SECURITY`, ceph-tag pushes the version commit + `v${VERSION}` tag only to the private `ceph-releases.git`; the push to `ceph.git` is deliberately skipped until the embargo lifts (#2681). So the SHA1 (`7a1e62f0`, present in ceph-releases.git as `v20.2.4`) simply doesn't exist in `ceph.git` yet.

## Fix

Clone from `git@github.com:ceph/ceph-releases.git` with the `jenkins-build` SSH credential in both the arch-specific and manifest-list stages — the same repo/credential `ceph-source-dist` already uses for release builds. ceph-tag pushes every release (regular and security) there, so this works for all `RELEASE_TYPE`s without the operator having to pass anything extra.

Also declares the repo globals with `@Field` to silence the "Did you forget the `def` keyword?" warning, and clarifies the `SHA1` parameter description.

Validated with the declarative linter.

## Test

Re-run `ceph-release-containers` with the same params as build 45 plus `CEPH_BUILD_BRANCH=wip-release-containers-security`.