### PR TITLE
builder-reimage: wait up to 2h for busy nodes and slow MAAS states

### DIFF
--- a/builder-reimage/build/Jenkins_builder-reimage.py
+++ b/builder-reimage/build/Jenkins_builder-reimage.py
@@ -28,7 +28,7 @@ from aiohttp.client_exceptions import (
 # Global Defaults
 # -------------------------------------------------------------------------
 LOG_FILE_DEFAULT = "maas_reimage.log"
-STATUS_WAIT_TIMEOUT = 1200
+STATUS_WAIT_TIMEOUT = 7200
 DEFAULT_OWNER = "jitendra"
 
 MAAS_URL = "http://soko02.front.sepia.ceph.com:5240/MAAS"

--- a/builder-reimage/build/jenkins_node_control.py
+++ b/builder-reimage/build/jenkins_node_control.py
@@ -79,7 +79,7 @@ def node_is_busy(node_info):
     return False
 
 
-def wait_until_idle(session, base_url, node_name, timeout=3600, interval=15):
+def wait_until_idle(session, base_url, node_name, timeout=7200, interval=15):
     waited = 0
 
     while waited < timeout:


### PR DESCRIPTION
On a saturated fleet, `wait_until_idle`'s 1h cap makes the job skip busy nodes: run #60 timed out on braggi02/10/11/12 (mid-build with ~1h queue + 1-2h build times) and restored them un-reimaged, leaving only the idle host to reimage. Raise the idle wait to **2h**, and the MAAS status wait (release/commission/deploy) from 20m to 2h for the same reason — both loops return early on success, so fast hosts are unaffected. Worst-case wall clock for a fully busy node rises accordingly; the per-host branches run in parallel so the batch doesn't serialize.