### PR TITLE
ceph-release-containers: exclude ppc64le from manifest-list stage

### DIFF
--- a/ceph-release-containers/build/Jenkinsfile
+++ b/ceph-release-containers/build/Jenkinsfile
@@ -84,7 +84,10 @@ pipeline {
     }
     stage("make manifest-list image") {
       agent {
-        label "centos9"
+        // exclude ppc64le: those nodes also carry the centos9 label but
+        // lack the github.com SSH host key needed to clone ceph-releases.git
+        // (and the /home/jenkins-build paths assumed below)
+        label "centos9&&!ppc64le"
       }
       environment {
         CONTAINER_REPO_HOSTNAME = 'quay.ceph.io'


### PR DESCRIPTION
The `make manifest-list image` stage used a bare `centos9` agent label. The `ppc64le-01/02` nodes also carry that label, and [build #47](https://jenkins.ceph.com/job/ceph-release-containers/47/) landed on `ppc64le-02` and failed cloning `ceph-releases.git`:

```
No ED25519 host key is known for github.com and you have requested strict checking.
Host key verification failed.
```

That node has no github.com SSH host key in its known_hosts and uses a different workspace/user layout than the `/home/jenkins-build` paths this stage assumes. Before #2682 the stage cloned ceph.git over anonymous HTTPS, so this never mattered.

Use `centos9&&!ppc64le` so the stage can still run on either x86_64 or arm64 builders. Build #46 (same SSH-clone code, manifest stage on `ceph129`) confirms the #2682 change itself works.

Follow-up (separate): the ppc64le nodes probably shouldn't carry a bare `centos9` label, or need github.com host keys + the jenkins-build layout.