### PR TITLE
ceph-trigger-build: keep resolute out of tentacle/umbrella branch builds

### DIFF
--- a/ceph-trigger-build/build/Jenkinsfile
+++ b/ceph-trigger-build/build/Jenkinsfile
@@ -55,6 +55,8 @@ def params_from_branch(initialParams) {
       params[-1]['ARCHS'] += ' arm64'
       break
     case ~/.*(tentacle|umbrella).*/:
+      // resolute is built for main only; don't inherit it from the defaults
+      params[0]['DISTROS'] = 'rocky10 centos9 jammy noble windows'
       if ( !singleSet ) {
         params << params[0].clone()
         params[-1]['ARCHS'] = 'x86_64'


### PR DESCRIPTION
59b542e5 (resolute enablement, merged via #2706) added resolute to the global `DISTROS` defaults so main builds Ubuntu 26.04, but the `~/.*(tentacle|umbrella).*/` case in `params_from_branch()` never overrides `DISTROS`, so every umbrella/tentacle wip branch inherited it — e.g. [ceph-dev-pipeline #8931](https://jenkins.ceph.com/job/ceph-dev-pipeline/8931/) building `wip-pdonnell-testing-20260910.003149-umbrella` for resolute.

This pins the tentacle/umbrella case to `rocky10 centos9 jammy noble windows`, matching what ceph-dev-cron already uses for those branches. It's set on `params[0]` before the `singleSet` split so both the pipeline path and the legacy two-set path get it (the legacy debug set still overrides to its own narrower list afterwards, as before). resolute continues to build for main and default-case (vampire-like) branches.

Jenkinsfile passes the declarative linter.