### PR TITLE
ceph-windows: retry VM image downloads and surface their errors

### DIFF
--- a/scripts/ceph-windows/setup_libvirt_ubuntu_vm
+++ b/scripts/ceph-windows/setup_libvirt_ubuntu_vm
@@ -20,7 +20,7 @@ export UBUNTU_SSH_USER="ubuntu"
 #
 mkdir -p $LIBVIRT_DIR
 echo "Downloading VM image from $UBUNTU_VM_IMAGE_URL"
-curl -s -L $UBUNTU_VM_IMAGE_URL -o ${LIBVIRT_DIR}/ceph-ubuntu-vstart.qcow2
+curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors $UBUNTU_VM_IMAGE_URL -o ${LIBVIRT_DIR}/ceph-ubuntu-vstart.qcow2
 qemu-img resize ${LIBVIRT_DIR}/ceph-ubuntu-vstart.qcow2 128G
 
 cat > ${LIBVIRT_DIR}/metadata.yaml << EOF

--- a/scripts/ceph-windows/setup_libvirt_windows_vm
+++ b/scripts/ceph-windows/setup_libvirt_windows_vm
@@ -15,7 +15,7 @@ export WINDOWS_SSH_USER="administrator"
 #
 mkdir -p $LIBVIRT_DIR
 echo "Downloading VM image from $WINDOWS_VM_IMAGE_URL"
-curl -s -L $WINDOWS_VM_IMAGE_URL -o ${LIBVIRT_DIR}/ceph-windows-client.qcow2
+curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors $WINDOWS_VM_IMAGE_URL -o ${LIBVIRT_DIR}/ceph-windows-client.qcow2
 
 sudo virt-install \
     --name $WINDOWS_VM_NAME \


### PR DESCRIPTION
Found in a 24h failure sweep: ceph-pr-pipeline #249's windows leg failed instantly on a transient cloud-images.ubuntu.com blip because the image downloads use `curl -s -L` (no -f, no -S, no retries) under errexit. Add `-fsSL --retry 5 --retry-delay 10 --retry-all-errors` to both VM image downloads. Takes effect on merge (scripts fetched from main per build).