### PR TITLE
ceph-pr-pipeline-trigger: use the ci-approved-trigger-token credential

### DIFF
--- a/ceph-pr-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-pr-pipeline-trigger/build/Jenkinsfile
@@ -189,8 +189,10 @@ pipeline {
     stage("evaluate event") {
       steps {
         script {
-          def event = env.X_GitHub_Event
-          if (event == "issue_comment") {
+          // Payload shape, not the X-GitHub-Event header (see the JJB
+          // trigger definition): comment events carry issue.pull_request.
+          def is_comment = (env.issue_is_pr ?: "").startsWith("http")
+          if (is_comment) {
             pr = env.issue_number
             checks = phraseToChecks(env.comment_body ?: "")
             if (!checks) {
@@ -236,7 +238,7 @@ pipeline {
 
           def approved = pr_labels.contains(approval_label)
           def author_trusted = hasCiPermission(author)
-          if (event == "issue_comment") {
+          if (is_comment) {
             authorized = approved || hasCiPermission(env.comment_author)
           } else if (env.action == "labeled") {
             // Adding a label requires triage permission on ceph/ceph, so the

--- a/ceph-pr-pipeline-trigger/config/definitions/ceph-pr-pipeline-trigger.yml
+++ b/ceph-pr-pipeline-trigger/config/definitions/ceph-pr-pipeline-trigger.yml
@@ -34,7 +34,7 @@
     triggers:
       - generic-webhook-trigger:
           token: ceph-pr-pipeline-trigger
-          token-credential-id: pipeline-trigger-token
+          token-credential-id: pr-check-trigger-token
           print-contrib-var: true
           silent-response: true
           header-params:

--- a/ceph-pr-pipeline-trigger/config/definitions/ceph-pr-pipeline-trigger.yml
+++ b/ceph-pr-pipeline-trigger/config/definitions/ceph-pr-pipeline-trigger.yml
@@ -36,11 +36,10 @@
           token: ceph-pr-pipeline-trigger
           token-credential-id: pr-check-trigger-token
           print-contrib-var: true
-          silent-response: true
-          header-params:
-            - key: X_GitHub_Event
-              value: ""
           post-content-params:
+            - type: JSONPath
+              key: pr_url
+              value: $.pull_request.html_url
             - type: JSONPath
               key: action
               value: $.action
@@ -74,11 +73,16 @@
             - type: JSONPath
               key: comment_author
               value: $.comment.user.login
-          regex-filter-text: $X_GitHub_Event:$action:$label_name:$issue_is_pr:$comment_body
+          # The event type is derived from payload shape rather than the
+          # X-GitHub-Event header (GWT's header-variable naming is easy to
+          # get wrong silently): pull_request events have $.pull_request
+          # (pr_url), issue_comment events have $.issue.pull_request
+          # (issue_is_pr).
+          regex-filter-text: $action:$label_name:$pr_url:$issue_is_pr:$comment_body
           # Accept:
-          #  - pull_request opened/reopened/synchronize
+          #  - pull_request opened/reopened/synchronize (pr_url non-empty)
           #  - pull_request labeled, but only for the ci-approved label
-          #  - issue_comment created on a PR (issue_is_pr non-empty) containing
-          #    a "jenkins test ..." or "jenkins retest" phrase
-          regex-filter-expression: "(?is)^(pull_request:(opened|reopened|synchronize):.*|pull_request:labeled:ci-approved:.*|issue_comment:created::https[^:]*:.*jenkins\\s+(re)?test\\b.*)$"
-          cause: "GitHub $X_GitHub_Event ($action) for PR $pr_number$issue_number"
+          #  - issue_comment created on a PR (issue_is_pr non-empty)
+          #    containing a "jenkins test ..." or "jenkins retest" phrase
+          regex-filter-expression: "(?is)^((opened|reopened|synchronize):[^:]*:https.*|labeled:ci-approved:https.*|created:::https[^:]*:.*jenkins\\s+(re)?test\\b.*)$"
+          cause: "GitHub $action for PR $pr_number$issue_number"

--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -57,7 +57,7 @@ webhook (pull_request / issue_comment)
 
 ## Rollout
 
-1. Credentials: `pipeline-trigger-token`, `github-status-check-token`
+1. Credentials: `pr-check-trigger-token`, `github-status-check-token`
    (repo:status + issues write + org read), `github-readonly-token`,
    `dgalloway-docker-hub`, `ibm-cloud-sccache-bucket`, `ceph_win_ci_private_key`.
 2. Deploy both jobs with JJB, then pre-approve the sandbox signatures in
@@ -87,7 +87,7 @@ webhook (pull_request / issue_comment)
 3. Test side by side: run `ceph-pr-pipeline` manually with a PR number and
    `STATUS_PREFIX=pipeline/` so required contexts are untouched.
 4. Add the webhook:
-   `https://jenkins.ceph.com/generic-webhook-trigger/invoke?token=<pipeline-trigger-token>`
+   `https://jenkins.ceph.com/generic-webhook-trigger/invoke?token=<pr-check-trigger-token value>`
    for `pull_request` + `issue_comment`, content type `application/json`.
 5. Flip: disable the GHPRB triggers on the six old jobs, drop `STATUS_PREFIX`.
 6. The cache lives in the dedicated `ceph-pr-builds` bucket (same COS


### PR DESCRIPTION
Follow-up to #2674. The generic-webhook-trigger endpoint 404ed every
webhook delivery because the trigger job referenced a
`pipeline-trigger-token` credential that was never created; the secret
actually provisioned on Jenkins (matching the ceph/ceph webhook URL
token) is `ci-approved-trigger-token`. GWT only matches jobs whose
token credential resolves, so the job was invisible to the webhook.

Verified against the live webhook deliveries (all 404) and a synthetic
probe of the invoke endpoint. Needs a JJB redeploy of
ceph-pr-pipeline-trigger to take effect.