### PR TITLE
Keep RELEASE_TYPE=SECURITY source distributions off public Jenkins

### DIFF
--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -125,9 +125,11 @@
 
       - choice:
           name: SETUP_JOB
+          description: "cve-source-dist is used by ceph-release-pipeline for RELEASE_TYPE=SECURITY; its artifacts are only visible to the ceph/security team"
           choices:
             - ceph-source-dist
             - ceph-dev-new-setup
+            - cve-source-dist
 
       - string:
           name: CEPH_BUILD_BRANCH

--- a/ceph-release-pipeline/build/Jenkinsfile
+++ b/ceph-release-pipeline/build/Jenkinsfile
@@ -74,6 +74,10 @@ pipeline {
               booleanParam(name: 'CI_CONTAINER',  value: false),
               booleanParam(name: 'DWZ',           value: true),
               booleanParam(name: 'SCCACHE',       value: false),
+              // SECURITY releases build from embargoed commits.  cve-source-dist runs the same
+              // Jenkinsfile as ceph-source-dist but is only readable by the ceph/security team,
+              // so the source tarball and change log are not published on public Jenkins.
+              string(name: 'SETUP_JOB',           value: env.RELEASE_TYPE == 'SECURITY' ? 'cve-source-dist' : 'ceph-source-dist'),
               string(name: "CEPH_BUILD_BRANCH",   value: env.CEPH_BUILD_BRANCH),
               string(name: 'RELEASE_TYPE',        value: env.RELEASE_TYPE),
               booleanParam(name: 'RELEASE_BUILD', value: true),

--- a/ceph-source-dist/build/Jenkinsfile
+++ b/ceph-source-dist/build/Jenkinsfile
@@ -17,14 +17,25 @@ pipeline {
               checkout_ref = env.BRANCH
             }
 
+            def release_build = params.RELEASE_BUILD?.toBoolean() ?: false
+
+            // SECURITY releases build embargoed commits.  This Jenkinsfile is shared by
+            // ceph-source-dist (public) and cve-source-dist (readable only by ceph/security),
+            // so refuse to check out or archive anything unless we're running in the private job.
+            if (release_build && env.RELEASE_TYPE == 'SECURITY' && env.JOB_NAME != 'cve-source-dist') {
+              error "RELEASE_TYPE=SECURITY source distributions must run in cve-source-dist, not ${env.JOB_NAME}, so the source tarball and change log are not publicly visible."
+            }
+
             // Rewrite repo + ref if RELEASE_BUILD=true.
             // RELEASE_BUILD is intentionally undefinable as a ceph-source-dist parameter but instead
             // defined by ceph-release-pipeline so that only that job may clone from ceph-releases.git.
-            def repoUrl = params.RELEASE_BUILD ? 'git@github.com:ceph/ceph-releases.git' : env.CEPH_REPO
-            env.checkout_ref = params.RELEASE_BUILD ? "v${params.VERSION}" : env.BRANCH
+            def repoUrl = release_build ? 'git@github.com:ceph/ceph-releases.git' : env.CEPH_REPO
+            env.checkout_ref = release_build ? "v${params.VERSION}" : env.BRANCH
             env.CEPH_REPO = repoUrl
 
-            checkout scmGit(
+            // Release builds come from ceph-releases.git (private).  Don't record a change log
+            // for them so commit messages don't show up on the build's "Changes" page.
+            checkout changelog: !release_build, scm: scmGit(
               branches: [[name: checkout_ref]],
               userRemoteConfigs: [[
                 url: env.CEPH_REPO,
@@ -42,7 +53,7 @@ pipeline {
             )
 
             // No need to fetch tags if this is a release build
-            if (!params.RELEASE_BUILD?.toBoolean()) {
+            if (!release_build) {
               sh 'git fetch --tags https://github.com/ceph/ceph.git'
             }
           }

--- a/ceph-source-dist/build/Jenkinsfile
+++ b/ceph-source-dist/build/Jenkinsfile
@@ -104,11 +104,10 @@ pipeline {
                 # ceph-dev-pipeline does not offer ceph-releases.git as an option for CEPH_REPO,
                 # and we don't want RELEASE_BUILD to be settable by the user to avoid being able
                 # clone from ceph-releases.git.
-                if [ "${RELEASE_TYPE}" = "PRIVATE" ]; then
-                  echo "CEPH_REPO=https://github.com/ceph/ceph-private" > dist/other_envvars
-                else
-                  echo "CEPH_REPO=https://github.com/ceph/ceph-releases" > dist/other_envvars
-                fi
+                # This is ceph-releases.git for every RELEASE_TYPE, including SECURITY: ceph-tag
+                # pushes the version commit and tag there (the SHA1 being built does not exist in
+                # ceph-private.git), and ceph-dev-pipeline only uses this to link to the commit.
+                echo "CEPH_REPO=https://github.com/ceph/ceph-releases" > dist/other_envvars
                 echo "RELEASE_BUILD=true" >> dist/other_envvars
                 echo "chacra_url=https://chacra.ceph.com/" >> dist/other_envvars
                 echo "BRANCH=${BRANCH}-release" > dist/branch

--- a/cve-source-dist/config/definitions/cve-source-dist.yml
+++ b/cve-source-dist/config/definitions/cve-source-dist.yml
@@ -2,7 +2,7 @@
 # must be made manually by a Jenkins admin.
 - job:
     name: cve-source-dist
-    description: This job is only called from https://jenkins.ceph.com/job/cve-pipeline.  The entire job and its artifacts are only visible to the ceph/security Github Team.
+    description: This job is only called from https://jenkins.ceph.com/job/cve-pipeline and (for RELEASE_TYPE=SECURITY) https://jenkins.ceph.com/job/ceph-dev-pipeline via ceph-release-pipeline.  The entire job and its artifacts are only visible to the ceph/security Github Team.
     project-type: pipeline
     concurrent: true
     pipeline-scm:
@@ -25,7 +25,8 @@
           artifact-days-to-keep: -1
           artifact-num-to-keep: 50
       - copyartifact:
-          projects: cve-pipeline
+          # ceph-dev-pipeline copies from here when ceph-release-pipeline runs with RELEASE_TYPE=SECURITY
+          projects: cve-pipeline,ceph-dev-pipeline
       - authorization:
           inheritance-strategy: none
           GROUP:ceph*security:


### PR DESCRIPTION
jenkins.ceph.com is anonymously readable and Jenkins has no per-build ACLs, so a `RELEASE_TYPE=SECURITY` release run through `ceph-source-dist` publishes the embargoed source tarball (`dist/**`) and the commit log ("Changes" tab from the `ceph-releases.git` checkout) to anyone.

`cve-source-dist` already runs the same Jenkinsfile but is restricted to the ceph/security GitHub team, so route SECURITY releases through it.

## Changes
- **ceph-release-pipeline**: pass `SETUP_JOB=cve-source-dist` to `ceph-dev-pipeline` when `RELEASE_TYPE=SECURITY` (`ceph-source-dist` otherwise).
- **ceph-dev-pipeline**: add `cve-source-dist` to the `SETUP_JOB` choices.
- **cve-source-dist**: allow `ceph-dev-pipeline` to copy its artifacts. ⚠️ JJB skips the `cve-*` jobs, so this has to be applied to the job config on Jenkins by hand.
- **ceph-source-dist/build/Jenkinsfile** (shared by both jobs), defense in depth:
  - `error()` before checkout if `RELEASE_TYPE=SECURITY` and `JOB_NAME != cve-source-dist`.
  - `checkout changelog: false` for release builds so commit messages from `ceph-releases.git` aren't recorded on the build page.

## Not covered (deliberately)
`ceph-dev-pipeline` / `ceph-release-pipeline` / `ceph-tag` build pages (params, VERSION/SHA1 description, console) stay public, and packages still land on chacra as today. Hiding those means a private release pipeline driving `cve-pipeline`, which is a larger change to the release/signing flow.

## To verify on Jenkins
- `build job: 'cve-source-dist'` from `ceph-dev-pipeline` is permitted (fine if the `build` step runs as SYSTEM, i.e. no Authorize Project config restricting it).
- Both Jenkinsfiles pass the declarative linter; JJB renders both yml changes as expected.