### PR TITLE
ceph-pr-pipeline: run make check (arm64) on all active release branches

### DIFF
--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -49,7 +49,7 @@ import groovy.transform.Field
 // Target-branch restrictions, same as the old freestyle jobs' whitelists.
 @Field List windows_branches = ["main", "umbrella", "tentacle", "squid", "reef"]
 @Field List api_branches = ["main", "umbrella", "tentacle", "squid", /feature-.*/]
-@Field List arm64_branches = ["main"]
+@Field List arm64_branches = ["main", "umbrella", "tentacle", "squid"]
 
 // Set by the prepare stage.
 @Field boolean run_signed = false


### PR DESCRIPTION
The arm64 leg was restricted to `main` while we validated the pipeline. Open it up to the same active branches as the other legs: squid, tentacle, umbrella, and main.

Jenkinsfile passes the declarative linter on jenkins.ceph.com.