### PR TITLE
ceph-pull-requests-ppc64le: make check for PRs on ppc64le, on request

### DIFF
--- a/ceph-pr-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-pr-pipeline-trigger/build/Jenkinsfile
@@ -64,9 +64,10 @@ def phraseToChecks(String body) {
   def hits = []
   if (body =~ /(?i)jenkins\s+test\s+signed/)      { hits << "signed" }
   if (body =~ /(?i)jenkins\s+test\s+submodules/)  { hits << "submodules" }
-  // negative lookahead so "make check arm64" doesn't also queue the
-  // x86_64 leg; both can still be named in one comment
-  if (body =~ /(?i)jenkins\s+test\s+make\s+check(?!\s+arm64)/) { hits << "make-check" }
+  // negative lookahead so "make check arm64" (and "make check ppc64le",
+  // which triggers the standalone ceph-pull-requests-ppc64le job) doesn't
+  // also queue the x86_64 leg; arm64 can still be named in the same comment
+  if (body =~ /(?i)jenkins\s+test\s+make\s+check(?!\s+(arm64|ppc64le))/) { hits << "make-check" }
   if (body =~ /(?i)jenkins\s+test\s+make\s+check\s+arm64/)     { hits << "make-check-arm64" }
   if (body =~ /(?i)jenkins\s+test\s+api/)         { hits << "api" }
   if (body =~ /(?i)jenkins\s+test\s+windows/)     { hits << "windows" }

--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -53,7 +53,9 @@ webhook (pull_request / issue_comment)
 - Comment phrases (org members always, others only while labeled):
   `jenkins retest ...` re-runs everything; `jenkins test <check>` runs one of
   `make check`, `make check arm64`, `api`, `windows`, `signed`, `submodules`.
-  Bare `jenkins test` runs nothing.
+  Bare `jenkins test` runs nothing.  `jenkins test make check ppc64le` is
+  handled by the standalone `ceph-pull-requests-ppc64le` freestyle job (fed
+  by the same webhook), not by this pipeline.
 
 ## Rollout
 

--- a/ceph-pull-requests-ppc64le/build/build
+++ b/ceph-pull-requests-ppc64le/build/build
@@ -1,0 +1,75 @@
+#!/bin/bash -ex
+
+# Webhook (issue_comment) triggers arrive straight from the generic webhook
+# trigger with no authorization layer in front of this job, so gate here the
+# same way ceph-pr-pipeline-trigger does: the commenter needs write/admin on
+# ceph/ceph, or the PR must carry the ci-approved label.  comment_author is
+# only set for webhook triggers; manual builds skip the check.
+if [ -n "${comment_author}" ]; then
+    # The permission endpoint needs a token with push access (the status
+    # token), unlike the read-only token used for the label lookup.
+    permission=$(curl -s -u ${GITHUB_STATUS_USER}:${GITHUB_STATUS_TOKEN} \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/ceph/ceph/collaborators/${comment_author}/permission" | jq -r '.permission')
+    if [ "$permission" != "admin" ] && [ "$permission" != "write" ]; then
+        labels=$(curl -s -u ${GITHUB_USER}:${GITHUB_PASS} \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/ceph/ceph/issues/${ghprbPullId}/labels" | jq -r '.[].name')
+        if ! grep -qxF "ci-approved" <<< "$labels"; then
+            echo "${comment_author} lacks write access and PR ${ghprbPullId} has no ci-approved label; not building"
+            exit 0
+        fi
+    fi
+fi
+
+# Report the result back to GitHub as a commit status.  Unlike the GHPRB-era
+# jobs there is no plugin posting statuses for webhook triggers, so post them
+# ourselves whatever the build cause.  Installed as an EXIT trap so it fires
+# no matter where the job exits, including the docs-only early exit below
+# (which reports success).
+export FORCE_GITHUB_PR_STATUS=true
+trap 'report_github_pr_status $? "make check (ppc64le)" "make check"' EXIT
+
+update_github_pr_status "pending" "running make check" "make check (ppc64le)"
+
+docs_pr_only
+container_pr_only
+gha_pr_only
+qa_pr_only
+if [[ "$DOCS_ONLY" = true || "$CONTAINER_ONLY" = true || "$GHA_ONLY" == true || "$QA_ONLY" == true ]]; then
+    echo "Only the doc/, container/, qa/ or .github/ dir changed.  No need to run make check."
+    exit 0
+fi
+
+# Same build configuration as the weekly ceph-make-check-periodic-ppc64le
+# job: no dashboard (so no npm cache to populate), and a few things that
+# don't build on ppc64le disabled.
+NPROC=$(nproc)
+cat >.env <<EOF
+NPROC=${NPROC}
+MAX_PARALLEL_JOBS=${NPROC}
+WITH_RBD_RWL=true
+WITHOUT_DASHBOARD=true
+WITHOUT_BREAKPAD=true
+WITHOUT_WERROR=true
+DISABLE_FIO=true
+JENKINS_HOME=${JENKINS_HOME}
+REWRITE_COVERAGE_ROOTDIR=${PWD}/src/pybind/mgr/dashboard/frontend
+EOF
+
+bwc_login
+bwc 1 -e configure
+bwc 4 -e tests
+sleep 5
+ps -ef | grep -v jnlp | grep ceph || true
+
+# `bwc -e tests` exits 0 even when individual tests fail so that the CTest
+# results are always published; the xUnit publisher is what fails the build (its
+# threshold fails on any failed test).  A non-test failure (e.g. compile) would
+# have aborted above under `set -e`.  Mirror xUnit here so the EXIT trap reports
+# the matching GitHub status.
+test_xml="$(find build/Testing -name Test.xml 2>/dev/null)"
+if [ -n "$test_xml" ] && grep -q 'Status="failed"' $test_xml; then
+    echo "CTest reported one or more failed tests; marking the build as failed."
+    exit 1
+fi

--- a/ceph-pull-requests-ppc64le/build/kill-tests
+++ b/ceph-pull-requests-ppc64le/build/kill-tests
@@ -1,0 +1,32 @@
+#!/bin/bash -ex
+
+# kill all descendant processes of ctest
+
+# ceph-pull-requests-ppc64le/build/build is killed by jenkins when the ceph-pull-requests-ppc64le job is aborted or
+# canceled, see https://www.jenkins.io/doc/book/using/aborting-a-build/ . but build/build does not
+# wait until all its children processes quit. after ctest is killed by SIGTERM, there is chance
+# that some tests are still running as ctest does not get a chance to kill them before it terminates.
+# if these tests had timed out, ctest would kill them using SIGKILL. so we need to kill them
+# manually after the job is aborted.
+
+# if ctest is still running, get its pid, otherwise we are done.
+ctest_pid=$(pgrep ctest) || exit 0
+# the parent process of ctest should have been terminated, but this might not be true when
+# it comes to some of its descendant processes, for instance, unittest-seastar-messenger
+ctest_pgid=$(ps --no-headers --format 'pgid:1' --pid $ctest_pid)
+kill -SIGTERM -- -"$ctest_pgid"
+# try harder
+for seconds in 0 1 1 2 3; do
+    sleep $seconds
+    if pgrep --pgroup $ctest_pgid > /dev/null; then
+        # kill only if we've waited for a while
+        if test $seconds != 0; then
+            pgrep --pgroup $ctest_pgid
+            echo 'try harder'
+            kill -SIGKILL -- -"$ctest_pgid"
+        fi
+    else
+        echo 'killed'
+        break
+    fi
+done

--- a/ceph-pull-requests-ppc64le/config/definitions/ceph-pull-requests-ppc64le.yml
+++ b/ceph-pull-requests-ppc64le/config/definitions/ceph-pull-requests-ppc64le.yml
@@ -1,0 +1,120 @@
+- job:
+    name: ceph-pull-requests-ppc64le
+    description: |
+      make check for a ceph.git PR on ppc64le (https://tracker.ceph.com/issues/80185).
+      Triggered by commenting "jenkins test make check ppc64le" on the PR
+      (via the generic webhook trigger; the ceph/ceph webhook that feeds
+      ceph-pr-pipeline-trigger feeds this job too), or manually by setting
+      ghprbPullId.  Same build configuration as the weekly
+      ceph-make-check-periodic-ppc64le job.
+    block-downstream: false
+    block-upstream: false
+    builders:
+    - shell:
+        !include-raw-verbatim:
+          - ../../../scripts/build_utils.sh
+          - ../../../scripts/bwc.sh
+          - ../../../scripts/setup_container_runtime.sh
+          - ../../build/build
+    concurrent: true
+    disabled: false
+    node: 'ppc64le && (installed-os-noble || centos9)'
+    parameters:
+    - string:
+        name: ghprbPullId
+        description: "the GitHub pull id, like '72' in 'ceph/pull/72'"
+    - string:
+        name: DISTRO_BASE
+        default: centos9
+        description: "the distribution used to create the container that builds and hosts the tests (see build-with-container.py for supported values)"
+    project-type: freestyle
+    properties:
+    - build-discarder:
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: -1
+        days-to-keep: 15
+        num-to-keep: 300
+    - github:
+        url: https://github.com/ceph/ceph/
+    quiet-period: '5'
+    retry-count: '3'
+    scm:
+    - git:
+        url: https://github.com/ceph/ceph.git
+        name: origin
+        branches:
+          - origin/pr/${{ghprbPullId}}/merge
+        refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+        skip-tag: true
+        shallow-clone: true
+        honor-refspec: true
+        timeout: 20
+        wipe-workspace: true
+    # The same ceph/ceph webhook that feeds ceph-pr-pipeline-trigger (matched
+    # by the shared pr-check-trigger-token credential) triggers this job; the
+    # filter only fires it for new PR comments containing the ppc64le phrase.
+    # Authorization (commenter permission / ci-approved label) is checked in
+    # the build script.  ghprbPullId is populated from the payload's issue
+    # number, which the SCM branch spec above then picks up.
+    triggers:
+      - generic-webhook-trigger:
+          token: ceph-pull-requests-ppc64le
+          token-credential-id: pr-check-trigger-token
+          print-contrib-var: true
+          post-content-params:
+            - type: JSONPath
+              key: action
+              value: $.action
+            - type: JSONPath
+              key: ghprbPullId
+              value: $.issue.number
+            - type: JSONPath
+              key: issue_is_pr
+              value: $.issue.pull_request.url
+            - type: JSONPath
+              key: comment_body
+              value: $.comment.body
+            - type: JSONPath
+              key: comment_author
+              value: $.comment.user.login
+          regex-filter-text: $action:$issue_is_pr:$comment_body
+          # A created issue_comment on a PR (issue_is_pr non-empty) containing
+          # the trigger phrase.
+          regex-filter-expression: "(?is)^created:https[^:]*:.*jenkins\\s+test\\s+make\\s+check\\s+ppc64le\\b.*$"
+          cause: "GitHub comment by $comment_author on PR $ghprbPullId"
+    publishers:
+      - postbuildscript:
+          builders:
+            - role: SLAVE
+              build-on:
+                - ABORTED
+              build-steps:
+                - shell:
+                    !include-raw-verbatim:
+                      - ../../build/kill-tests
+      - xunit:
+          thresholds:
+            - failed:
+                unstable: 0
+                unstablenew: 0
+                failure: 0
+                failurenew: 0
+          types:
+            - ctest:
+                pattern: "build/Testing/**/Test.xml"
+                skip-if-no-test-files: true
+    wrappers:
+      - ansicolor
+      - credentials-binding:
+          - username-password-separated:
+              credential-id: github-readonly-token
+              username: GITHUB_USER
+              password: GITHUB_PASS
+          - username-password-separated:
+              credential-id: github-status-check-token
+              username: GITHUB_STATUS_USER
+              password: GITHUB_STATUS_TOKEN
+          - username-password-separated:
+              credential-id: dgalloway-docker-hub
+              username: DOCKER_HUB_USERNAME
+              password: DOCKER_HUB_PASSWORD

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1275,7 +1275,10 @@ update_github_pr_status() {
   # already have their status managed by the GitHub Pull Request Builder plugin,
   # so posting here would just be a duplicate.  Check ROOT_BUILD_CAUSE too so a
   # job kicked off down an upstream chain from a manual trigger is still covered.
-  if [ "$BUILD_CAUSE" != "MANUALTRIGGER" ] && [ "$ROOT_BUILD_CAUSE" != "MANUALTRIGGER" ]; then
+  # Jobs with no status-posting plugin at all (e.g. generic-webhook-trigger
+  # jobs like ceph-pull-requests-ppc64le) set FORCE_GITHUB_PR_STATUS=true to
+  # post for every build cause.
+  if [ "$FORCE_GITHUB_PR_STATUS" != true ] && [ "$BUILD_CAUSE" != "MANUALTRIGGER" ] && [ "$ROOT_BUILD_CAUSE" != "MANUALTRIGGER" ]; then
     return 0
   fi
 

--- a/scripts/build_utils.sh
+++ b/scripts/build_utils.sh
@@ -1706,10 +1706,13 @@ pr_only_for() {
   # receive by creating another local array ("$@")
   local -n local_patterns=$1
   local files
-  # Manually-triggered jobs don't get the ghprb* variables set by the GitHub
-  # Pull Request Builder plugin.  Assume ceph/ceph and look up the PR's target
-  # branch from the GitHub API.
-  if [ "$BUILD_CAUSE" = "MANUALTRIGGER" ]; then
+  # Manually-triggered and generic-webhook-triggered jobs don't get the
+  # ghprb* variables set by the GitHub Pull Request Builder plugin.  Assume
+  # ceph/ceph and look up the PR's target branch from the GitHub API.  Key on
+  # the variable being unset rather than the build cause: with an empty
+  # ghprbGhRepository the files lookup below hits repos//pulls/... (404), the
+  # file list comes back empty, and every *_pr_only check is vacuously true.
+  if [ -z "$ghprbGhRepository" ]; then
     ghprbGhRepository="ceph/ceph"
     ghprbTargetBranch="$(curl -s -u ${GITHUB_USER}:${GITHUB_PASS} https://api.github.com/repos/${ghprbGhRepository}/pulls/${ghprbPullId} | jq -r '.base.ref')"
   fi


### PR DESCRIPTION
https://tracker.ceph.com/issues/80185: let developers run make check for a PR on ppc64le by commenting `jenkins test make check ppc64le`, alongside the existing weekly `ceph-make-check-periodic-ppc64le` job.

- New freestyle job modeled on `ceph-pull-requests-arm64`, with the weekly ppc64le job's build configuration (centos9 container, no dashboard, no breakpad/werror/fio).  No S3 build cache: the ppc64le builders can't reach the doli cluster, so every run builds fresh, like the weekly job.
- Triggered by the generic webhook trigger on the same ceph/ceph webhook that feeds `ceph-pr-pipeline-trigger` (matched via the shared `pr-check-trigger-token` credential), filtered to new PR comments containing the phrase.  Since nothing sits in front of the job, the build script enforces the same policy as the pipeline trigger: the commenter needs write/admin on ceph/ceph, or the PR must carry the `ci-approved` label.
- Statuses are posted as `make check (ppc64le)` by the job itself for every build cause, via a new `FORCE_GITHUB_PR_STATUS` override of the manual-triggers-only guard in `update_github_pr_status`.
- `ceph-pr-pipeline-trigger` gets a wider negative lookahead so the ppc64le phrase doesn't also queue the x86_64 make-check leg.

JJB definition renders clean with `jenkins-jobs test`; the trigger Jenkinsfile passes the declarative linter.