### PR TITLE
ceph-windows: cross-compile in a podman container instead of a VM

### DIFF
--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -12,7 +12,7 @@ rules don't change.
 | `Unmodified Submodules` | [ceph-pr-submodules](../ceph-pr-submodules/) | GitHub API only, no clone, seconds |
 | `make check` | [ceph-pull-requests](../ceph-pull-requests/) | shared build → ctest on its own builder |
 | `ceph API tests` | [ceph-pr-api](../ceph-pr-api/) | shared build → API tests on its own builder |
-| `ceph windows tests` | [ceph-windows-pull-requests](../ceph-windows-pull-requests/) | parallel leg, own (win32) build |
+| `ceph windows tests` | [ceph-windows-pull-requests](../ceph-windows-pull-requests/) | parallel leg, containerized builds + one Windows VM (see below) |
 | `make check (arm64)` | [ceph-pull-requests-arm64](../ceph-pull-requests-arm64/) | parallel leg, build+test on one arm64 node |
 
 ## Flow
@@ -24,7 +24,7 @@ webhook (pull_request / issue_comment)
             prepare                   resolve PR, classify files, post pending statuses
             ├─ Signed-off-by          GitHub API
             ├─ Unmodified Submodules  GitHub API
-            ├─ ceph windows tests     (libvirt) own clone + build + tests
+            ├─ ceph windows tests     (noble+libvirt) container builds + Windows VM
             ├─ build and test (arm64) (arm64)  restore-or-build + tests
             └─ build and test
                  build ceph           (huge)  ONE clone, bwc -e buildtests, tree → S3
@@ -41,6 +41,85 @@ webhook (pull_request / issue_comment)
   (plus qa-only for windows/arm64) report success without building.
 - **Checkout time:** set `CEPH_REFERENCE_REPO` to a local ceph.git mirror on
   the builders to cut the remaining clones to seconds.
