### PR TITLE
ceph-dev-cron, ceph-trigger-build: build main for Ubuntu 26.04 (resolute)

### DIFF
--- a/ceph-dev-cron/build/Jenkinsfile
+++ b/ceph-dev-cron/build/Jenkinsfile
@@ -28,7 +28,7 @@ node('built-in') {
           ]
       ],
       main: [
-          distros: 'noble jammy rocky10 centos9 windows',
+          distros: 'resolute noble jammy rocky10 centos9 windows',
           extras : [
               [distros:'centos9 rocky10 noble', flavors:'debug', archs:'x86_64'],
               [distros:'centos9 rocky10', flavors:'default', archs:'arm64'],

--- a/ceph-trigger-build/build/Jenkinsfile
+++ b/ceph-trigger-build/build/Jenkinsfile
@@ -20,7 +20,7 @@ def pretty(obj) {
 // These are the default parameter values for the pipeline
 @Field def defaults = [
   'CEPH_BUILD_JOB': 'ceph-dev-pipeline',
-  'DISTROS': 'rocky10 centos9 jammy noble windows',
+  'DISTROS': 'rocky10 centos9 jammy noble resolute windows',
   'ARCHS': 'x86_64',
   'FLAVOR': 'default',
 ]


### PR DESCRIPTION
Main now builds, packages and passes smoke on Ubuntu 26.04 (ceph-dev-pipeline #8828; https://pulpito-ng.ceph.com/dgalloway-2026-09-05_11:49:45-smoke-wip-resolute-distro-default-trial/), so add `resolute` to the automatic matrices for `main` (nightly cron and the ceph-ci push trigger). Releases (tentacle/umbrella) untouched.

Depends on #2706 (the pipeline's `resolute` axis) — merge that first.