### PR TITLE
ceph-dev-build: survive root-owned leftovers from failed mingw builds

### DIFF
--- a/ceph-dev-build/build/build_mingw
+++ b/ceph-dev-build/build/build_mingw
@@ -14,6 +14,11 @@ cd /mnt/ceph
 CMAKE_BUILD_TYPE=Release BUILD_ZIP=1 CLEAN_BUILD=1 timeout 3h ./win32_build.sh
 EOF
 chmod a+x $tmp_pbuild_script
+
+# pbuilder runs as root in the bind-mounted workspace; reclaim ownership even
+# if the build fails, or the next build on this node can't clean up the workarea
+trap 'sudo chown -R jenkins-build ${WORKSPACE}/dist || true' EXIT
+
 sudo pbuilder execute \
     --bindmounts "$(pwd):/mnt/ceph" \
     --distribution "jammy" \
@@ -52,6 +57,3 @@ EOF
 
     echo Check the status of the repo at: https://shaman.ceph.com/api/repos/${chacra_repo_endpoint}/
 fi
-
-# pbuilder will leave root-owned files in shared workspaces
-sudo chown -R jenkins-build ${WORKSPACE}/dist

--- a/ceph-dev-build/config/definitions/ceph-dev-build.yml
+++ b/ceph-dev-build/config/definitions/ceph-dev-build.yml
@@ -58,9 +58,9 @@
     builders:
       - shell: |
           echo "Cleaning up top-level workarea (shared among workspaces)"
-          rm -rf dist
+          sudo rm -rf dist
           rm -rf venv
-          rm -rf release
+          sudo rm -rf release
       - copyartifact:
           project: ceph-dev-setup
           filter: 'dist/**'

--- a/ceph-dev-new-build/build/build_mingw
+++ b/ceph-dev-new-build/build/build_mingw
@@ -14,6 +14,11 @@ cd /mnt/ceph
 CMAKE_BUILD_TYPE=Release BUILD_ZIP=1 CLEAN_BUILD=1 timeout 3h ./win32_build.sh
 EOF
 chmod a+x $tmp_pbuild_script
+
+# pbuilder runs as root in the bind-mounted workspace; reclaim ownership even
+# if the build fails, or the next build on this node can't clean up the workarea
+trap 'sudo chown -R jenkins-build ${WORKSPACE}/dist || true' EXIT
+
 sudo pbuilder execute \
     --bindmounts "$(pwd):/mnt/ceph" \
     --distribution "jammy" \
@@ -52,6 +57,3 @@ EOF
 
     echo Check the status of the repo at: https://shaman.ceph.com/api/repos/${chacra_repo_endpoint}/
 fi
-
-# pbuilder will leave root-owned files in shared workspaces
-sudo chown -R jenkins-build ${WORKSPACE}/dist


### PR DESCRIPTION
The `DIST=windows` cell of ceph-dev-build has failed on every run since mid-August. The shared-workarea cleanup (`rm -rf dist`) dies with `Permission denied` on root-owned files (`dist/ceph-*/build.deps/mingw`, `mingw-llvm.tar.xz`, ...) that a failed pbuilder run left behind on adami10. `build_mingw` only chowned `dist` back to `jenkins-build` after a *successful* build, so a single mid-build failure wedged the node for every windows build after it.

Two fixes:
- `build_mingw` (both ceph-dev-build and ceph-dev-new-build): move the ownership reclaim into an `EXIT` trap so it also runs when the build fails.
- ceph-dev-build preamble: `sudo rm -rf` for `dist`/`release`, matching what ceph-dev-new-build already does, so an already-wedged workspace can still be cleared.

Related: the `windows` label itself was dropped from the adami nodes in the recent ceph-sepia-secrets relabel, which is why the queued windows cells currently show *"There are no nodes with the label 'gigantic&&x86_64&&windows'"* — that's being restored in a ceph-sepia-secrets PR.