### PR TITLE
builder-reimage: take the node offline before syncing labels

### DIFF
--- a/builder-reimage/build/Jenkinsfile
+++ b/builder-reimage/build/Jenkinsfile
@@ -87,6 +87,42 @@ pipeline {
                                         }
                                     }
                                     
+                                    // Take the node offline BEFORE syncing labels: a newly synced
+                                    // label can instantly attract queued builds onto a node that is
+                                    // about to be wiped (and still has its pre-reimage disk state).
+                                    stage("Prepare Jenkins Node-${machine}") {
+                                        if (!params.SKIP_REIMAGE) {
+                                            withCredentials([
+                                                usernamePassword(
+                                                    credentialsId: 'jenkins-api-token',
+                                                    usernameVariable: 'JOB_BUILDER_USER',
+                                                    passwordVariable: 'JOB_BUILDER_PASS'
+                                                )
+                                            ]) {
+                                                withEnv([
+                                                    "SYNC_MACHINE=${machine}",
+                                                    "SYNC_TARGET_FQDN=${TARGET_FQDN}",
+                                                    "SYNC_STATE_FILE=${JENKINS_NODE_STATE_FILE}"
+                                                ]) {
+                                                    sh '''#!/bin/bash
+                                                        set -euo pipefail
+
+                                                        echo "[INFO] Preparing Jenkins node state for $SYNC_MACHINE"
+
+                                                        python3 builder-reimage/build/jenkins_node_control.py \
+                                                          --action prepare_for_reimage \
+                                                          --jenkins_url "$JENKINS_URL" \
+                                                          --user "$JOB_BUILDER_USER" \
+                                                          --token "$JOB_BUILDER_PASS" \
+                                                          --node "$SYNC_TARGET_FQDN" \
+                                                          --state-file "$SYNC_STATE_FILE" \
+                                                          --message "Marked temporary offline for builder reimage activity"
+                                                    '''
+                                                }
+                                            }
+                                        }
+                                    }
+
                                     stage("Sync Labels-${machine}") {
                                         withCredentials([
                                             usernamePassword(
@@ -141,39 +177,6 @@ pipeline {
                                         echo "Detected OS: ${env.DETECTED_OS}"
                                         echo "Libvirt enabled: ${env.LIBVIRT_ENABLED}"
 
-                                    }
-
-                                    stage("Prepare Jenkins Node-${machine}") {
-                                        if (!params.SKIP_REIMAGE) {
-                                            withCredentials([
-                                                usernamePassword(
-                                                    credentialsId: 'jenkins-api-token',
-                                                    usernameVariable: 'JOB_BUILDER_USER',
-                                                    passwordVariable: 'JOB_BUILDER_PASS'
-                                                )
-                                            ]) {
-                                                withEnv([
-                                                    "SYNC_MACHINE=${machine}",
-                                                    "SYNC_TARGET_FQDN=${TARGET_FQDN}",
-                                                    "SYNC_STATE_FILE=${JENKINS_NODE_STATE_FILE}"
-                                                ]) {
-                                                    sh '''#!/bin/bash
-                                                        set -euo pipefail
-
-                                                        echo "[INFO] Preparing Jenkins node state for $SYNC_MACHINE"
-
-                                                        python3 builder-reimage/build/jenkins_node_control.py \
-                                                          --action prepare_for_reimage \
-                                                          --jenkins_url "$JENKINS_URL" \
-                                                          --user "$JOB_BUILDER_USER" \
-                                                          --token "$JOB_BUILDER_PASS" \
-                                                          --node "$SYNC_TARGET_FQDN" \
-                                                          --state-file "$SYNC_STATE_FILE" \
-                                                          --message "Marked temporary offline for builder reimage activity"
-                                                    '''
-                                                }
-                                            }
-                                        }
                                     }
 
                                     stage("Reimage-${machine}") {


### PR DESCRIPTION
Follow-up to the ceph-dev-build windows saga: the reimage of adami10 today did work, but the **Sync Labels** stage runs three stages before **Prepare Jenkins Node** marks the node offline. The moment `sync_labels.py` restored the `windows` label, Jenkins dispatched all four queued windows cells onto the still-online, still-dirty node — each failed in ~0.6s on the pre-reimage disk state, seconds before FOG wiped it.

Reorder so the node is marked temporarily offline *before* labels are synced. `prepare_for_reimage` is self-contained (needs only the node name, exits 0 if the node doesn't exist) and **Detect OS** reads the inventory file rather than the live node, so the reorder has no other effects. `SKIP_REIMAGE=true` label-only syncs behave exactly as before.