### PR TITLE
builder-reimage: re-apply alloy.yml after reimage

### DIFF
--- a/builder-reimage/build/ansible_runner.sh
+++ b/builder-reimage/build/ansible_runner.sh
@@ -348,6 +348,29 @@ if ! (
     FAILED_LOGS+=("${LOG_DIR}/${TARGET_FQDN}-play6-main-builder.log")
 fi
 
+##############################################
+# PLAYBOOK 7 — alloy.yml (metrics/log shipping)
+##############################################
+# A fresh deploy wipes Grafana Alloy (node_exporter -> Mimir, journald/auditd
+# -> Loki), which the fleet-wide alloy.yml runs installed.  Re-apply it here so
+# a reimaged builder comes back observable without waiting for the next fleet
+# run.  The play's host pattern covers ci_infrastructure, which contains the
+# jenkins builders; --limit narrows it to this node.
+if ! (
+  cd "${ANSIBLE_DIR}"
+
+  CMD="ANSIBLE_HOST_KEY_CHECKING=False ANSIBLE_STDOUT_CALLBACK=json ansible-playbook alloy.yml \
+        -i '${INVENTORY_PATH}' \
+        ${VAULT_ARG} \
+        --limit='${TARGET_FQDN}' \
+        -e ansible_ssh_user='${SSH_USER}'"
+
+  run_playbook "play7-alloy" "${CMD}"
+); then
+    FAILED_PLAYBOOKS+=("play7-alloy")
+    FAILED_LOGS+=("${LOG_DIR}/${TARGET_FQDN}-play7-alloy.log")
+fi
+
 fi
 
 echo "========================================"


### PR DESCRIPTION
A fresh MAAS deploy wipes Grafana Alloy (node_exporter → Mimir, journald/auditd → Loki) that the fleet-wide `alloy.yml` run installed. This adds it as **playbook 7** in `ansible_runner.sh`, limited to the reimaged node, so builders come back observable without waiting for the next fleet-wide run.

Notes for review:
- Runs from the cm-ansible checkout (`${ANSIBLE_DIR}`), same as playbooks 1–4; `alloy.yml` lives at the repo root and its host pattern includes `ci_infrastructure` (jenkins builders), so `--limit` selects the node.
- `${VAULT_ARG}` passed in case the alloy role's remote-write credentials come from vaulted group_vars; harmless if unused.
- Same 3-attempt retry + failure-summary handling as the other playbooks.