### PR TITLE
ceph-pr-pipeline: never let a GitHub status POST change a leg's outcome

### DIFF
--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -80,22 +80,31 @@ def postStatus(String key, String state, String description) {
   if (!env.HEAD_SHA) {
     return
   }
-  if (state != "pending") {
-    leg_finalized[key] = true
-  }
   writeFile(file: "status.json", text: groovy.json.JsonOutput.toJson([
     state: state,
     context: "${params.STATUS_PREFIX}${contexts[key]}",
     description: description,
     target_url: env.BUILD_URL,
   ]))
-  sh(
+  // Best-effort: a status POST must never change a leg's outcome (2026-09-09
+  // a GitHub API brownout turned dozens of green legs red).  Retry through
+  // transient errors; if the POST still fails, log it and move on, leaving
+  // the context unfinalized so the post{} sweep gets another shot later.
+  def rc = sh(
     label: "GitHub status: ${contexts[key]} -> ${state}",
-    script: "curl -sf -o /dev/null -X POST " +
+    returnStatus: true,
+    script: "curl -sfS -o /dev/null --retry 5 --retry-delay 10 --retry-all-errors -X POST " +
             "-u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
             "-H 'Accept: application/vnd.github+json' -d @status.json " +
             "'${github_api}/repos/${github_repo}/statuses/${env.HEAD_SHA}'"
   )
+  if (rc != 0) {
+    echo "WARNING: could not post GitHub status ${contexts[key]} -> ${state} (curl exit ${rc})"
+    return
+  }
+  if (state != "pending") {
+    leg_finalized[key] = true
+  }
 }
 
 // Run a leg with pending/success/failure statuses around it.
@@ -757,6 +766,11 @@ pipeline {
     }
     failure {
       script { finalizePendingStatuses("error", "did not run: the pipeline failed earlier") }
+    }
+    // A SUCCESS build means every selected leg ran and passed; anything still
+    // unfinalized just lost its success POST to a transient GitHub error.
+    success {
+      script { finalizePendingStatuses("success", "succeeded") }
     }
   }
 }


### PR DESCRIPTION
During the 2026-09-09 13:25–17:00 UTC GitHub API brownout, the plain `curl -sf` in `postStatus()` failed dozens of times across ~15 `ceph-pr-pipeline` builds. Because the `sh` step threw, a failed POST didn't just lose the status update — it failed the leg itself:

- legs whose work had already **succeeded** went red (e.g. [build 985](https://jenkins.ceph.com/job/ceph-pr-pipeline/985/)'s 78-minute arm64 make check passed, then died posting `-> success`),
- other legs died before starting when the `-> pending` POST was the one that failed (963, 970–977, 984, 989, …),
- the affected contexts were left stuck `pending` on the PRs; each needed a manual status repost or a retrigger.

This makes `postStatus()` best-effort:

- retry the POST through transient errors (`--retry 5 --retry-delay 10 --retry-all-errors`, same shape as 2e90ae5e), and log the HTTP error (`-S` still prints it under `-f`) plus a warning if it ultimately fails, instead of throwing;
- only mark `leg_finalized` once a terminal POST actually lands, so the `post{}` sweep can repair anything that slipped through;
- add a `success{}` branch to `post{}` so the sweep also runs for green builds, whose lost `-> success` contexts previously stayed pending forever.

Declarative linter passes.