### PR TITLE
ceph-pr-pipeline: move the build-tree cache to the doli LRC's RGW

### DIFF
--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -32,9 +32,9 @@ webhook (pull_request / issue_comment)
                  └─ ceph API tests    tree ← S3, run-backend-api-tests (in container)
 ```
 
-- **Cache:** build trees are zstd-tarred to S3 as
-  `pr-builds/<PR>/<head sha>.<arch>.tar.zst`.  Re-runs for an unchanged head
-  sha skip compilation (`FORCE_BUILD=true` overrides).
+- **Cache:** build trees are zstd-tarred to the Sepia LRC's RGW (the doli
+  cluster) as `pr-builds/<PR>/<head sha>.<arch>.tar.zst`.  Re-runs for an
+  unchanged head sha skip compilation (`FORCE_BUILD=true` overrides).
 - **Statuses:** each leg posts its own context via the GitHub API.  Pending
   is posted from `prepare` before legs wait for executors; canceled/failed
   runs finalize any still-pending contexts.  Docs/container/gha-only PRs
@@ -59,7 +59,8 @@ webhook (pull_request / issue_comment)
 
 1. Credentials: `pr-check-trigger-token`, `github-status-check-token`
    (repo:status + issues write + org read), `github-readonly-token`,
-   `dgalloway-docker-hub`, `ibm-cloud-sccache-bucket`, `ceph_win_ci_private_key`.
+   `dgalloway-docker-hub`, `doli-lrc-pr-builds` (RGW keys for the
+   `ceph-pr-builds` user on the doli LRC), `ceph_win_ci_private_key`.
 2. Deploy both jobs with JJB, then pre-approve the sandbox signatures in
    Manage Jenkins → Script Console:
 
@@ -90,10 +91,12 @@ webhook (pull_request / issue_comment)
    `https://jenkins.ceph.com/generic-webhook-trigger/invoke?token=<pr-check-trigger-token value>`
    for `pull_request` + `issue_comment`, content type `application/json`.
 5. Flip: disable the GHPRB triggers on the six old jobs, drop `STATUS_PREFIX`.
-6. The cache lives in the dedicated `ceph-pr-builds` bucket (same COS
-   instance as ceph-sccache, so the same credential works) with a
-   bucket-wide 21-day expiry lifecycle rule.  Optionally seed reference
-   mirrors for `CEPH_REFERENCE_REPO`.
+6. The cache lives in the dedicated `ceph-pr-builds` bucket on the doli
+   LRC's RGW (any `doli0N.front.sepia.ceph.com:8080` endpoint; the legs
+   pick the first one that answers).  The bucket-wide 21-day expiry
+   lifecycle rule and a 20T quota on the `ceph-pr-builds` RGW user live
+   server-side.  Optionally seed reference mirrors for
+   `CEPH_REFERENCE_REPO`.
 
 ## Known gaps
 

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -19,11 +19,19 @@ import groovy.transform.Field
 @Field String github_api = "https://api.github.com"
 @Field String ceph_repo = "https://github.com/ceph/ceph.git"
 @Field String ceph_build_repo = "https://github.com/ceph/ceph-build"
-@Field String cache_endpoint = "https://s3.us-south.cloud-object-storage.appdomain.cloud"
-// Dedicated bucket (same COS instance as ceph-sccache, so the existing
-// ibm-cloud-sccache-bucket credential works): keeps the pipeline's few huge
-// short-lived objects out of sccache's object store, gives it its own
-// bucket-wide 21-day expiry, and makes bucket usage == pipeline usage.
+// The cache lives in the Sepia LRC's RGW (the doli cluster).  All six hosts
+// serve the same zone; s3_setup picks the first endpoint that answers, so a
+// single doli host being down doesn't take the pipeline with it.
+@Field String cache_endpoints =
+    "http://doli01.front.sepia.ceph.com:8080 " +
+    "http://doli02.front.sepia.ceph.com:8080 " +
+    "http://doli03.front.sepia.ceph.com:8080 " +
+    "http://doli04.front.sepia.ceph.com:8080 " +
+    "http://doli05.front.sepia.ceph.com:8080 " +
+    "http://doli06.front.sepia.ceph.com:8080"
+// Dedicated bucket owned by the ceph-pr-builds RGW user (doli-lrc-pr-builds
+// credential): bucket-wide 21-day expiry lifecycle rule and a 20T user quota
+// live server-side, and bucket usage == pipeline usage.
 @Field String cache_bucket = "ceph-pr-builds"
 
 // CHECKS tokens -> GitHub status contexts.  Keep in sync with the trigger.