+
+## The windows leg
+
+Historically ([ceph-windows-pull-requests](../ceph-windows-pull-requests/))
+this check provisioned three VMs per run: an Ubuntu VM to cross-compile
+Ceph for Windows in, a second Ubuntu VM to build and host a vstart cluster,
+and a Windows VM to run the tests — 114–177 minutes, most of it VM
+provisioning and two from-scratch builds.  Now only the Windows client is a
+VM (it loads the wnbd/Dokan kernel drivers; nothing but a real Windows
+kernel can); both builds run in containers on the builder host with
+persistent caches.  Measured: 79 min on a node with cold caches, ~60 warm.
+
+Steps, in order (all scripts in [scripts/ceph-windows](../scripts/ceph-windows/)):
+
+1. **Checkout**: ceph-build plus the PR merge ref, then submodules.
+2. **Cross-compile** (`win32_build_container`): runs the PR's own
+   `win32_build.sh` in a podman container built from
+   `win32-build.containerfile` (just the mingw toolchain packages; podman's
+   layer cache makes the image build a no-op after each builder's first
+   run).  Produces
+   `$WORKSPACE/ceph.zip`; the build tree is then removed so `do_cmake.sh`
+   can run later.  Two per-builder caches under `~/.cache/ceph-win32-build/`:
+   - `deps/<sha>`: the compiled mingw deps (mingw-llvm, boost, openssl,
+     ...), keyed by the sha of the branch's `win32_deps_build.sh` +
+     `mingw_conf.sh` + the containerfile, so a deps change in any branch
+     just builds a new entry (flock-guarded); `win32_build.sh` skips the
+     whole deps build when the cache's `completed` marker exists.
+   - `ccache`: compiler cache for the tree itself.  Mount paths are fixed
+     (`/workspace`, `/depscache`) so object paths stay stable across builds
+     and nodes.  `MINGW_LLVM_DIR` must be exported into the container:
+     `mingw_conf.sh` defaults it relative to the ceph tree, not `DEPS_DIR`.
+3. **`setup_libvirt`**: ensures the libvirt default NAT network (virbr0,
+   192.168.122.1) and the ssh helpers.
+4. **`setup_libvirt_windows_vm`**: boots the pristine Windows Server 2019
+   image as a QEMU/KVM guest on that network.
+5. **`setup_ceph_vstart_container`**: compiles the PR's own source into
+   the Ceph cluster the Windows client is tested against, and starts it.
+   Nothing prebuilt is downloaded and no release is involved: bwc starts
+   a container that has Ceph's build dependencies installed, mounts the
+   same `$WORKSPACE/ceph` checkout (the PR merged onto its target
+   branch) inside it, and runs `do_cmake.sh && ninja vstart` on it —
+   `CMAKE_BUILD_TYPE=Release` just means an optimized compile of the
+   PR's code.  Because both the client zip and the cluster come from
+   this one checkout, a PR that changes mon/osd/mds behavior is tested
+   on both sides of the wire, exactly like the VM flow was.  ccache is
+   what makes the compile fast: a per-builder stash of object files from
+   previous runs, so source files the PR didn't change are cache hits
+   and only the PR's actual changes recompile (~5 min typical; ~10 min
+   on a builder compiling for the first time).  vstart.sh then launches
+   the daemons (mon/mgr/osd/mds) inside a second, long-lived container
+   named `ceph_build`.  That container shares the host's network
+   (`--net=host`) and the daemons bind 192.168.122.1 — the builder's own
+   address on the libvirt NAT bridge — which is an address the Windows
+   VM can reach, so the client talks to the cluster like it would any
+   remote one.  The leg waits (bounded) for a READY marker the vstart
+   script drops once pools are set up, and fails immediately if the
+   cluster container dies instead.  Two vstart behaviors worth knowing:
+   - vstart writes `mds root ino uid/gid = $(id -u/-g)` into the MDS conf,
+     and the Windows client mounts with `client_mount_uid/gid = 1000` and
+     `client_permissions = true` — the cluster must be started by uid 1000
+     (as the VM's ubuntu user silently always did) or every cephfs write
+     from the client gets EACCES.
+   - vstart writes outside its data dir: `logrotate.conf`/`.state` in the
+     build dir and `vstart_environment.sh` next to itself in src.  The
+     vstart user owns the build dir wholesale plus that one src file; the
+     host-side conf/keyring/log extraction goes through `podman cp`/`podman
+     exec` because those files are subuid-owned on the host.
+6. **`run_tests`**: uploads `ceph.zip` + conf/keyring to the Windows VM,
+   runs `run_tests.ps1` and the qa/workunits/windows suite.  With
+   `VSTART_CONTAINER` set, its cluster-side diagnostics use `podman exec`
+   and local log copies; unset, the old ssh-into-the-VM behavior is
+   unchanged (the old freestyle job shares this script).
+7. **Cleanup** (post): remove both containers, destroy the VM, wipe the
+   workspace.
+
+The leg needs `installed-os-noble` builders: the container builds need a
+modern podman, and on jammy `setup_container_runtime.sh` can only provide
+docker.  The `ceph-windows-container-build` job runs step 2 standalone for
+validation or one-off manual windows builds.
 
 ## Gating
 

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -518,13 +518,19 @@ def doWindowsTests() {
         rm -rf ceph/build
       """
     )
+    // The vstart cluster builds and runs in a bwc container too (Release,
+    // same configuration the VM used), so the only VM left is the Windows
+    // client itself.
     postStatus("windows", "pending", "running windows tests")
     sh """#!/bin/bash -ex
+      export DOCKER_HUB_USERNAME="\$DOCKER_HUB_CREDS_USR"
+      export DOCKER_HUB_PASSWORD="\$DOCKER_HUB_CREDS_PSW"
+      export GIT_BRANCH="origin/pr/${params.ghprbPullId}/merge"
       source ./ceph-build/scripts/build_utils.sh
+      source ./ceph-build/scripts/bwc.sh
       source ./ceph-build/scripts/ceph-windows/setup_libvirt
-      source ./ceph-build/scripts/ceph-windows/setup_libvirt_ubuntu_vm
       source ./ceph-build/scripts/ceph-windows/setup_libvirt_windows_vm
-      source ./ceph-build/scripts/ceph-windows/setup_ceph_vstart
+      source ./ceph-build/scripts/ceph-windows/setup_ceph_vstart_container
       source ./ceph-build/scripts/ceph-windows/run_tests
     """
   }
@@ -612,9 +618,9 @@ pipeline {
           post {
             always {
               sh """#!/bin/bash
-                podman rm -f "ceph-win32-build-\$BUILD_ID" 2>/dev/null || true
+                podman rm -f "ceph-win32-build-\$BUILD_ID" ceph_build 2>/dev/null || true
                 mkdir -p artifacts
-                cp ceph/build/*.log artifacts/ 2>/dev/null || true
+                cp ceph/build/*.log vstart-container.log artifacts/ 2>/dev/null || true
               """
               archiveArtifacts(artifacts: "artifacts/**", allowEmptyArchive: true)
               sh """#!/bin/bash

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -599,7 +599,10 @@ pipeline {
         }
         stage("ceph windows tests") {
           when { beforeAgent true; expression { run_windows } }
-          agent { label "x86_64 && (installed-os-noble || installed-os-jammy) && libvirt" }
+          // noble only: the containerized cross-build needs a modern podman,
+          // which setup_container_runtime.sh can't provide on jammy (it falls
+          // back to docker there).
+          agent { label "x86_64 && installed-os-noble && libvirt" }
           environment {
             CEPH_WIN_CI_KEY = credentials("ceph_win_ci_private_key")
           }

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -499,15 +499,29 @@ def doWindowsTests() {
   checkoutCephBuild()
   checkoutCephPr()
   withStatus("windows", "ceph windows tests") {
-    // Same script chain as the old ceph-windows-pull-requests job (which
-    // concatenated these into one shell); check_docs_pr_only is handled by
-    // the prepare stage instead.
+    // The cross-compile runs in a podman container on this host (with the
+    // mingw deps and ccache persisted between builds), replacing the
+    // throwaway build VM the old ceph-windows-pull-requests job provisioned
+    // on every run.  Only the vstart cluster host and the Windows client
+    // remain libvirt VMs.
+    postStatus("windows", "pending", "cross-compiling ceph for windows")
+    sh "./ceph-build/scripts/setup_container_runtime.sh"
+    sh(
+      label: "cross-compile ceph for windows (container)",
+      script: """#!/bin/bash -ex
+        export DOCKER_HUB_USERNAME="\$DOCKER_HUB_CREDS_USR"
+        export DOCKER_HUB_PASSWORD="\$DOCKER_HUB_CREDS_PSW"
+        bash ./ceph-build/scripts/ceph-windows/win32_build_container
+        # The cross-build outputs are all in ceph.zip; drop the build tree
+        # so setup_ceph_vstart's rsync doesn't ship it to the cluster VM
+        # (do_cmake.sh refuses to run in a tree with a build dir).
+        rm -rf ceph/build
+      """
+    )
+    postStatus("windows", "pending", "running windows tests")
     sh """#!/bin/bash -ex
       source ./ceph-build/scripts/build_utils.sh
       source ./ceph-build/scripts/ceph-windows/setup_libvirt
-      source ./ceph-build/scripts/ceph-windows/setup_libvirt_ubuntu_vm
-      source ./ceph-build/scripts/ceph-windows/win32_build
-      source ./ceph-build/scripts/ceph-windows/cleanup_libvirt_ubuntu_vm
       source ./ceph-build/scripts/ceph-windows/setup_libvirt_ubuntu_vm
       source ./ceph-build/scripts/ceph-windows/setup_libvirt_windows_vm
       source ./ceph-build/scripts/ceph-windows/setup_ceph_vstart
@@ -594,6 +608,11 @@ pipeline {
           }
           post {
             always {
+              sh """#!/bin/bash
+                podman rm -f "ceph-win32-build-\$BUILD_ID" 2>/dev/null || true
+                mkdir -p artifacts
+                cp ceph/build/*.log artifacts/ 2>/dev/null || true
+              """
               archiveArtifacts(artifacts: "artifacts/**", allowEmptyArchive: true)
               sh """#!/bin/bash
                 source ./ceph-build/scripts/build_utils.sh

--- a/ceph-windows-container-build/README.md
+++ b/ceph-windows-container-build/README.md
@@ -17,6 +17,10 @@ Two host-side caches make repeat builds fast:
   ceph tree itself.  Container mount paths are fixed so object paths are
   stable across builds.
 
-This job is the testbed for moving ceph-pr-pipeline's windows leg off VMs;
-it is also usable for one-off manual windows builds of a branch or PR
-(set `CEPH_BRANCH` or `ghprbPullId`).
+This job runs the cross-compile step of ceph-pr-pipeline's windows leg
+standalone — for validating changes to the container build without a full
+pipeline run, and for one-off manual windows builds of a branch or PR (set
+`CEPH_BRANCH` or `ghprbPullId`).  How the full leg fits together
+(cross-compile container, vstart cluster container, Windows VM, and the
+network between them) is documented in
+[ceph-pr-pipeline's README](../ceph-pr-pipeline/README.md#the-windows-leg).

--- a/ceph-windows-container-build/README.md
+++ b/ceph-windows-container-build/README.md
@@ -1,0 +1,22 @@
+# ceph-windows-container-build
+
+Builds Ceph for Windows (ceph.git's `win32_build.sh`) inside a podman
+container on the builder host, via
+`scripts/ceph-windows/win32_build_container`, instead of the throwaway
+libvirt Ubuntu VM the windows CI used historically.  Produces the same
+`ceph.zip` that `setup_libvirt_windows_vm`/`run_tests` consume.
+
+Two host-side caches make repeat builds fast:
+
+- **deps** (`~/.cache/ceph-win32-build/deps/<hash>`): the compiled mingw
+  dependencies (mingw-llvm, boost, openssl, ...), keyed by the sha of the
+  branch's `win32_deps_build.sh` + `mingw_conf.sh` + the containerfile.
+  `win32_build.sh` skips the whole deps build when the cache's `completed`
+  marker is present.
+- **ccache** (`~/.cache/ceph-win32-build/ccache`): compiler cache for the
+  ceph tree itself.  Container mount paths are fixed so object paths are
+  stable across builds.
+
+This job is the testbed for moving ceph-pr-pipeline's windows leg off VMs;
+it is also usable for one-off manual windows builds of a branch or PR
+(set `CEPH_BRANCH` or `ghprbPullId`).

--- a/ceph-windows-container-build/build/Jenkinsfile
+++ b/ceph-windows-container-build/build/Jenkinsfile
@@ -1,0 +1,79 @@
+// ceph-windows-container-build: validation job for the containerized Ceph
+// Windows cross-build.  Runs ceph.git's win32_build.sh inside a podman
+// container on the builder host (scripts/ceph-windows/win32_build_container)
+// instead of the throwaway libvirt Ubuntu VM the windows CI has used so far,
+// and produces the same ceph.zip the windows test flow consumes.
+//
+// Testbed for moving ceph-pr-pipeline's windows leg off VMs; also usable for
+// one-off manual windows builds of a branch or PR.
+
+def checkoutCeph() {
+  if (params.ghprbPullId) {
+    sh "rm -rf ceph"
+    checkout scmGit(
+      branches: [[name: "origin/pr/${params.ghprbPullId}/merge"]],
+      browser: [$class: 'GithubWeb', repoUrl: 'https://github.com/ceph/ceph'],
+      userRemoteConfigs: [[
+        url: "https://github.com/ceph/ceph.git",
+        refspec: "+refs/pull/${params.ghprbPullId}/*:refs/remotes/origin/pr/${params.ghprbPullId}/*",
+      ]],
+      extensions: [
+        [$class: 'RelativeTargetDirectory', relativeTargetDir: 'ceph'],
+        [$class: 'CloneOption', shallow: true, noTags: true, honorRefspec: true,
+         timeout: 20],
+      ],
+    )
+  } else {
+    sh """#!/bin/bash -ex
+      rm -rf ceph
+      git clone --depth 1 --no-tags -b "${params.CEPH_BRANCH}" https://github.com/ceph/ceph.git ceph
+    """
+  }
+}
+
+pipeline {
+  agent { label params.NODE_LABEL }
+  options {
+    skipDefaultCheckout(true)
+    timeout(time: 5, unit: "HOURS")
+    timestamps()
+  }
+  environment {
+    TERM = "xterm"
+    DOCKER_HUB_CREDS = credentials("dgalloway-docker-hub")
+  }
+  stages {
+    stage("checkout") {
+      steps {
+        sh """#!/bin/bash -ex
+          rm -rf ceph-build
+          git clone --depth 1 --no-tags -b "${params.CEPH_BUILD_BRANCH}" https://github.com/ceph/ceph-build ceph-build
+        """
+        script { checkoutCeph() }
+      }
+    }
+    stage("build ceph windows") {
+      steps {
+        sh "./ceph-build/scripts/setup_container_runtime.sh"
+        sh """#!/bin/bash -ex
+          export DOCKER_HUB_USERNAME="\$DOCKER_HUB_CREDS_USR"
+          export DOCKER_HUB_PASSWORD="\$DOCKER_HUB_CREDS_PSW"
+          export NUM_WORKERS="${params.NUM_WORKERS}"
+          bash ./ceph-build/scripts/ceph-windows/win32_build_container
+        """
+      }
+    }
+  }
+  post {
+    always {
+      sh """#!/bin/bash
+        podman rm -f "ceph-win32-build-\$BUILD_ID" 2>/dev/null || true
+        rm -rf artifacts
+        mkdir -p artifacts
+        cp ceph/build/*.log artifacts/ 2>/dev/null || true
+        ls -lh ceph.zip 2>/dev/null || true
+      """
+      archiveArtifacts(artifacts: "artifacts/**", allowEmptyArchive: true)
+    }
+  }
+}

--- a/ceph-windows-container-build/config/definitions/ceph-windows-container-build.yml
+++ b/ceph-windows-container-build/config/definitions/ceph-windows-container-build.yml
@@ -43,8 +43,8 @@
 
       - string:
           name: NODE_LABEL
-          default: "x86_64 && (installed-os-noble || installed-os-jammy) && libvirt"
-          description: "builder label expression (default: the same pool the windows test jobs use)"
+          default: "x86_64 && installed-os-noble && libvirt"
+          description: "builder label expression (noble only: the container build needs a modern podman, which setup_container_runtime.sh can't provide on jammy)"
 
       - string:
           name: NUM_WORKERS

--- a/ceph-windows-container-build/config/definitions/ceph-windows-container-build.yml
+++ b/ceph-windows-container-build/config/definitions/ceph-windows-container-build.yml
@@ -1,0 +1,62 @@
+- job:
+    name: ceph-windows-container-build
+    description: |
+      Validation job for the containerized Ceph Windows cross-build: runs
+      ceph.git's win32_build.sh inside a podman container on the builder host
+      (instead of the libvirt Ubuntu VM the windows CI used historically) and
+      produces the ceph.zip consumed by the windows tests.  Compiled mingw
+      dependencies and ccache persist on the builder between runs.
+      Testbed for ceph-pr-pipeline's windows leg; also usable for one-off
+      manual windows builds of a branch or PR.
+    project-type: pipeline
+    quiet-period: 1
+    concurrent: true
+
+    properties:
+      - build-discarder:
+          days-to-keep: 15
+          num-to-keep: 50
+
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/ceph/ceph-build
+            branches:
+              - ${{CEPH_BUILD_BRANCH}}
+            shallow-clone: true
+            submodule:
+              disable: true
+            wipe-workspace: true
+      script-path: ceph-windows-container-build/build/Jenkinsfile
+      lightweight-checkout: true
+      do-not-fetch-tags: true
+
+    parameters:
+      - string:
+          name: CEPH_BRANCH
+          default: main
+          description: "ceph.git branch to build (ignored if ghprbPullId is set)"
+
+      - string:
+          name: ghprbPullId
+          description: "optional: build this ceph PR's merge ref instead of CEPH_BRANCH"
+
+      - string:
+          name: NODE_LABEL
+          default: "x86_64 && (installed-os-noble || installed-os-jammy) && libvirt"
+          description: "builder label expression (default: the same pool the windows test jobs use)"
+
+      - string:
+          name: NUM_WORKERS
+          default: ""
+          description: "parallel build jobs (default: nproc, capped at 32)"
+
+      - string:
+          name: CEPH_BUILD_BRANCH
+          default: main
+          description: "Use the Jenkinsfile and scripts from this ceph-build branch"
+
+    wrappers:
+      - inject-passwords:
+          global: true
+          mask-password-params: true

--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -74,7 +74,10 @@ function collect_artifacts() {
 
         sudo journalctl -b > $WORKSPACE/artifacts/cluster/journal || true
 
-        cp $WORKSPACE/ceph/build/vstart/out/*.log $WORKSPACE/artifacts/cluster/ceph_logs/
+        # tar via podman exec, not cp: the cluster runs as uid 1000 in the
+        # container, so on the host its files are owned by a subuid.
+        podman exec $VSTART_CONTAINER bash -c "cd /ceph/build/vstart/out && tar cf - *.log" \
+            | tar xf - -C $WORKSPACE/artifacts/cluster/ceph_logs/
         cp $WORKSPACE/vstart-container.log $WORKSPACE/artifacts/cluster/ 2>/dev/null || true
     else
         SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec free -h

--- a/scripts/ceph-windows/run_tests
+++ b/scripts/ceph-windows/run_tests
@@ -8,8 +8,23 @@ if [[ ! -f $CEPH_KEYRING ]]; then echo "ERROR: The Ceph keyring file doesn't exi
 
 if [[ -z $WINDOWS_SSH_USER ]]; then echo "ERROR: The WINDOWS_SSH_USER env variable is not set"; exit 1; fi
 if [[ -z $WINDOWS_VM_IP ]]; then echo "ERROR: The WINDOWS_VM_IP env variable is not set"; exit 1; fi
-if [[ -z $UBUNTU_SSH_USER ]]; then echo "ERROR: The UBUNTU_SSH_USER env variable is not set"; exit 1; fi
-if [[ -z $UBUNTU_VM_IP ]]; then echo "ERROR: The UBUNTU_VM_IP env variable is not set"; exit 1; fi
+# The vstart cluster runs either in a libvirt VM (UBUNTU_VM_IP) or, when
+# VSTART_CONTAINER is set (see setup_ceph_vstart_container), in a container
+# on this host.
+if [[ -z $VSTART_CONTAINER ]]; then
+    if [[ -z $UBUNTU_SSH_USER ]]; then echo "ERROR: The UBUNTU_SSH_USER env variable is not set"; exit 1; fi
+    if [[ -z $UBUNTU_VM_IP ]]; then echo "ERROR: The UBUNTU_VM_IP env variable is not set"; exit 1; fi
+fi
+
+function cluster_status() {
+    if [[ -n $VSTART_CONTAINER ]]; then
+        podman exec -e CEPH_CONF=/ceph/build/vstart/ceph.conf \
+            -e CEPH_KEYRING=/ceph/build/vstart/keyring \
+            $VSTART_CONTAINER /ceph/build/bin/ceph status
+    else
+        SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec ./ceph/build/bin/ceph status
+    fi
+}
 
 export SSH_USER=$WINDOWS_SSH_USER
 export SSH_ADDRESS=$WINDOWS_VM_IP
@@ -53,19 +68,28 @@ function collect_artifacts() {
     mkdir -p $WORKSPACE/artifacts/cluster
     mkdir -p $WORKSPACE/artifacts/cluster/ceph_logs
 
-    SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec ./ceph/build/bin/ceph status
-    SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec free -h
-    SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec df -h
-    SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec \
-        "du -sh ./ceph-vstart/*"
+    cluster_status
+    if [[ -n $VSTART_CONTAINER ]]; then
+        podman exec $VSTART_CONTAINER bash -c "free -h; df -h; du -sh /ceph/build/vstart/*"
 
-    SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec \
-        "journalctl -b > /tmp/journal"
-    SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP scp_download \
-        /tmp/journal $WORKSPACE/artifacts/cluster/journal
+        sudo journalctl -b > $WORKSPACE/artifacts/cluster/journal || true
 
-    SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP scp_download \
-        './ceph-vstart/out/*.log' $WORKSPACE/artifacts/cluster/ceph_logs/
+        cp $WORKSPACE/ceph/build/vstart/out/*.log $WORKSPACE/artifacts/cluster/ceph_logs/
+        cp $WORKSPACE/vstart-container.log $WORKSPACE/artifacts/cluster/ 2>/dev/null || true
+    else
+        SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec free -h
+        SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec df -h
+        SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec \
+            "du -sh ./ceph-vstart/*"
+
+        SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec \
+            "journalctl -b > /tmp/journal"
+        SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP scp_download \
+            /tmp/journal $WORKSPACE/artifacts/cluster/journal
+
+        SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP scp_download \
+            './ceph-vstart/out/*.log' $WORKSPACE/artifacts/cluster/ceph_logs/
+    fi
 
     scp_download /workspace/test_results $WORKSPACE/artifacts/test_results
     if [[ "$INCLUDE_USERSPACE_CRASH_DUMPS" = true ]]; then
@@ -98,7 +122,7 @@ function on_exit() {
 trap on_exit EXIT
 
 # View cluster status before test run
-SSH_USER=$UBUNTU_SSH_USER SSH_ADDRESS=$UBUNTU_VM_IP ssh_exec ./ceph/build/bin/ceph status
+cluster_status
 #
 # Run the Windows tests
 #

--- a/scripts/ceph-windows/setup_ceph_vstart_container
+++ b/scripts/ceph-windows/setup_ceph_vstart_container
@@ -91,8 +91,11 @@ set -o errexit
 set -o pipefail
 
 useradd --uid 1000 --user-group --no-create-home cephtest 2> /dev/null || true
-mkdir -p build/vstart
-chown -R 1000:1000 build/vstart
+# vstart writes throughout the build dir (vstart data, logrotate.conf, ...)
+# and drops an environment helper next to vstart.sh in the source tree.
+chown -R 1000:1000 build
+touch src/vstart_environment.sh
+chown 1000:1000 src/vstart_environment.sh
 exec runuser -u cephtest -- env HOME=/tmp bash ./vstart-run-inner.sh
 EOF
 chmod +x vstart-run.sh
@@ -138,6 +141,13 @@ rm -f build/vstart/READY
 TIMEOUT=900
 SECONDS=0
 until [[ -f build/vstart/READY ]]; do
+    # bwc prints this when the container command fails; don't sit out the
+    # full timeout on a cluster that already died.
+    if grep -q "returned non-zero exit status" "$WORKSPACE/vstart-container.log" 2> /dev/null; then
+        echo "ERROR: the vstart container exited"
+        tail -100 "$WORKSPACE/vstart-container.log"
+        exit 1
+    fi
     if (( SECONDS > TIMEOUT )); then
         echo "TIMEOUT: vstart cluster not ready after ${TIMEOUT}s"
         tail -100 "$WORKSPACE/vstart-container.log"

--- a/scripts/ceph-windows/setup_ceph_vstart_container
+++ b/scripts/ceph-windows/setup_ceph_vstart_container
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Build and run the Ceph vstart cluster for the windows tests in a bwc
+# container on the builder host, replacing the libvirt Ubuntu VM that
+# setup_libvirt_ubuntu_vm + setup_ceph_vstart provisioned (and fully rebuilt
+# ceph in) on every run.  Same Release build and vstart configuration as the
+# VM flow, but the image has the build deps baked in and a persistent ccache
+# makes repeat builds fast.
+#
+# The cluster container runs with --net=host and vstart binds the libvirt
+# bridge address, which guests on the default NAT network reach directly --
+# that's how the Windows client VM gets to the cluster.
+#
+# Expects build_utils.sh, bwc.sh and setup_libvirt to be sourced already
+# (bwc + podman helpers, and the libvirt default network for VSTART_IP).
+# Exports for run_tests: VSTART_CONTAINER, CEPH_CONF, CEPH_KEYRING,
+# CEPH_WINDOWS_CONF.
+
+if [[ -z $WORKSPACE ]]; then echo "ERROR: The WORKSPACE env variable is not set"; exit 1; fi
+
+export VSTART_DIR="$WORKSPACE/ceph_vstart"
+export VSTART_CONTAINER="ceph_build"
+VSTART_CCACHE_DIR="${VSTART_CCACHE_DIR:-$HOME/.cache/ceph-win32-build/vstart-ccache}"
+
+USE_MEMSTORE="${USE_MEMSTORE:-no}"
+VSTART_MEMSTORE_BYTES="5368709120"  # 5GB
+VSTART_BLUESTORE_BYTES="5368709120"  # 5GB
+
+VSTART_IP=$(ip -4 -o addr show virbr0 | awk '{print $4}' | cut -d/ -f1)
+if [[ -z $VSTART_IP ]]; then
+    echo "ERROR: no address on virbr0; is the libvirt default network up?"
+    exit 1
+fi
+
+if [[ "$USE_MEMSTORE" == "yes" ]]; then
+    OBJECTSTORE_ARGS="--memstore -o memstore_device_bytes=$VSTART_MEMSTORE_BYTES"
+else
+    OBJECTSTORE_ARGS="--bluestore -o bluestore_block_size=$VSTART_BLUESTORE_BYTES"
+fi
+
+mkdir -p "$VSTART_DIR" "$VSTART_CCACHE_DIR"
+cd "$WORKSPACE/ceph"
+cat > .env << EOF
+NPROC=$(nproc)
+MAX_PARALLEL_JOBS=$(nproc)
+EOF
+
+bwc_login
+# A stale cluster container from an aborted run would collide on the name.
+podman rm -f "$VSTART_CONTAINER" 2>/dev/null || true
+
+#
+# Build Ceph vstart (Release, same effective configuration as the VM flow)
+#
+cat > vstart-build.sh << 'EOF'
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+cmake_flags=(
+    -DCMAKE_BUILD_TYPE=Release
+    -DWITH_RADOSGW=OFF
+    -DWITH_MGR_DASHBOARD_FRONTEND=OFF
+    -DWITH_TESTS=OFF
+)
+if command -v ccache > /dev/null; then
+    cmake_flags+=(-DWITH_CCACHE=ON)
+    ccache -s
+fi
+./do_cmake.sh "${cmake_flags[@]}"
+cd ./build
+ninja vstart
+command -v ccache > /dev/null && ccache -s || true
+EOF
+chmod +x vstart-build.sh
+time bwc 2 \
+    "--extra=--volume=$VSTART_CCACHE_DIR:/vstartccache:z" \
+    "--extra=-eCCACHE_DIR=/vstartccache" \
+    -e custom -- ./vstart-build.sh
+
+#
+# Run the cluster; the container stays up (sleep) until cleanup removes it.
+#
+cat > vstart-run.sh << 'EOF'
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+cd ./build
+mkdir -p vstart/out
+VSTART_DEST=$PWD/vstart ../src/vstart.sh \
+    -n $OBJECTSTORE_ARGS \
+    --without-dashboard -i "$VSTART_IP" \
+    2>&1 | tee vstart/vstart.log
+
+export CEPH_CONF=$PWD/vstart/ceph.conf
+export CEPH_KEYRING=$PWD/vstart/keyring
+
+./bin/ceph osd pool create rbd
+
+./bin/ceph osd pool set cephfs.a.data size 1 --yes-i-really-mean-it
+./bin/ceph osd pool set cephfs.a.meta size 1 --yes-i-really-mean-it
+./bin/ceph osd pool set rbd size 1 --yes-i-really-mean-it
+
+./bin/ceph tell mon.* config set debug_mon 0
+./bin/ceph tell mon.* config set debug_ms 0
+
+touch vstart/READY
+sleep infinity
+EOF
+chmod +x vstart-run.sh
+rm -f build/vstart/READY
+# Backgrounded with all fds detached so the Jenkins sh step doesn't wait on
+# it; the double fork orphans it from this shell.
+( bwc 8 \
+    "--extra=--net=host" \
+    "--extra=-eVSTART_IP=$VSTART_IP" \
+    "--extra=-eOBJECTSTORE_ARGS=$OBJECTSTORE_ARGS" \
+    -e custom -- ./vstart-run.sh \
+    < /dev/null > "$WORKSPACE/vstart-container.log" 2>&1 & )
+
+TIMEOUT=900
+SECONDS=0
+until [[ -f build/vstart/READY ]]; do
+    if (( SECONDS > TIMEOUT )); then
+        echo "TIMEOUT: vstart cluster not ready after ${TIMEOUT}s"
+        tail -100 "$WORKSPACE/vstart-container.log"
+        exit 1
+    fi
+    echo "Waiting for the vstart cluster (${SECONDS}s)"
+    sleep 10
+done
+echo "vstart cluster is up on $VSTART_IP"
+
+#
+# Host-side conf/keyring for the windows client (same as the VM flow)
+#
+cp build/vstart/ceph.conf "$VSTART_DIR/ceph.conf"
+cp build/vstart/keyring "$VSTART_DIR/keyring"
+cd "$WORKSPACE"
+
+export CEPH_CONF="$VSTART_DIR/ceph.conf"
+export CEPH_KEYRING="$VSTART_DIR/keyring"
+export CEPH_WINDOWS_CONF="$VSTART_DIR/ceph-windows.conf"
+
+MON_HOST=$(cat $CEPH_CONF | grep -o "mon host \=.*")
+
+cat > $CEPH_WINDOWS_CONF << EOF
+[client]
+    keyring = C:/ProgramData/ceph/keyring
+    log file = C:/ProgramData/ceph/logs/\$name.\$pid.log
+    admin socket = C:/ProgramData/ceph/out/\$name.\$pid.asok
+    client_mount_uid = 1000
+    client_mount_gid = 1000
+    client_permissions = true
+[global]
+    log to stderr = true
+    run dir = C:/ProgramData/ceph/out
+    crash dir = C:/ProgramData/ceph/out
+    $MON_HOST
+EOF

--- a/scripts/ceph-windows/setup_ceph_vstart_container
+++ b/scripts/ceph-windows/setup_ceph_vstart_container
@@ -81,7 +81,23 @@ time bwc 2 \
 #
 # Run the cluster; the container stays up (sleep) until cleanup removes it.
 #
+# vstart sets "mds root ino uid/gid" to the invoking user, and the windows
+# client mounts with client_mount_uid/gid = 1000 and client_permissions
+# enforced -- so the cluster must be started by uid 1000, exactly like the
+# ubuntu user in the VM flow, or every write from the client gets EACCES.
 cat > vstart-run.sh << 'EOF'
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+useradd --uid 1000 --user-group --no-create-home cephtest 2> /dev/null || true
+mkdir -p build/vstart
+chown -R 1000:1000 build/vstart
+exec runuser -u cephtest -- env HOME=/tmp bash ./vstart-run-inner.sh
+EOF
+chmod +x vstart-run.sh
+
+cat > vstart-run-inner.sh << 'EOF'
 #!/usr/bin/env bash
 set -o errexit
 set -o pipefail
@@ -108,7 +124,7 @@ export CEPH_KEYRING=$PWD/vstart/keyring
 touch vstart/READY
 sleep infinity
 EOF
-chmod +x vstart-run.sh
+chmod +x vstart-run-inner.sh
 rm -f build/vstart/READY
 # Backgrounded with all fds detached so the Jenkins sh step doesn't wait on
 # it; the double fork orphans it from this shell.
@@ -133,10 +149,12 @@ done
 echo "vstart cluster is up on $VSTART_IP"
 
 #
-# Host-side conf/keyring for the windows client (same as the VM flow)
+# Host-side conf/keyring for the windows client (same as the VM flow).
+# podman cp, not cp: the cluster runs as uid 1000 in the container, so on
+# the host these are owned by a subuid and the keyring is mode 0600.
 #
-cp build/vstart/ceph.conf "$VSTART_DIR/ceph.conf"
-cp build/vstart/keyring "$VSTART_DIR/keyring"
+podman cp "$VSTART_CONTAINER:/ceph/build/vstart/ceph.conf" "$VSTART_DIR/ceph.conf"
+podman cp "$VSTART_CONTAINER:/ceph/build/vstart/keyring" "$VSTART_DIR/keyring"
 cd "$WORKSPACE"
 
 export CEPH_CONF="$VSTART_DIR/ceph.conf"

--- a/scripts/ceph-windows/win32-build.containerfile
+++ b/scripts/ceph-windows/win32-build.containerfile
@@ -1,0 +1,37 @@
+# Build environment for cross-compiling Ceph for Windows (ceph.git's
+# win32_build.sh) on a builder host, replacing the throwaway libvirt Ubuntu
+# VM the windows CI used historically.
+#
+# Only the toolchain packages live here, mirroring the "ubuntu" branch of
+# win32_deps_build.sh (plus make/perl, which the Ubuntu cloud image shipped
+# implicitly).  The compiled dependencies themselves (mingw-llvm, boost,
+# openssl, ...) are branch-specific, so they are built at run time by
+# win32_build.sh and persisted in a host-mounted cache keyed by the deps
+# script's hash -- see win32_build_container.
+FROM docker.io/library/ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        autoconf \
+        bzip2 \
+        ca-certificates \
+        ccache \
+        cmake \
+        g++ \
+        gcc \
+        git \
+        libtool \
+        make \
+        mingw-w64 \
+        ninja-build \
+        patch \
+        perl \
+        pkg-config \
+        python3-dev \
+        python3-yaml \
+        sudo \
+        wget \
+        xz-utils \
+        zip \
+    && rm -rf /var/lib/apt/lists/*

--- a/scripts/ceph-windows/win32_build_container
+++ b/scripts/ceph-windows/win32_build_container
@@ -36,6 +36,8 @@ fi
 nproc=$(nproc)
 NUM_WORKERS="${NUM_WORKERS:-$(( nproc > 32 ? 32 : nproc ))}"
 
+rm -f "$WORKSPACE/ceph.zip"
+
 git -C "$CEPH_SRC" submodule update --init --recursive
 
 #

--- a/scripts/ceph-windows/win32_build_container
+++ b/scripts/ceph-windows/win32_build_container
@@ -73,11 +73,14 @@ if [[ ! -f $deps_cache_dir/deps/mingw/completed ]]; then
     flock --timeout 7200 9
 fi
 
+# MINGW_LLVM_DIR must be set explicitly: mingw_conf.sh defaults it relative
+# to the ceph tree ($CEPH_DIR/build.deps), not to DEPS_DIR.
 podman run --rm --name "$CONTAINER_NAME" \
     -v "$WORKSPACE:/workspace" \
     -v "$deps_cache_dir:/depscache" \
     -v "$ccache_dir:/ccache" \
     -e DEPS_DIR=/depscache/deps \
+    -e MINGW_LLVM_DIR=/depscache/deps/mingw-llvm \
     -e ZIP_DEST=/workspace/ceph.zip \
     -e CCACHE_DIR=/ccache \
     -e CCACHE_MAXSIZE="$CCACHE_MAXSIZE" \

--- a/scripts/ceph-windows/win32_build_container
+++ b/scripts/ceph-windows/win32_build_container
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Cross-compile Ceph for Windows in a podman container on the builder host,
+# replacing the setup_libvirt_ubuntu_vm + win32_build (VM) flow.  Produces the
+# same $WORKSPACE/ceph.zip that setup_libvirt_windows_vm/run_tests consume.
+#
+# Expects:
+#   $WORKSPACE/ceph        - the ceph tree to build
+#   $WORKSPACE/ceph-build  - this repo (for the containerfile)
+#
+# Two host-side caches survive between builds:
+#   deps    - the compiled mingw dependencies (mingw-llvm, boost, openssl,
+#             ...), keyed by the sha of the branch's win32_deps_build.sh +
+#             mingw_conf.sh + the containerfile, so a deps change in any
+#             branch simply builds a new cache entry.  win32_build.sh skips
+#             the whole deps build when it finds the cache's completed marker.
+#   ccache  - compiler cache for the ceph tree itself.  Mount paths are fixed
+#             (/workspace, /depscache) so object paths are stable across
+#             builds and nodes.
+set -o errexit
+set -o pipefail
+
+: "${WORKSPACE:?WORKSPACE is not set}"
+CEPH_SRC="${CEPH_SRC:-$WORKSPACE/ceph}"
+CONTAINERFILE="${CONTAINERFILE:-$WORKSPACE/ceph-build/scripts/ceph-windows/win32-build.containerfile}"
+CACHE_ROOT="${CEPH_WIN32_CACHE_ROOT:-$HOME/.cache/ceph-win32-build}"
+CCACHE_MAXSIZE="${CCACHE_MAXSIZE:-30G}"
+WIN32_BUILD_TIMEOUT="${WIN32_BUILD_TIMEOUT:-3h}"
+CONTAINER_NAME="ceph-win32-build-${BUILD_ID:-$$}"
+
+if [[ ! -f $CEPH_SRC/win32_build.sh ]]; then
+    echo "ERROR: no win32_build.sh in $CEPH_SRC; is the ceph tree checked out?"
+    exit 1
+fi
+
+nproc=$(nproc)
+NUM_WORKERS="${NUM_WORKERS:-$(( nproc > 32 ? 32 : nproc ))}"
+
+git -C "$CEPH_SRC" submodule update --init --recursive
+
+#
+# Build the toolchain image (podman's layer cache makes this a no-op unless
+# the containerfile changed).  The base image pull must not go anonymous, or
+# we hit Docker Hub rate limits.
+#
+if [[ -n $DOCKER_HUB_USERNAME && -n $DOCKER_HUB_PASSWORD ]]; then
+    # Same persistent authfile as bwc_login (https://tracker.ceph.com/issues/77920)
+    export REGISTRY_AUTH_FILE="${HOME}/.config/containers/auth.json"
+    mkdir -p "${REGISTRY_AUTH_FILE%/*}"
+    podman login -u "$DOCKER_HUB_USERNAME" -p "$DOCKER_HUB_PASSWORD" docker.io
+fi
+cf_hash=$(sha256sum "$CONTAINERFILE" | cut -c1-12)
+IMAGE="localhost/ceph-win32-build:${cf_hash}"
+if ! podman image exists "$IMAGE"; then
+    podman build -t "$IMAGE" -f "$CONTAINERFILE" "$(dirname "$CONTAINERFILE")"
+fi
+
+deps_hash=$(cat "$CEPH_SRC/win32_deps_build.sh" "$CEPH_SRC/mingw_conf.sh" "$CONTAINERFILE" \
+            | sha256sum | cut -c1-12)
+deps_cache_dir="$CACHE_ROOT/deps/$deps_hash"
+ccache_dir="$CACHE_ROOT/ccache"
+mkdir -p "$deps_cache_dir" "$ccache_dir"
+
+#
+# The first build for this deps key populates the cache; hold an exclusive
+# lock so concurrent builds on the same node don't build it twice (once the
+# completed marker exists the cache is only ever read, so no lock is needed).
+# win32_build.sh re-checks the marker after the lock is acquired.
+#
+if [[ ! -f $deps_cache_dir/deps/mingw/completed ]]; then
+    echo "No cached mingw deps for $deps_hash; the deps build will run (with the lock held)"
+    exec 9> "$deps_cache_dir.lock"
+    flock --timeout 7200 9
+fi
+
+podman run --rm --name "$CONTAINER_NAME" \
+    -v "$WORKSPACE:/workspace" \
+    -v "$deps_cache_dir:/depscache" \
+    -v "$ccache_dir:/ccache" \
+    -e DEPS_DIR=/depscache/deps \
+    -e ZIP_DEST=/workspace/ceph.zip \
+    -e CCACHE_DIR=/ccache \
+    -e CCACHE_MAXSIZE="$CCACHE_MAXSIZE" \
+    -e CMAKE_C_COMPILER_LAUNCHER=ccache \
+    -e CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -e NUM_WORKERS="$NUM_WORKERS" \
+    -e OS=ubuntu \
+    -w /workspace/ceph \
+    "$IMAGE" \
+    bash -c "ccache -s; timeout $WIN32_BUILD_TIMEOUT ./win32_build.sh; ccache -s"
+
+ls -lh "$WORKSPACE/ceph.zip"


### PR DESCRIPTION
The windows CI cross-compiles Ceph inside a freshly provisioned libvirt Ubuntu VM on every run: download the cloud image, boot, cloud-init, rsync the tree in, build everything (including all the mingw deps) from scratch, rsync ceph.zip back out, destroy the VM. That was ~50 minutes of a recent successful run (ceph-windows-pull-requests #86724) before the cluster-side work even started.

`win32_build.sh` is a plain Linux mingw cross-compile, so this runs it in a podman container on the builder host instead:

- a static toolchain image (`scripts/ceph-windows/win32-build.containerfile`) with the apt packages from `win32_deps_build.sh`'s ubuntu branch
- `scripts/ceph-windows/win32_build_container` bind-mounts the workspace and produces the same `$WORKSPACE/ceph.zip` that `setup_libvirt_windows_vm`/`run_tests` consume
- the compiled mingw deps (mingw-llvm, boost, openssl, ...) persist on the builder, keyed by the sha of the branch's `win32_deps_build.sh` + `mingw_conf.sh` + the containerfile, so any deps change simply builds a new cache entry; `win32_build.sh` already skips the deps build when it finds the cache's completed marker (a flock guards the first build per key)
- ccache for the ceph tree itself, with fixed container mount paths so object paths stay stable across builds

The new `ceph-windows-container-build` job validates this on the same builder pool the windows test jobs use, without touching ceph-pr-pipeline or the existing windows jobs; it doubles as a one-off manual windows build job for a branch or PR.

Validation on braggi07 (ceph main):
- [build 2](https://jenkins.ceph.com/job/ceph-windows-container-build/2/) (fully cold): **17.7 min** total — 6 min deps build, ~20 s configure, ~7 min ninja (32 workers), 222M ceph.zip
- [build 3](https://jenkins.ceph.com/job/ceph-windows-container-build/3/) (warm caches): **5.5 min** total — deps build skipped, ninja ~25 s at an 89% ccache hit rate, identical ceph.zip

vs ~50 minutes for the VM-based build phase it replaces. Not yet validated: running the produced ceph.zip through the actual windows tests — that's the next step before switching ceph-pr-pipeline's windows leg over.

Assisted-by: Claude Fable 5 (claude-fable-5)