### PR TITLE
notify_shaman_pulp_repo: key shaman records by the per-sha1 content URL

### DIFF
--- a/scripts/notify_shaman_pulp_repo.sh
+++ b/scripts/notify_shaman_pulp_repo.sh
@@ -8,10 +8,12 @@ submit_repo_status() {
     # 'project' is used to post to the right url in shaman.
     # shaman keys repos by 'chacra_url' and builds Arch rows from the 'archs'
     # list, so the arch must be sent as a JSON array (not 'distro_arch').
-    # Mirroring chacra's repo records: 'url' is the browsable location of the
-    # actual package repo (here, the Pulp content distribution) and
-    # 'chacra_url' is the repo's API endpoint (chacra: /repos/..., pulp:
-    # /pulp/api/v3/repositories/...).
+    # shaman dedups on 'chacra_url' and never updates sha1/ref on a repost,
+    # so 'chacra_url' must embed the sha1 (as chacra's /repos/... URLs did).
+    # The Pulp repository API href is branch-scoped (reused across sha1s):
+    # sending it here kept records pinned to the branch's first sha1, and
+    # build_container's search by the new sha1 then timed out. Send the
+    # per-sha1 content URL instead and keep the repository href in 'extra'.
     http_method=$1
     state=$2
     project=$3
@@ -41,7 +43,7 @@ submit_repo_status() {
     cat > $WORKSPACE/repo_status.json << EOF
 {
     "url":"$url",
-    "chacra_url":"${PULP_REPO_API_URL:-$url}",
+    "chacra_url":"$url",
     "status":"$state",
     "distro":"$distro",
     "distro_version":"$distro_version",
@@ -52,6 +54,7 @@ submit_repo_status() {
     "extra":{
         "version":"$CEPH_VERSION",
         "package_manager_version":"$PACKAGE_MANAGER_VERSION",
+        "repository_api_url":"$PULP_REPO_API_URL",
         "build_url":"$BUILD_URL",
         "root_build_cause":"$ROOT_BUILD_CAUSE",
         "node_name":"$NODE_NAME",

--- a/scripts/pulp_upload.sh
+++ b/scripts/pulp_upload.sh
@@ -554,9 +554,10 @@ else
 fi
 
 # Hand off repo metadata to the shaman notify step, which runs as a
-# separate process. PACKAGE_MANAGER_VERSION is included in the repo
-# record's extra metadata; the repository's API URL becomes the record's
-# chacra_url. See notify_shaman_pulp_repo.sh.
+# separate process. Both values end up in the repo record's extra
+# metadata; the repository's API href must NOT become the record's
+# chacra_url (shaman's dedup key) because it is branch-scoped and reused
+# across sha1s. See notify_shaman_pulp_repo.sh.
 # rpm repositories are named after the rpm arch (aarch64), not the Jenkins
 # matrix arch (arm64); see the SRPMS/noarch/aarch64/x86_64 loop above.
 _repo_arch="${ARCH}"


### PR DESCRIPTION
## Problem

[cve-pipeline #34](https://jenkins.ceph.com/job/cve-pipeline/34/) failed all four container stages (and the downstream registry uploads) with:

```
FAIL: timed out waiting for shaman repo to be built
```

even though compilation, the Pulp package uploads, and the shaman notify itself all succeeded.

## Root cause

Shaman dedups repo records on `chacra_url` and, when a record already exists, only updates `status`/`url`/`extra` — never `sha1` or `ref` ([`ProjectController.index_post`](https://github.com/ceph/shaman/blob/main/shaman/controllers/api/repos/projects.py)). The Pulp notify was sending the Pulp **repository** API href as `chacra_url`, but `pulp_upload.sh` reuses branch-scoped repositories across commits, so that href is identical for every sha1 of a branch.

Rebuilding a branch at a new commit therefore updated the previous build's shaman records in place, leaving `sha1` pinned to the branch's first commit. The surviving record shows the mismatch — `url`/`extra` from build 34, `sha1` from the prior build:

```json
{
  "url": ".../repos/ceph/wip-nbalacha-test-aug14/59b56099.../centos/9/flavors/default/",
  "chacra_url": "https://pulp.front.sepia.ceph.com/pulp/api/v3/repositories/rpm/rpm/01a0006b-.../",
  "sha1": "4a522c91f889c2e5b1bad38855d034bc5d571949",
  "extra": { "build_url": "https://jenkins.ceph.com/job/cve-pipeline/34/", ... }
}
```

`build_container` polls shaman by the *current* sha1, so it could never match and timed out after 15 minutes. This bites any ceph-dev-pipeline/cve-pipeline branch rebuilt at a new commit on the Pulp path with `CI_CONTAINER=true`.

## Fix

Send the per-sha1 flavor-level content URL as `chacra_url`, restoring chacra's keying semantics (chacra's `chacra_url` always embedded ref+sha1+distro+version+flavor, which is what made shaman's dedup correct). The repository API href moves into the record's `extra.repository_api_url`.

Nothing consumes `chacra_url` on Pulp records: the chacra artifact-check stage filters on `chacra.ceph.com`, and teuthology's `urljoin(chacra_url, 'repo')` was equally non-functional against a repository API href.

## Notes

- Existing records keyed by repository hrefs keep their stale sha1; they only match searches for the old sha1 (whose packages the branch-scoped Pulp repos no longer hold anyway). I can clean up the `wip-nbalacha-test-aug14` ones manually.
- A shaman-side fix (refresh `sha1`/`ref` on repost) would also be reasonable, but this restores correctness without a shaman deploy.