@@ -305,11 +313,11 @@ def bwcPreamble(String arch) {
     source ./ceph-build/scripts/build_utils.sh
     source ./ceph-build/scripts/bwc.sh
     source ./ceph-build/ceph-pr-pipeline/build/s3_cache.sh
-    export CACHE_ENDPOINT="${cache_endpoint}"
+    export CACHE_ENDPOINTS="${cache_endpoints}"
     export CACHE_BUCKET="${cache_bucket}"
     export CACHE_KEY="pr-builds/${params.ghprbPullId}/${env.HEAD_SHA}.${arch}.tar.zst"
-    export AWS_ACCESS_KEY_ID="\$SCCACHE_BUCKET_CREDS_USR"
-    export AWS_SECRET_ACCESS_KEY="\$SCCACHE_BUCKET_CREDS_PSW"
+    export AWS_ACCESS_KEY_ID="\$CACHE_BUCKET_CREDS_USR"
+    export AWS_SECRET_ACCESS_KEY="\$CACHE_BUCKET_CREDS_PSW"
     export DOCKER_HUB_USERNAME="\$DOCKER_HUB_CREDS_USR"
     export DOCKER_HUB_PASSWORD="\$DOCKER_HUB_CREDS_PSW"
     export GIT_BRANCH="origin/pr/${params.ghprbPullId}/merge"
@@ -534,7 +542,7 @@ pipeline {
     // stage environment{} block) get these too: any leg may need the S3
     // cache, and any leg may have to (re)build the bwc container image,
     // which pulls the base image from Docker Hub.
-    SCCACHE_BUCKET_CREDS = credentials("ibm-cloud-sccache-bucket")
+    CACHE_BUCKET_CREDS = credentials("doli-lrc-pr-builds")
     DOCKER_HUB_CREDS = credentials("dgalloway-docker-hub")
   }
   stages {

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -621,7 +621,7 @@ pipeline {
           when { beforeAgent true; expression { run_make_check || run_api } }
           stages {
             stage("build ceph") {
-              agent { label "huge && x86_64 && installed-os-noble && !smithi && sepia" }
+              agent { label "huge && x86_64 && installed-os-noble && sepia" }
               steps {
                 script {
                   try {
@@ -659,7 +659,7 @@ pipeline {
                   def legs = [:]
                   if (run_make_check) {
                     legs["make check"] = {
-                      node("x86_64 && installed-os-noble && !smithi && sepia") {
+                      node("x86_64 && installed-os-noble && sepia") {
                         try {
                           doMakeCheck()
                         } finally {
@@ -680,7 +680,7 @@ pipeline {
                   }
                   if (run_api) {
                     legs["ceph API tests"] = {
-                      node("huge && x86_64 && installed-os-noble && !smithi && sepia") {
+                      node("huge && x86_64 && installed-os-noble && sepia") {
                         try {
                           doApiTests()
                         } finally {

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -21,7 +21,9 @@ import groovy.transform.Field
 @Field String ceph_build_repo = "https://github.com/ceph/ceph-build"
 // The cache lives in the Sepia LRC's RGW (the doli cluster).  All six hosts
 // serve the same zone; s3_setup picks the first endpoint that answers, so a
-// single doli host being down doesn't take the pipeline with it.
+// single doli host being down doesn't take the pipeline with it.  It is only
+// reachable from inside the lab, so the legs that move the build tree
+// through it require the sepia label.
 @Field String cache_endpoints =
     "http://doli01.front.sepia.ceph.com:8080 " +
     "http://doli02.front.sepia.ceph.com:8080 " +
@@ -577,7 +579,7 @@ pipeline {
         }
         stage("build and test (arm64)") {
           when { beforeAgent true; expression { run_make_check_arm64 } }
-          agent { label "arm64 && (installed-os-noble || centos9)" }
+          agent { label "arm64 && (installed-os-noble || centos9) && sepia" }
           steps {
             script { doMakeCheckArm64() }
           }
@@ -619,7 +621,7 @@ pipeline {
           when { beforeAgent true; expression { run_make_check || run_api } }
           stages {
             stage("build ceph") {
-              agent { label "huge && x86_64 && installed-os-noble && !smithi" }
+              agent { label "huge && x86_64 && installed-os-noble && !smithi && sepia" }
               steps {
                 script {
                   try {
@@ -657,7 +659,7 @@ pipeline {
                   def legs = [:]
                   if (run_make_check) {
                     legs["make check"] = {
-                      node("x86_64 && installed-os-noble && !smithi") {
+                      node("x86_64 && installed-os-noble && !smithi && sepia") {
                         try {
                           doMakeCheck()
                         } finally {
@@ -678,7 +680,7 @@ pipeline {
                   }
                   if (run_api) {
                     legs["ceph API tests"] = {
-                      node("huge && x86_64 && installed-os-noble && !smithi") {
+                      node("huge && x86_64 && installed-os-noble && !smithi && sepia") {
                         try {
                           doApiTests()
                         } finally {

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -473,14 +473,19 @@ def doMakeCheckArm64() {
         """
       )
       // Upload before running the tests so a failed run still leaves a
-      // cached build for "jenkins test make check arm64" to reuse.
-      sh(
-        label: "upload build tree to cache",
+      // cached build for "jenkins test make check arm64" to reuse.  Best
+      // effort: unlike the x86_64 leg, the tests run on this same node,
+      // so a cache outage shouldn't throw away the build we just did.
+      if (sh(
+        label: "upload build tree to cache (best effort)",
         script: bwcPreamble("arm64") + """
           s3_setup
           s3_cache_put ceph
-        """
-      )
+        """,
+        returnStatus: true,
+      ) != 0) {
+        echo "Cache upload failed; continuing (a re-run will rebuild)"
+      }
     }
     postStatus("make-check-arm64", "pending", "running make check (arm64)")
     sh(label: "run make check (arm64)", script: makeCheckTestsShell("arm64"))

--- a/ceph-pr-pipeline/build/s3_cache.sh
+++ b/ceph-pr-pipeline/build/s3_cache.sh
@@ -10,7 +10,9 @@
 # install_python_packages).
 #
 # Environment:
-#   CACHE_ENDPOINT - S3 endpoint URL
+#   CACHE_ENDPOINTS - space-separated S3 endpoint URLs (all serving the same
+#                     zone, e.g. the RGWs on the doli LRC hosts); s3_setup
+#                     sets CACHE_ENDPOINT to the first one that answers
 #   CACHE_BUCKET   - bucket name
 #   CACHE_KEY      - object key, e.g. pr-builds/12345/<head sha>.tar.zst
 #   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY - bucket credentials
@@ -26,6 +28,18 @@ s3_setup() {
         install_python_packages "$venv" "pkgs[@]"
         AWSCLI=${venv}/bin/aws
     fi
+    # Every endpoint serves the same RGW zone; take the first live one so a
+    # single host being down doesn't fail the leg.
+    local ep
+    for ep in $CACHE_ENDPOINTS; do
+        if curl -s -m 10 -o /dev/null "$ep"; then
+            CACHE_ENDPOINT=$ep
+            return 0
+        fi
+        echo "s3_setup: $ep not answering, trying next" >&2
+    done
+    echo "s3_setup: no cache endpoint reachable: $CACHE_ENDPOINTS" >&2
+    return 1
 }
 
 s3_cache_exists() {


### PR DESCRIPTION
## What

Moves the ceph-pr-pipeline build-tree cache (the zstd tarballs that hand the
compiled tree from the build leg to the make check / API test builders, and
serve as the re-run cache) from IBM COS to the RGW already running on the
Sepia LRC (the doli cluster), and makes the arm64 leg's cache upload
best-effort.

- `CACHE_ENDPOINTS` lists all six `doli0N.front.sepia.ceph.com:8080` RGWs;
  `s3_setup` picks the first one that answers, so a single doli host being
  down doesn't fail a leg.
- The `ibm-cloud-sccache-bucket` credential is replaced by
  `doli-lrc-pr-builds` (keys of the dedicated `ceph-pr-builds` RGW user).
  ceph-dev-pipeline is untouched and keeps using the IBM credential.
- The arm64 leg's upload no longer fails the leg: unlike x86_64 (where the
  tarball is the hand-off to other builders and must stay fatal), arm64
  builds and tests on the same node, so a cache outage shouldn't throw away
  a multi-hour build before the tests have even run.

## Why

Every builder the pipeline can land on lives in the Sepia lab, so the cache
traffic (a few huge, short-lived objects per PR) never needs to leave the
lab or ride on the IBM COS quota.

## Server-side setup (already done on the LRC)

- Dedicated `ceph-pr-builds` RGW user and bucket.
- Bucket-wide 21-day expiry lifecycle rule (same policy the COS bucket had)
  and a 20T user quota as a runaway safety valve.
- `doli-lrc-pr-builds` Jenkins credential created.

## Validation

- End-to-end from braggi01 with awscli (the client the legs use): upload,
  head-object (confirms objects get stamped with the `expire-21d` rule),
  download, byte-compare, delete.
- All six RGW endpoints answer by hostname from every builder pool the
  pipeline uses (braggi, soko, toko, bath, adami).
- Jenkinsfile passes the declarative linter.

Suggested post-merge check: one `FORCE_BUILD=true` run to exercise the new
cache through Jenkins' own credential, then the old COS `ceph-pr-builds`
bucket can be deleted.