### PR TITLE
dashboard: manage the chrome apt repo with add-apt-repository

### DIFF
--- a/scripts/dashboard/install-e2e-test-deps.sh
+++ b/scripts/dashboard/install-e2e-test-deps.sh
@@ -7,14 +7,15 @@ if [[ ! $(arch) =~ (i386|x86_64|amd64) ]]; then
 fi
 
 if grep -q  debian /etc/*-release; then
-    sudo bash -c 'echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list'
     curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+    sudo add-apt-repository -y "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main"
     sudo apt-get update
     sudo apt-get install -y google-chrome-stable
     sudo apt-get install -y python3-requests python3-openssl python3-jinja2 \
         python3-jwt python3-scipy python3-routes
     sudo apt-get install -y xvfb libxss1
-    sudo rm /etc/apt/sources.list.d/google-chrome.list
+    sudo add-apt-repository -y --remove "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main"
+    sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
 elif grep -q rhel /etc/*-release; then
     sudo dd of=/etc/yum.repos.d/google-chrome.repo status=none <<EOF
 [google-chrome]


### PR DESCRIPTION
ceph-dashboard-cephadm-e2e has failed on every run since 2026-08-19 09:31 UTC (e.g. [#25030](https://jenkins.ceph.com/job/ceph-dashboard-cephadm-e2e/25030/), [#25039](https://jenkins.ceph.com/job/ceph-dashboard-cephadm-e2e/25039/)):

```
+ sudo rm /etc/apt/sources.list.d/google-chrome.list
rm: cannot remove '/etc/apt/sources.list.d/google-chrome.list': No such file or directory
```

`install-e2e-test-deps.sh` hand-writes the Google repo line into `/etc/apt/sources.list.d/google-chrome.list` — the file the `google-chrome-stable` package manages itself. As of 151.0.7922.169-1 ("Unpacking ... over (151.0.7922.137-1)") its postinst migrates a legacy `google-chrome.list` containing its repo line to a deb822 `google-chrome.sources` and deletes the `.list` ([`install_deb822_sources()`](https://chromium.googlesource.com/chromium/src/+/main/chrome/installer/linux/common/apt.include#106) / [`remove_legacy_list()`](https://chromium.googlesource.com/chromium/src/+/main/chrome/installer/linux/common/apt.include#42), called from [`debian/postinst`](https://chromium.googlesource.com/chromium/src/+/main/chrome/installer/linux/debian/postinst)), so our cleanup `rm` aborts the script under `set -e` before the tests start.

Per @dmick's suggestion: stop writing that file by hand and use `add-apt-repository` / `add-apt-repository --remove` instead. It writes the entry to a file of its own naming that chrome's maintainer scripts never touch, and `--remove` is a no-op (exit 0) when the entry is already gone. `software-properties-common` is part of the builder image (`ansible/examples/builder.yml`).

**Update:** also `rm -f` chrome's own `google-chrome.sources` after the `--remove`. Chrome's postinst drops that file itself (URI `dl.google.com/linux/chrome-stable/deb/`, different from the one we add, so `--remove` doesn't match it) and recreates it on every install while it exists — which it now does on the builders since today's failed runs migrated our old `.list` into it. The old `rm` left no Google repo behind once the job was done; this keeps that behavior (`repo_add_once` is already `false` on the builders, so chrome won't re-add it).

Tested in an `ubuntu:24.04` amd64 container running the actual script: exit 0 on a fresh install and on a repeat run with chrome already installed; `google-chrome-stable 151.0.7922.169` installed; `sources.list.d/` contains only `ubuntu.sources` afterwards and `apt-get update` no longer touches dl.google.com.
