### PR TITLE
Ubuntu 26.04 (resolute) in ceph-dev-pipeline and the main build matrices

### DIFF
--- a/ceph-dev-cron/build/Jenkinsfile
+++ b/ceph-dev-cron/build/Jenkinsfile
@@ -28,7 +28,7 @@ node('built-in') {
           ]
       ],
       main: [
-          distros: 'noble jammy rocky10 centos9 windows',
+          distros: 'resolute noble jammy rocky10 centos9 windows',
           extras : [
               [distros:'centos9 rocky10 noble', flavors:'debug', archs:'x86_64'],
               [distros:'centos9 rocky10', flavors:'default', archs:'arm64'],

--- a/ceph-dev-pipeline/build/Jenkinsfile
+++ b/ceph-dev-pipeline/build/Jenkinsfile
@@ -5,6 +5,7 @@ import groovy.transform.Field
 @Field String ceph_build_branch = "main"
 @Field String base_node_label = "gigantic"
 @Field Map ubuntu_releases = [
+  "resolute": "26.04",
   "noble": "24.04",
   "jammy": "22.04",
   "focal": "20.04",
@@ -735,7 +736,7 @@ pipeline {
         axes {
           axis {
             name 'DIST'
-            values 'centos9', 'centos10', 'rocky9', 'rocky10', 'focal', 'jammy', 'noble', 'bookworm', 'trixie'
+            values 'centos9', 'centos10', 'rocky9', 'rocky10', 'focal', 'jammy', 'noble', 'resolute', 'bookworm', 'trixie'
           }
           axis {
             name 'ARCH'

--- a/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
+++ b/ceph-dev-pipeline/config/definitions/ceph-dev-pipeline.yml
@@ -42,7 +42,7 @@
 
       - string:
           name: DISTROS
-          description: "A list of distros to build for. Available options are: centos9, centos8, noble, jammy, and windows"
+          description: "A list of distros to build for. Available options are: centos9, centos8, resolute, noble, jammy, and windows"
           default: "centos9 noble jammy"
 
       - string:

--- a/ceph-trigger-build/build/Jenkinsfile
+++ b/ceph-trigger-build/build/Jenkinsfile
@@ -20,7 +20,7 @@ def pretty(obj) {
 // These are the default parameter values for the pipeline
 @Field def defaults = [
   'CEPH_BUILD_JOB': 'ceph-dev-pipeline',
-  'DISTROS': 'rocky10 centos9 jammy noble windows',
+  'DISTROS': 'rocky10 centos9 jammy noble resolute windows',
   'ARCHS': 'x86_64',
   'FLAVOR': 'default',
 ]


### PR DESCRIPTION
Ubuntu 26.04 (resolute) in the dev build pipeline, in two commits:

1. **ceph-dev-pipeline**: allow `DIST=resolute` in the matrix and map it to 26.04. ceph.git main's `build-with-container.py` already knows ubuntu26.04 (ceph/ceph@c9cca3ad821), and package builds run in containers, so the existing noble/centos9 builders build it — no new builder OS.
2. **ceph-dev-cron, ceph-trigger-build**: add `resolute` to the automatic matrices for `main` (nightly cron and the ceph-ci push trigger). Releases (tentacle/umbrella) untouched.

Validated end to end with `CEPH_BUILD_BRANCH=wip-resolute`: ceph-dev-pipeline #8828 (ceph-ci `wip-resolute` = main + ceph/ceph#71559) built, packaged and uploaded for resolute, and the resulting packages passed smoke on `trial_ubuntu_26.04` testnodes: https://pulpito-ng.ceph.com/dgalloway-2026-09-05_11:49:45-smoke-wip-resolute-distro-default-trial/

Related: ceph/ceph#71559 (ceph.git fixes for 26.04), ceph/teuthology#2254, ceph/ceph-cm-ansible#881, #2705 (MAAS-seeded FOG images).
