### PR TITLE
PR CI gating fixes: GHPRB org-admin flag, trigger supersession and label removal

### DIFF
--- a/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
+++ b/ceph-build-pull-requests/config/definitions/ceph-build-pull-requests.yml
@@ -31,6 +31,7 @@
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false
+          allow-whitelist-orgs-as-admins: true
           auto-close-on-fail: false
 
     scm:

--- a/ceph-iscsi-tox/config/definitions/ceph-iscsi-tox.yml
+++ b/ceph-iscsi-tox/config/definitions/ceph-iscsi-tox.yml
@@ -48,6 +48,7 @@
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false
+          allow-whitelist-orgs-as-admins: true
           auto-close-on-fail: false
           status-context: "tox"
 

--- a/ceph-pr-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-pr-pipeline-trigger/build/Jenkinsfile
@@ -312,11 +312,22 @@ pipeline {
           if (is_comment) {
             authorized = approved || hasCiPermission(env.comment_author)
           } else if (env.action == "labeled") {
-            // Adding a label requires triage permission on ceph/ceph, so the
-            // label itself is the approval.  Clear author-ci-perms.yml's
-            // marker so the PR no longer looks blocked.
-            authorized = true
-            removeLabel("needs-ci-approval")
+            // Labels only need triage permission, a lower bar than the
+            // write access required of authors whose CI runs automatically;
+            // honor the label only when the person who added it meets that
+            // same bar (author-ci-perms.yml applies the identical check).
+            authorized = hasCiPermission(env.sender)
+            if (authorized) {
+              // Clear author-ci-perms.yml's marker so the PR no longer
+              // looks blocked.
+              removeLabel("needs-ci-approval")
+            } else {
+              // Strip the unauthorized approval: the opened/reopened and
+              // comment paths trust the label's mere presence, so leaving
+              // it would only delay the leak until the next comment.
+              echo "Ignoring ${approval_label} added by ${env.sender}: needs write access"
+              removeLabel(approval_label)
+            }
           } else if (env.action == "synchronize") {
             authorized = author_trusted
             if (!authorized && approved) {

--- a/ceph-pr-pipeline-trigger/build/Jenkinsfile
+++ b/ceph-pr-pipeline-trigger/build/Jenkinsfile
@@ -11,8 +11,9 @@
 //   - "jenkins test <check>" comments re-run individual checks (org members
 //     always; others only while the PR carries the ci-approved label).
 //   - A newly triggered run aborts still-running runs it supersedes: same
-//     PR on an older head, or overlapping checks on the same head.  Runs
-//     of disjoint checks on the same head are left alone.
+//     PR on an older head, or a same-head run whose checks the new run
+//     fully covers.  A same-head run doing anything the new run won't redo
+//     is left alone.
 
 import groovy.transform.Field
 
@@ -164,11 +165,17 @@ def hasCiPermission(String user) {
 }
 
 def removeLabel(String name) {
-  sh(
-    script: "curl -s -o /dev/null -X DELETE " +
+  def code = sh(
+    script: "curl -s -o /dev/null -w '%{http_code}' -X DELETE " +
             "-u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
-            "'${github_api}/repos/${github_repo}/issues/${pr}/labels/${name}'"
-  )
+            "'${github_api}/repos/${github_repo}/issues/${pr}/labels/${name}'",
+    returnStdout: true,
+  ).trim()
+  // 404 = already gone (e.g. author-ci-perms.yml won the removal race).
+  if (code != "200" && code != "404") {
+    echo "WARNING: could not remove label '${name}' (HTTP ${code}); " +
+         "the github-status-check-token needs issues write access on ${github_repo}"
+  }
 }
 
 def postStatus(String context, String state, String description, String url) {
@@ -188,11 +195,13 @@ def postStatus(String context, String state, String description, String url) {
 }
 
 // Abort the running ceph-pr-pipeline builds this run supersedes: any build
-// of the same PR on an older head, or one running a check we are about to
-// run again on the same head.  Same-head builds of disjoint checks survive:
-// "one command per comment" means asking for two checks takes two comments,
-// and the second must not kill the first.  Needs one-time in-process script
-// approval (Jenkins model access from a sandboxed pipeline).
+// of the same PR on an older head, or a same-head build whose checks the
+// new run fully covers.  A same-head build doing anything the new run
+// won't redo survives — "jenkins test submodules" after ci-approved must
+// not kill the six-check run the label started, stranding the other five
+// contexts at "canceled" with nothing queued to redo them (PR 69804).
+// Needs one-time in-process script approval (Jenkins model access from a
+// sandboxed pipeline).
 @NonCPS
 def cancelRunningPrBuilds(String pr_number, String new_sha, String new_checks) {
   def wanted = new_checks.tokenize(" ")
@@ -211,13 +220,18 @@ def cancelRunningPrBuilds(String pr_number, String new_sha, String new_checks) {
     def b_sha = params.getParameter("HEAD_SHA")?.getValue()?.toString() ?: ""
     def b_checks = (params.getParameter("CHECKS")?.getValue()?.toString() ?: "")
         .tokenize(" ")
-    if (b_sha == new_sha && !b_checks.any { wanted.contains(it) }) {
+    if (b_sha == new_sha && !wanted.containsAll(b_checks)) {
       println("Keeping ${pipeline_job} build #${b.getNumber()}: " +
-              "same head, disjoint checks [${b_checks.join(' ')}]")
+              "same head, checks [${b_checks.join(' ')}] not fully covered " +
+              "by [${wanted.join(' ')}]")
       continue
     }
     println("Aborting superseded ${pipeline_job} build #${b.getNumber()}")
-    b.getExecutor()?.interrupt(hudson.model.Result.ABORTED)
+    // A pipeline build occupies only a flyweight executor while it waits
+    // for agents, and getExecutor() is null then; fall back to the one-off
+    // executor so those builds are aborted too.
+    def exec = b.getExecutor() ?: b.getOneOffExecutor()
+    exec?.interrupt(hudson.model.Result.ABORTED)
   }
 }
 

--- a/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
+++ b/ceph-qa-suite-pull-requests/config/definitions/ceph-qa-suite-pull-requests.yml
@@ -31,6 +31,7 @@
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false
+          allow-whitelist-orgs-as-admins: true
           auto-close-on-fail: false
 
     scm:

--- a/ceph-volume-unit-tests/config/definitions/ceph-volume-pr.yml
+++ b/ceph-volume-unit-tests/config/definitions/ceph-volume-pr.yml
@@ -43,6 +43,7 @@
           trigger-phrase: 'jenkins ceph-volume unit tests'
           github-hooks: true
           permit-all: false
+          allow-whitelist-orgs-as-admins: true
           auto-close-on-fail: false
           status-context: "ceph-volume tox testing"
           started-status: "ceph-volume tox running"

--- a/cephmetrics-pull-requests/config/definitions/cephmetrics-pull-requests.yml
+++ b/cephmetrics-pull-requests/config/definitions/cephmetrics-pull-requests.yml
@@ -35,6 +35,7 @@
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false
+          allow-whitelist-orgs-as-admins: true
           auto-close-on-fail: false
 
     scm:

--- a/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
+++ b/merfi-pull-requests/config/definitions/merfi-pull-requests.yml
@@ -44,6 +44,7 @@
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false
+          allow-whitelist-orgs-as-admins: true
           auto-close-on-fail: false
 
     scm:

--- a/paddles-pull-requests/config/definitions/paddles-pull-requests.yml
+++ b/paddles-pull-requests/config/definitions/paddles-pull-requests.yml
@@ -47,6 +47,7 @@
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false
+          allow-whitelist-orgs-as-admins: true
           auto-close-on-fail: false
 
     scm:

--- a/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
+++ b/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
@@ -59,6 +59,7 @@
           only-trigger-phrase: false
           github-hooks: true
           permit-all: false
+          allow-whitelist-orgs-as-admins: true
           auto-close-on-fail: false
 
     scm:


### PR DESCRIPTION
Fixes for problems found while investigating ceph/ceph#69804 (external contributor's PR where `jenkins ceph-volume unit tests` was silently ignored and a comment-triggered re-run canceled the full check run):

**ghprb: let org members trigger checks on external PRs**

Since 01ed6534 ("All: Limit PR checks to Ceph org") these jobs run with `permit-all: false`, an empty admin list, and org members not treated as admins. GHPRB only honors a trigger phrase from a non-admin when the PR author is already trusted, so on an external contributor's PR nobody could trigger these checks at all — the comment was received (confirmed in the Jenkins log) and silently dropped. Most GHPRB jobs already set `allow-whitelist-orgs-as-admins: true`; this adds it to the eight that were missed, including `ceph-volume-unit-tests`. Needs a JJB re-apply after merge.

**ceph-pr-pipeline-trigger: don't let partial re-runs kill full runs**

`jenkins test submodules`, commented minutes after `ci-approved` started the six-check run, aborted that run because supersession matched any same-head check overlap; the other five contexts were left stuck at "canceled" with nothing queued to redo them. Now a same-head build is only superseded when the new run fully covers its checks. Also: abort via the one-off executor when `getExecutor()` is null (pipeline builds waiting for an agent escaped cancellation — observed with builds 1109/1111 surviving while 1107 died), and log `removeLabel` failures instead of discarding them — the `github-status-check-token` cannot modify labels, so the `needs-ci-approval` removal has been failing silently (ceph/ceph#71689 makes the Actions workflow clear it reliably).

**ceph-pr-pipeline-trigger: only honor ci-approved from maintainers**

Adding a label needs only triage permission, a lower bar than the write access required of authors whose CI runs automatically, so anyone with triage could green-light CI on untrusted code. The trigger now honors the `ci-approved` label only when the person who added it has write/admin permission, and strips it otherwise (the opened/reopened and comment paths trust the label's presence, so an unhonored label left in place would still leak authorization on the next event). The matching sender check on the Actions side lives in ceph/ceph#71689; this one is the enforcement point, since the trigger reacts to the webhook before any workflow can intervene.