### PR TITLE
sepia-fog-images: really claim testnodes, and pause the queue first

### DIFF
--- a/sepia-fog-images/build/fog-images.sh
+++ b/sepia-fog-images/build/fog-images.sh
@@ -3,7 +3,8 @@
 # this script once per stage with a phase argument:
 #
 #   fog-images.sh prepare   Clone/bootstrap teuthology and ceph-cm-ansible
-#   fog-images.sh lock      Lock testnodes (skipped when DEFINEDHOSTS is set)
+#   fog-images.sh lock      Pause the teuthology queue and lock testnodes
+#                           (locking skipped when DEFINEDHOSTS is set)
 #   fog-images.sh deploy    FOG-deploy the existing image for each distro and
 #                           wait for the network sentinel file
 #   fog-images.sh ansible   Run cephlab.yml and prep-fog-capture.yml
@@ -249,16 +250,84 @@ funCheckHostOs () {
   echo "$host is running $gotid $gotver as expected for $want"
 }
 
-# Mark down one free host of the given machine type for image verification.
+# Claiming testnodes.
+#
+# Marking a node down is not a claim: it is not atomic against lock_many, and
+# build #6 (2026-08-20) picked trial059 out of "--status up --locked false" in
+# the 20s gap between one scheduled job releasing it and the next one locking
+# it, so the pipeline and a teuthology job FOG-deployed the same host and the
+# ansible phase died with UNREACHABLE.  Take a real paddles lock instead --
+# atomic, owned by the Jenkins user, so lock_many cannot hand the node out
+# from under us -- and mark it down as well.
+#
+# --no-reimage (ceph/teuthology#2250) is what makes --lock usable here: by
+# default it reimages bare-metal nodes whose machine_type is a reimage type,
+# which is the opposite of what phase_deploy wants.
+
+# Usage: funClaim <fqdn>.  Nonzero if somebody else locked it first.
+funClaim () {
+  teuthology-lock --lock --no-reimage --desc "$lockdesc" "$1" || return 1
+  teuthology-lock --update --status down --desc "$lockdesc" "$1"
+}
+
+# Usage: funRelease <host>...  Put nodes back in the pool: status up, then
+# drop the lock.  --unlock powers a FOG-type node off on its way out; that's
+# fine, the queue's next reimage power-cycles it anyway.  -f releases the
+# rest even if one host fails (still exits nonzero).
+funRelease () {
+  if [ $# -eq 0 ]; then
+    return 0
+  fi
+  local host
+  for host in "$@"; do
+    teuthology-lock --update --status up $host
+  done
+  teuthology-lock --unlock -f "$@"
+}
+
+# The hosts this build has claimed, one short hostname per line.
+# Usage: funClaimedHosts [machine-type]
+#
+# Keyed off the lock owner and description, not "--status down": another job's
+# reimage flips a node back up behind our back, and in build #6 that is how
+# the cleanup phase lost track of trial059 and left it claimed.  --brief with
+# neither -a nor --owner already filters to the invoking user's locks.
+funClaimedHosts () {
+  # --brief rows are "<fqdn> up|down locked|unlocked <owner> "<desc>"".  Match
+  # on the status column so a stray line can never be read back as a hostname.
+  teuthology-lock --brief --desc-pattern "$lockdesc" ${1:+--machine-type $1} |
+    awk '$2 == "up" || $2 == "down" { print $1 }' | cut -d '.' -f1
+}
+
+# Free hosts of the given machine type, one FQDN per line, sorted by name.
+# Usage: funFreeHosts <machine-type>
+funFreeHosts () {
+  teuthology-lock --brief -a --machine-type $1 --status up --locked false |
+    awk '$2 == "up" { print $1 }'
+}
+
+# Usage: funPauseQueue <seconds>.  0 unpauses.  No-op unless PAUSEQUEUE.
+funPauseQueue () {
+  if [ "$PAUSEQUEUE" == "true" ]; then
+    for qtype in $pausetypes; do
+      teuthology-queue --pause $1 --machine_type $qtype
+    done
+  fi
+}
+
+# Claim one free host of the given machine type for image verification.
 # Prints the claimed short hostname.  Usage: funClaimExtraHost <type>
 funClaimExtraHost () {
   local currentretries=0 candidate
   while true; do
-    candidate=$(teuthology-lock --brief -a --machine-type $1 --status up --locked false | head -n 1 | awk '{ print $1 }')
-    if [ -n "$candidate" ] && teuthology-lock --update --status down --desc "$lockdesc" $candidate >&2; then
-      echo $candidate | cut -d '.' -f1
-      return 0
-    fi
+    # Walk the whole free list: a claim can lose the race to the queue, and
+    # retrying the same head-of-list host forever would just burn the timeout
+    for candidate in $(funFreeHosts $1); do
+      if funClaim $candidate >&2; then
+        echo $candidate | cut -d '.' -f1
+        return 0
+      fi
+    done
     sleep 5
     ((++currentretries))
     # Retry for 20min
@@ -285,7 +354,7 @@ pausetypes="$MACHINETYPES${IMAGETYPE:+ $IMAGETYPE}"
 
 funAllHosts () {
   if [ "$use_teuthologylock" = true ]; then
-    teuthology-lock --brief -a --status down | grep "$lockdesc" | cut -d '.' -f1 | tr "\n" " "
+    funClaimedHosts | tr "\n" " "
   else
     echo "$DEFINEDHOSTS"
   fi
@@ -343,27 +412,40 @@ EOF
 }
 
 phase_lock () {
+  funActivateVenv
+
+  # Pause the queue before claiming anything, not at capture time.  funClaim
+  # is atomic, but a live dispatcher still races us for every node the queue
+  # frees, and the job that wins that race reimages a host this build is in
+  # the middle of using (build #6, 2026-08-20).  Paused, nodes only ever come
+  # free towards us.  The 2h expiry is a safety valve in case this job dies
+  # without running cleanup.
+  funPauseQueue 7200
+
   if [ "$use_teuthologylock" != true ]; then
     echo "DEFINEDHOSTS set; skipping locking"
     return 0
   fi
 
-  funActivateVenv
-
   # Don't bail if we fail to lock machines
   set +e
 
-  # Keep trying to claim machines until we have one per distro.  We mark them
-  # down with a descriptive desc instead of locking because locking attempts
-  # to reimage using FOG.
+  # Keep trying to claim machines until we have one per distro
   for type in $MACHINETYPES; do
     currentretries=0
     while true; do
-      numlocked=$(teuthology-lock --brief -a --machine-type $type --status down | grep -c "$lockdesc")
+      numlocked=$(funClaimedHosts $type | wc -l | tr -d '[:space:]')
       [ "$numlocked" -ge "$numdistros" ] && break
-      candidate=$(teuthology-lock --brief -a --machine-type $type --status up --locked false | head -n 1 | awk '{ print $1 }')
-      if [ -z "$candidate" ] || ! teuthology-lock --update --status down --desc "$lockdesc" $candidate; then
-        # Nothing free or the claim failed; don't hammer the lock server
+      claimed=false
+      for candidate in $(funFreeHosts $type); do
+        if funClaim $candidate; then
+          claimed=true
+          break
+        fi
+      done
+      if [ "$claimed" != true ]; then
+        # Nothing free, or the queue beat us to every free node; don't
+        # hammer paddles
         sleep 5
       fi
       ((++currentretries))
@@ -396,7 +478,7 @@ phase_deploy () {
   # that distro so we have something to update and recapture
   for type in $MACHINETYPES; do
     if [ "$use_teuthologylock" = true ]; then
-      lockedhosts=$(teuthology-lock --brief -a --machine-type $type --status down | grep "$lockdesc" | cut -d '.' -f1 | sort)
+      lockedhosts=$(funClaimedHosts $type | sort)
     else
       lockedhosts=$(echo $DEFINEDHOSTS | tr ' ' '\n' | grep "^${type}" || true)
     fi
@@ -601,15 +683,13 @@ phase_capture () {
   fogcaptureid=$(funFogApi GET /tasktype '{"name": "Capture"}' | jq -r '.tasktypes[0].id')
   fogdeployid=$(funFogApi GET /tasktype '{"name": "Deploy"}' | jq -r '.tasktypes[0].id')
 
-  # Pause the queue for the whole capture+verify window: captures replace the
-  # image the queue deploys from, and the new image is unusable until the
-  # verify phase has proven it boots.  The 2h expiry is a safety valve in
-  # case this job dies without running cleanup.
-  if [ "$PAUSEQUEUE" == "true" ]; then
-    for qtype in $pausetypes; do
-      teuthology-queue --pause 7200 --machine_type $qtype
-    done
+  # phase_lock already paused the queue; re-arm the 2h expiry so it covers
+  # the capture+verify window too.  Captures replace the image the queue
+  # deploys from, and the new image is unusable until the verify phase has
+  # proven it boots.
+  funPauseQueue 7200
 
+  if [ "$PAUSEQUEUE" == "true" ]; then
     # Let any already-scheduled deploys drain before we start capturing
     deploytasks=$(funFogApi GET /task/active '{"typeID": "'${fogdeployid}'"}' | jq -r '.count // 0')
     currentretries=0
@@ -772,16 +852,10 @@ phase_verify () {
   done 3< $verifyfile
 
   # Release any extra hosts we claimed just for verification
-  for host in $extrahosts; do
-    teuthology-lock --update --status up $host
-  done
+  funRelease $extrahosts
 
   # The new images are good; the queue can deploy them again
-  if [ "$PAUSEQUEUE" == "true" ]; then
-    for qtype in $pausetypes; do
-      teuthology-queue --pause 0 --machine_type $qtype
-    done
-  fi
+  funPauseQueue 0
   rm -f $WORKSPACE/captures-started
 }
 
@@ -790,9 +864,7 @@ phase_unlock () {
 
   if [ "$use_teuthologylock" = true ]; then
     # Unlock all machines after all capture images are finished
-    for host in $(funAllHosts); do
-      teuthology-lock --update --status up $host
-    done
+    funRelease $(funAllHosts)
   fi
 }
 
@@ -850,21 +922,15 @@ phase_cleanup () {
       echo "WARNING: Captures started but the new image(s) were never verified."
       echo "WARNING: LEAVING the teuthology queue paused for: $pausetypes"
       echo "WARNING: Verify or restore the images, then unpause with: teuthology-queue --pause 0 --machine_type <type>"
-      for qtype in $pausetypes; do
-        teuthology-queue --pause 7200 --machine_type $qtype
-      done
+      funPauseQueue 7200
     else
-      for qtype in $pausetypes; do
-        teuthology-queue --pause 0 --machine_type $qtype
-      done
+      funPauseQueue 0
     fi
   fi
 
   if [ "$use_teuthologylock" = true ]; then
     # Unlock all machines
-    for host in $allhosts; do
-      teuthology-lock --update --status up $host
-    done
+    funRelease $allhosts
   fi
 
   return 0

--- a/sepia-fog-images/build/fog-images.sh
+++ b/sepia-fog-images/build/fog-images.sh
@@ -512,13 +512,21 @@ phase_deploy () {
       # install), and the job captured that as trial_rocky_10.  Only an
       # image FOG has a size for counts as deployable.
       deployimageid=$(funUsableImageId $deployimagename)
+      seedsearched=false
       if [ -z "$deployimageid" ] && [ "$distroversion" == "${distroversion%%.*}" ]; then
         # Major-only distro (rocky_10) with no captured image yet: seed it
-        # from the newest captured point-release image of that major
+        # from the newest captured point-release image of that major.  The
+        # ansible phase passes rocky_upgrade_scope=major for this distro, so
+        # prep-fog-capture walks the seed to the newest minor against the
+        # major tree before we capture it as ${deployimagename}.
+        seedsearched=true
         seed=$(funNewestMinorImage $type $splitdistro $distroversion)
         if [ -n "$seed" ]; then
           deployimageid=${seed%% *}
           echo "No captured ${deployimagename} image; seeding it from ${seed#* } (image ${deployimageid})"
+          echo "prep-fog-capture will upgrade it to the newest ${splitdistro} ${distroversion} minor before capture"
+        else
+          echo "No captured ${deployimagename} image and no ${type}_${splitdistro}_${distroversion}.* point release to seed it from"
         fi
       fi
       # Make sure the image we'll capture into exists, creating the template
@@ -539,7 +547,11 @@ phase_deploy () {
           # Nothing to deploy.  Brand new distros for a machine type have to
           # be seeded manually: image a host by hand, then rerun this job
           # with DEFINEDHOSTS pointing at it.
-          echo "ERROR: No captured FOG image named ${deployimagename} exists so there is nothing to deploy and update."
+          if [ "$seedsearched" == true ]; then
+            echo "ERROR: No captured FOG image named ${deployimagename} exists, and FOG has no captured ${type}_${splitdistro}_${distroversion}.* point-release image to seed it from."
+          else
+            echo "ERROR: No captured FOG image named ${deployimagename} exists so there is nothing to deploy and update."
+          fi
           echo "Seed the first ${deployimagename} image manually, then rerun this job with DEFINEDHOSTS set."
           exit 1
         fi

--- a/sepia-fog-images/build/fog-images.sh
+++ b/sepia-fog-images/build/fog-images.sh
@@ -169,6 +169,25 @@ funWaitForOurTasks () {
   done
 }
 
+# FOG host IDs for the given machine types, as a JSON array of strings.
+# Testnodes are named <type><NNN> (trial059, smithi042), so anchor the match:
+# a bare "trial" prefix would also swallow trial-perf hosts.
+# Usage: funTypeHostIds <type>...
+funTypeHostIds () {
+  funFogApi GET /host | jq -c --arg types "$*" '
+    ($types | split(" ") | map(select(length > 0))) as $t
+    | [ (.hosts // [])[]
+        | select(.name as $n | $t | any(. as $p | $n | test("^\($p)[0-9]+$")))
+        | .id | tostring ]'
+}
+
+# Count active tasks of one type whose host is in the given JSON ID array.
+# Usage: funCountTasksFor <tasktypeid> '["1","2"]'
+funCountTasksFor () {
+  funFogApi GET /task/active '{"typeID": "'${1}'"}' \
+    | jq -r --argjson ids "$2" '[(.tasks // [])[] | select((.hostID|tostring) as $h | $ids | index($h))] | length'
+}
+
 # Does a FOG image have captured content?  FOG only fills in an image's
 # "size" when a capture has completed, so a record without one is just a
 # template (or a capture that never happened) and must not be deployed.
@@ -702,13 +721,23 @@ phase_capture () {
   funPauseQueue 7200
 
   if [ "$PAUSEQUEUE" == "true" ]; then
-    # Let any already-scheduled deploys drain before we start capturing
-    deploytasks=$(funFogApi GET /task/active '{"typeID": "'${fogdeployid}'"}' | jq -r '.count // 0')
+    # Let any already-scheduled deploys drain before we start capturing, but
+    # only the ones that could be deploying an image we are about to
+    # overwrite.  A busy trial queue is no reason to hold up a smithi
+    # capture, and the whole-server count used to block on exactly that.
+    drainhostids=$(funTypeHostIds $pausetypes)
+    if [ -z "$drainhostids" ] || [ "$drainhostids" == "[]" ]; then
+      # phase_deploy resolved a FOG host for every one of these types, so an
+      # empty list here means the host query failed, not that the lab is idle
+      echo "ERROR: Could not list FOG hosts for: $pausetypes"
+      exit 1
+    fi
+    deploytasks=$(funCountTasksFor $fogdeployid "$drainhostids")
     currentretries=0
     while [ "${deploytasks:-0}" -gt 0 ]; do
-      echo "$(date) -- $deploytasks FOG deploy tasks still queued.  Sleeping 10sec"
+      echo "$(date) -- $deploytasks FOG deploy tasks still queued for $pausetypes.  Sleeping 10sec"
       sleep 10
-      deploytasks=$(funFogApi GET /task/active '{"typeID": "'${fogdeployid}'"}' | jq -r '.count // 0')
+      deploytasks=$(funCountTasksFor $fogdeployid "$drainhostids")
       ((++currentretries))
       # Retry for 1hr
       funRetry $currentretries 360

--- a/sepia-fog-images/build/fog-images.sh
+++ b/sepia-fog-images/build/fog-images.sh
@@ -363,13 +363,15 @@ fi
 
 numdistros=$(echo $DISTROS | wc -w)
 
-# IMAGETYPE overrides the machine-type prefix of the FOG image names, e.g.
-# MACHINETYPES=trial IMAGETYPE=trial-perf locks trial nodes but deploys and
-# recaptures trial-perf_<distro> images.  Empty means images are named after
-# the machine type.
-# The queue is paused for the machine types being used AND the type whose
-# images are being rewritten.
-pausetypes="$MACHINETYPES${IMAGETYPE:+ $IMAGETYPE}"
+# The job always captures ${machine type}_<distro> images, from nodes of
+# that machine type, so images match the hardware they deploy to.  IMAGETYPE
+# names a different machine type's image to deploy as the starting point:
+# MACHINETYPES=trial-perf IMAGETYPE=trial deploys trial_<distro> on a
+# trial-perf node and captures the result as trial-perf_<distro> (created in
+# FOG on first capture).  The source image is only read, never recaptured.
+# Only the machine types being used have their images rewritten, so those
+# are the only queues that pause.
+pausetypes="$MACHINETYPES"
 
 funAllHosts () {
   if [ "$use_teuthologylock" = true ]; then
@@ -511,12 +513,12 @@ phase_deploy () {
         exit 1
       fi
       funSetProfiles ${array2[$i-1]}
-      # The node is provisioned with its own machine type's image and the
-      # result is captured under IMAGETYPE's name (they're the same unless
-      # IMAGETYPE is set, e.g. deploy trial_X on a trial node, capture it
-      # back as trial-perf_X)
-      deployimagename="${type}_${fogprofile}"
-      captureimagename="${IMAGETYPE:-$type}_${fogprofile}"
+      # The node is provisioned from IMAGETYPE's image when set (e.g.
+      # deploy trial_X on a trial-perf node) and the result is always
+      # captured back as the node's own machine type's image
+      sourcetype="${IMAGETYPE:-$type}"
+      deployimagename="${sourcetype}_${fogprofile}"
+      captureimagename="${type}_${fogprofile}"
       # Get FOG host ID
       foghostid=$(funFogApi GET /host '{"name": "'${host}'"}' | jq -r '.hosts[0].id')
       if [ -z "$foghostid" ] || [ "$foghostid" == "null" ]; then
@@ -539,13 +541,13 @@ phase_deploy () {
         # prep-fog-capture walks the seed to the newest minor against the
         # major tree before we capture it as ${deployimagename}.
         seedsearched=true
-        seed=$(funNewestMinorImage $type $splitdistro $distroversion)
+        seed=$(funNewestMinorImage $sourcetype $splitdistro $distroversion)
         if [ -n "$seed" ]; then
           deployimageid=${seed%% *}
           echo "No captured ${deployimagename} image; seeding it from ${seed#* } (image ${deployimageid})"
           echo "prep-fog-capture will upgrade it to the newest ${splitdistro} ${distroversion} minor before capture"
         else
-          echo "No captured ${deployimagename} image and no ${type}_${splitdistro}_${distroversion}.* point release to seed it from"
+          echo "No captured ${deployimagename} image and no ${sourcetype}_${splitdistro}_${distroversion}.* point release to seed it from"
         fi
       fi
       # Make sure the image we'll capture into exists, creating the template
@@ -567,7 +569,7 @@ phase_deploy () {
           # be seeded manually: image a host by hand, then rerun this job
           # with DEFINEDHOSTS pointing at it.
           if [ "$seedsearched" == true ]; then
-            echo "ERROR: No captured FOG image named ${deployimagename} exists, and FOG has no captured ${type}_${splitdistro}_${distroversion}.* point-release image to seed it from."
+            echo "ERROR: No captured FOG image named ${deployimagename} exists, and FOG has no captured ${sourcetype}_${splitdistro}_${distroversion}.* point-release image to seed it from."
           else
             echo "ERROR: No captured FOG image named ${deployimagename} exists so there is nothing to deploy and update."
           fi

--- a/sepia-fog-images/config/definitions/sepia-fog-images.yml
+++ b/sepia-fog-images/config/definitions/sepia-fog-images.yml
@@ -24,7 +24,7 @@
       - string:
           name: MACHINETYPES
           default: "trial"
-          description: "Machine types to capture images for.  (e.g., 'trial' or 'trial smithi' for multiple machine types)"
+          description: "The machine type(s) whose images this run creates or refreshes.  The job locks nodes OF this type, updates them, and captures <MACHINETYPES>_<distro> images FROM them -- the capture always lands under this type's name, on this type's hardware.  e.g. MACHINETYPES=trial-perf produces trial-perf_<distro> images from trial-perf nodes.  Space-separated for multiple types ('trial smithi')."
       - string:
           name: TEUTHOLOGYBRANCH
           default: main
@@ -44,7 +44,7 @@
       - string:
           name: IMAGETYPE
           default: ""
-          description: "Capture the images under a different machine-type name than the nodes being used.  e.g. MACHINETYPES=trial IMAGETYPE=trial-perf locks a trial node, provisions it with the trial_<distro> image, then captures it back as trial-perf_<distro> (creating that image in FOG if needed).  Leave empty to capture back into the same image that was deployed."
+          description: "OPTIONAL: the machine type whose EXISTING image is deployed as the starting point.  This does NOT change what gets captured -- the capture is always <MACHINETYPES>_<distro>.  Leave empty for a normal refresh: deploy <MACHINETYPES>_<distro>, update it, capture it back.  Set it when <MACHINETYPES> has no image yet (or should be rebuilt from another type's): e.g. MACHINETYPES=trial-perf IMAGETYPE=trial locks a trial-perf node, deploys the existing trial_<distro> image onto it, runs the ansible/prep-fog-capture phases, and captures the result as trial-perf_<distro> (created in FOG on first capture).  The <IMAGETYPE>_<distro> source image is only ever read -- it is never modified or recaptured by this run."
       - bool:
           name: SKIPDEPLOY
           default: false


### PR DESCRIPTION
[Build #6](https://jenkins.ceph.com/job/sepia-fog-images/6/console) failed in the ansible stage with `trial059` UNREACHABLE. The node was fine — the pipeline and a scheduled teuthology job were both driving it.

> [!NOTE]
> Needs `teuthology-lock --no-reimage`, merged in ceph/teuthology#2250. The job's prepare phase clones teuthology `main` on every run, so no `TEUTHOLOGYBRANCH` override is needed.

## What happened

| time (UTC) | event |
| --- | --- |
| 20:54:34 | teuthology job 499501 finishes on trial059, releases it |
| 20:54:5x | the lock phase picks trial059 out of `--status up --locked false` |
| **20:54:54** | **teuthology job 499559 locks trial059** — a real, atomic paddles lock |
| 20:54:5x | our `--update --status down --desc` lands *after*, clobbering 499559's description |
| 20:55:24 | FOG reports **3 active tasks** for the 2 hosts we queued 2 deploys for |
| 21:02 | trial059 comes up as ubuntu 22.04; `funCheckHostOs` passes, nothing looks wrong |
| 21:03:15–17 | 1.9s window, 61 consecutive `authorized_keys` items fail with `mkdir /home/ubuntu/.ansible/tmp ... exited with result 1`; items resume `ok` right after, but ansible still marks the host UNREACHABLE → rc 4 → `set -e` kills the phase |
| 21:05:39 | cleanup unpauses and releases **only trial075** |
| 21:06:32 | job 499581 locks trial075, 53s later |

## Why marking a node down never claimed anything

`lock_many` filters `Node.up.is_(True) AND Node.locked.is_(False)`, so a node genuinely marked down can't be selected — which fixes the ordering above: 499559's lock landed first, ours second.

And nothing stopped us. `teuthology-lock --update` → `PUT /nodes/<name>/` → `index_put()` → `node.update(...)`, with no ownership check anywhere on that path. `Node._check_for_update()` bails out immediately unless the payload carries a `locked` key:

```python
locking = values.get('locked')
if locking not in (True, False):
    return
```

`--status down --desc` sends only `up` and `description`. So paddles overwrote a node another job owned and returned success — the claim operation had no failure mode, and losing the race was silent by construction. Any reimage then sets the node back `up`, which is why cleanup released only trial075 and left trial059 wearing this build's lock description while a teuthology job owned it. It still reads that way in paddles.

## Really claim them

`funClaim` now takes a real lock and *then* marks the node down:

```bash
teuthology-lock --lock --no-reimage --desc "$lockdesc" "$1" || return 1
teuthology-lock --update --status down --desc "$lockdesc" "$1"
```

`--lock` alone was unusable here — for a FOG-backed machine type `lock/cli.py` reimages the node on the way in, the opposite of what the deploy phase wants — hence the `--no-reimage` dependency above. A lock payload carries a `locked` key, so `_check_for_update` actually runs and a contended claim fails loudly. Locking before touching the description also means we can no longer scribble on another job's node.

- `funRelease` undoes both via `teuthology-lock --unlock` (`-f` so one failed host doesn't strand the rest). On FOG-type nodes that powers the node off on its way out, which is fine — the queue's next reimage power-cycles it anyway.
- `funClaimedHosts` finds this build's hosts by lock owner + description instead of by status, so a foreign reimage can't make the pipeline forget a host it's holding. `--brief` with neither `-a` nor `--owner` already filters to the invoking user, so there's no owner plumbing.
- The claim loop walks the whole free list (`funFreeHosts`) instead of retrying the head of it, since losing a race is now a real outcome.

## Pause the queue first

Moved from the capture phase to the lock phase. The lock is atomic, but a live dispatcher still competes for every node the queue frees, and lock/deploy/ansible were all running against one. Paused, nodes only ever come free towards the job. The capture phase re-arms the same 2h expiry, and the four inline pause loops collapse into `funPauseQueue`.

## Testing

Every `teuthology-lock` invocation was checked against the `--no-reimage` branch's own `parse_args` and the assertions `cli.main()` runs — including that `--brief` with no `-a`/`--owner` defaults to the invoking user, and that `--update --no-reimage` is correctly rejected.

Phase logic was exercised against a stubbed lock server, running the real phases:

- lock → queue paused first, two nodes locked as `jenkins-build@soko04...` and marked down, loop exits at `numlocked=2`
- **the build #6 case** → flipped a held node back to `up` behind the script's back; unlock still found and released both
- lost lock race (`Cannot lock an already-locked node`) → falls through to the next free node instead of spinning
- another build's node (down, different description) → correctly ignored
- `DEFINEDHOSTS` set → pauses, skips locking, leaves the lock server untouched
- `PAUSEQUEUE=false` → no queue calls, and no misleading "LEAVING the queue paused" warning in cleanup

The stub can't prove the paddles round-trip, so a live build off this branch — with `TEUTHOLOGYBRANCH` pointed at the teuthology branch — is still the real check.

---

# Also in this PR

## `sepia-fog-images: say why a major-tracking seed found nothing`

Seeding `trial_rocky_10` from the newest captured point release already worked (`funNewestMinorImage`), and `rocky_upgrade_scope=major` already makes prep-fog-capture upgrade the seed against the major tree before capture. Only the diagnostics were missing: when no point release exists either, the job exited 1 saying `No captured FOG image named trial_rocky_10 exists`, which reads as if nothing was tried. Now it names the seed and the upgrade when one is found, and names the empty search when one isn't. No behaviour change.

## `sepia-fog-images: only drain deploys for the types we are capturing`

`phase_capture` waited on `.count` from `/task/active` — every active deploy on the FOG server. soko03 serves the whole lab, so a busy trial queue blocked a smithi capture, and with a 1hr retry budget could fail the job over deploys that can't touch the images being rewritten.

Now it counts only tasks whose host belongs to `$pausetypes`, via `funTypeHostIds` + `funCountTasksFor`. Host names are matched anchored, `^<type>[0-9]+$`, so `trial` doesn't also drag in `trial-perf`. An empty ID list is an error, not "nothing to wait for" — `phase_deploy` already resolved a host for every one of these types.

Against synthetic `/host` and `/task/active` payloads with six active deploys: capturing `smithi` waits on 1 instead of 6; `trial` matches trial059/trial075 but not trial-perf004 or trialrunner; `trial trial-perf` picks up all three.


## `sepia-fog-images: IMAGETYPE names the source image, not the capture`

The old semantics (`b8014107`/`669e54e5`) had `IMAGETYPE` rename the *capture*: `MACHINETYPES=trial IMAGETYPE=trial-perf` built trial-perf images on trial hardware, and verify booted them on a trial node too — the image for one machine type never touched that machine type.

Flipped: the job always captures `<MACHINETYPES>_<distro>` from nodes of that machine type (hardware-matched capture and verify), and `IMAGETYPE` names a different type's existing image to deploy as the **starting point**. `MACHINETYPES=trial-perf IMAGETYPE=trial` locks a trial-perf node, deploys the existing `trial_X`, runs ansible + prep-fog-capture, and captures the result as `trial-perf_X` (created in FOG on first capture). The source image is only ever read, so reruns re-derive from the same baseline and nothing can overwrite the source from the wrong hardware. `pausetypes` no longer includes the source type — its queue keeps running. The rocky major-only seeding follows the source type. Parameter descriptions on the job rewritten to spell all of this out.
