### PR TITLE
jenkins-job-builder: persist the JJB cache so runs stop storming the controller

### DIFF
--- a/jenkins-job-builder/build/build
+++ b/jenkins-job-builder/build/build
@@ -32,6 +32,33 @@ install_python_packages $TEMPVENV "pkgs[@]" latest
 JENKINS_FQDN=$(echo $JENKINS_URL | awk -F/ '{print $3}')
 JJB_CONFIG="$HOME/.jenkins_jobs.$JENKINS_FQDN.ini"
 
+# JJB only reconfigures jobs whose generated XML md5 differs from its local
+# cache.  Builders are ephemeral (reimaged regularly), so that cache is almost
+# always cold and every run reconfigured every job on the controller at once.
+# That config storm (ghprb webhook re-registration, job reloads) has driven
+# the controller into GC death spirals, making Jenkins unresponsive whenever
+# this job runs.  Persist the cache as a build artifact so each run only
+# touches jobs whose definitions actually changed.
+CACHE_DIR="$HOME/.cache/jenkins_jobs"
+CACHE_TAR="jenkins_jobs_cache.tar.gz"
+mkdir -p "$CACHE_DIR"
+if [ "$FORCE" != true ]; then
+    # lastCompletedBuild first: a failed run may still have updated (and
+    # cached) some jobs before dying, and its snapshot is newer.
+    for build in lastCompletedBuild lastSuccessfulBuild; do
+        if curl -fsS -u "$JOB_BUILDER_USER:$JOB_BUILDER_PASS" \
+                -o "$WORKSPACE/$CACHE_TAR" \
+                "${JENKINS_URL%/}/job/$JOB_NAME/$build/artifact/$CACHE_TAR" &&
+           tar -xzf "$WORKSPACE/$CACHE_TAR" -C "$CACHE_DIR"; then
+            echo "restored JJB cache from $build"
+            break
+        fi
+    done
+fi
+# Snapshot the cache even if a later step fails so the next run can pick up
+# from whatever this one managed to update.
+trap 'tar -czf "$WORKSPACE/$CACHE_TAR" -C "$CACHE_DIR" .' EXIT
+
 # slap the programatically computed JJB config using env vars from Jenkins
 cat > $JJB_CONFIG << EOF
 [jenkins]

--- a/jenkins-job-builder/config/definitions/jjb.yml
+++ b/jenkins-job-builder/config/definitions/jjb.yml
@@ -4,7 +4,9 @@
     project-type: freestyle
     defaults: global
     display-name: 'Jenkins Job Builder'
-    concurrent: true
+    # Two overlapping runs would double the config-update load on the
+    # controller and race on the persisted JJB cache artifact; queue instead.
+    concurrent: false
     quiet-period: 5
     block-downstream: false
     block-upstream: false
@@ -50,6 +52,12 @@ If this is checked, JJB will wipe out its cache and force each job to align with
             - ../../build/build
 
     publishers:
+      # Persist JJB's md5 cache between runs; builders are ephemeral, and
+      # without this every run starts cold and reconfigures every job on the
+      # controller at once (which has made Jenkins unresponsive).
+      - archive:
+          artifacts: 'jenkins_jobs_cache.tar.gz'
+          allow-empty: true
       - postbuildscript:
           builders:
             - role: SLAVE


### PR DESCRIPTION
## Problem

Every `jenkins-job-builder` run has been making jenkins.ceph.com unresponsive. Diagnosis from the controller (2026-09-08, build 1733):

- The job runs on label `small`, landing on a different, regularly-reimaged builder each run (soko10, braggi11, soko15, braggi07, ...), so JJB's md5 cache in `~/.cache/jenkins_jobs` is almost always cold.
- With a cold cache, JJB reconfigures **every** job the controller manages, every run — builds 1729–1732 each logged ~125 "Reconfiguring jenkins job" lines even when almost nothing had changed.
- Each reconfigure makes Jenkins reload the job, re-register ghprb webhooks (`GhprbRepository#createHook` SEVEREs in the journal line up with the runs), and churn build-history objects. The allocation spike pushes the 20g heap into a GC death spiral: all eight G1 GC worker threads pegged at 100% CPU, nginx returning 502s. Today's run died a third of the way through when Jenkins got too sick to answer JJB's API calls.

## Fix

- Persist the JJB cache as a build artifact: restore `jenkins_jobs_cache.tar.gz` at the start of each run (`lastCompletedBuild` first, since a failed run may have updated and cached some jobs before dying) and snapshot it via an EXIT trap so even failed runs record their progress. With a warm cache, a run only reconfigures jobs whose definitions actually changed. `FORCE=true` still skips the restore and wipes the cache, preserving the full-sync escape hatch.
- `concurrent: false` — two overlapping full-storm updates double the load on the controller and would race on the cache artifact.

## Notes

- The first run after this merges still starts cold, so it will be one last full storm (and it seeds the cache artifact). Worth triggering manually at a quiet moment.
- 2.jenkins.ceph.com's copy of this job runs the same script and gets the same behavior automatically.