### PR TITLE
ceph-pr-pipeline: retry GitHub API calls, and never let a status POST decide a leg's outcome

### DIFF
--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -59,6 +59,8 @@ import groovy.transform.Field
 @Field boolean run_api = false
 @Field boolean run_windows = false
 @Field boolean build_cached = false
+// true once prepare has resolved the PR and decided which legs run
+@Field boolean prepared = false
 // context key -> true once a terminal (non-pending) status was posted, so the
 // abort/failure sweep in post{} only finalizes contexts still left pending.
 @Field Map leg_finalized = [:]
@@ -135,22 +137,33 @@ def postStatus(String key, String state, String description) {
   if (!env.HEAD_SHA) {
     return
   }
-  if (state != "pending") {
-    leg_finalized[key] = true
-  }
   writeFile(file: "status.json", text: groovy.json.JsonOutput.toJson([
     state: state,
     context: "${params.STATUS_PREFIX}${contexts[key]}",
     description: description,
     target_url: env.BUILD_URL,
   ]))
-  sh(
+  // Best-effort: a status POST must never change a leg's outcome.  During
+  // the 2026-09-09 GitHub API brownout a throwing sh step here turned dozens
+  // of green legs red (build 985's 78-minute arm64 make check passed, then
+  // died posting "-> success").  If the POST still fails after gh_curl's
+  // retries, log it and move on; the context stays unfinalized so the
+  // post{} sweep gets another shot at it.
+  def rc = sh(
     label: "GitHub status: ${contexts[key]} -> ${state}",
+    returnStatus: true,
     script: gh_curl + "gh_curl -X POST " +
             "-u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
             "-H 'Accept: application/vnd.github+json' -d @status.json " +
             "'${github_api}/repos/${github_repo}/statuses/${env.HEAD_SHA}' > /dev/null"
   )
+  if (rc != 0) {
+    echo "WARNING: could not post GitHub status ${contexts[key]} -> ${state} (exit ${rc})"
+    return
+  }
+  if (state != "pending") {
+    leg_finalized[key] = true
+  }
 }
 
 // Run a leg with pending/success/failure statuses around it.
@@ -173,17 +186,35 @@ def withStatus(String key, String label, Closure body) {
 // from post{}, which has no agent, so it grabs one itself; best-effort by
 // nature (a hard kill skips post{} entirely).
 def finalizePendingStatuses(String state, String description) {
+  // If prepare died before resolving the PR (its GitHub fetch failed, or the
+  // head moved and it bailed as superseded), HEAD_SHA is unset and the run_*
+  // flags are all still false -- but the trigger has already set every
+  // context in CHECKS to "queued" on the sha it passed in, and without this
+  // they would stay pending on the PR forever.  Fall back to that sha and
+  // that list.  A manual run without HEAD_SHA has no trigger-posted
+  // statuses to clean up, so returning is right there.
   if (!env.HEAD_SHA) {
-    return
+    if (!params.HEAD_SHA) {
+      return
+    }
+    env.HEAD_SHA = params.HEAD_SHA
   }
-  def pending = [
-    "signed": run_signed,
-    "submodules": run_submodules,
-    "make-check": run_make_check,
-    "make-check-arm64": run_make_check_arm64,
-    "api": run_api,
-    "windows": run_windows,
-  ].findAll { key, will_run -> will_run && !leg_finalized[key] }.keySet()
+  def will_run
+  if (prepared) {
+    will_run = [
+      "signed": run_signed,
+      "submodules": run_submodules,
+      "make-check": run_make_check,
+      "make-check-arm64": run_make_check_arm64,
+      "api": run_api,
+      "windows": run_windows,
+    ]
+  } else {
+    will_run = params.CHECKS.tokenize(" ").findAll { contexts[it] }
+        .collectEntries { [(it): true] }
+  }
+  def pending = will_run
+      .findAll { key, run -> run && !leg_finalized[key] }.keySet()
   if (!pending) {
     return
   }
@@ -339,6 +370,7 @@ def doPrepare() {
       api_branches.any { env.ghprbTargetBranch ==~ it }
   run_windows = wantCheck("windows") && !qa_skip &&
       windows_branches.contains(env.ghprbTargetBranch)
+  prepared = true
 
   // Post pending for every leg that will run NOW, from the small node we're
   // already holding, so the PR shows all its checks within seconds of the
@@ -841,6 +873,12 @@ pipeline {
     }
     failure {
       script { finalizePendingStatuses("error", "did not run: the pipeline failed earlier") }
+    }
+    // A SUCCESS build means every selected leg ran and passed; anything
+    // still unfinalized just lost its success POST to a transient GitHub
+    // error.
+    success {
+      script { finalizePendingStatuses("success", "succeeded") }
     }
   }
 }

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -74,6 +74,61 @@ def logNode() {
   echo "Running on ${shortname} (${env.JENKINS_URL}computer/${env.NODE_NAME}/)"
 }
 
+// Every GitHub API call in this pipeline goes through gh_curl.  A bare
+// `curl -sf` turns one bad response into exit 22 with no clue which status
+// it was: builds 1126 and 1127 both died in the same second on the PR fetch
+// in prepare, and because that happens before HEAD_SHA is known, no leg ever
+// posts a terminal status -- the six contexts the trigger had already set to
+// "queued" stay pending on the PR forever, blocking it silently.
+//
+// Plain `curl --retry` is not enough: it ignores 403 (which is what GitHub
+// uses for secondary rate limits), and --retry-all-errors doesn't exist on
+// the older builders' curl.  Retries are limited to the statuses that can
+// actually clear on their own; anything else still fails fast, now with the
+// status code and the response body in the log.
+@Field String gh_curl = '''#!/bin/bash
+set -e
+gh_curl() {
+  local out code attempt retry
+  local url="${@: -1}"
+  out=$(mktemp)
+  for attempt in 1 2 3 4 5; do
+    code=$(curl -s -o "$out" -w '%{http_code}' --max-time 60 "$@") || code=""
+    case "$code" in
+      2??)
+        cat "$out"
+        rm -f "$out"
+        return 0
+        ;;
+      403)
+        # also what a revoked token gets; only the rate limit clears on its own
+        if grep -qi 'rate limit' "$out"; then retry=yes; else retry=no; fi
+        ;;
+      429|5??|"")
+        retry=yes
+        ;;
+      *)
+        retry=no
+        ;;
+    esac
+    if [ "$retry" = no ]; then
+      echo "gh_curl: HTTP $code from $url, not retrying" >&2
+      cat "$out" >&2
+      rm -f "$out"
+      return 22
+    fi
+    echo "gh_curl: HTTP ${code:-connection failure} from $url, attempt ${attempt}/5" >&2
+    if [ "$attempt" -lt 5 ]; then
+      sleep $((attempt * 5))
+    fi
+  done
+  echo "gh_curl: giving up on $url after 5 attempts (last HTTP ${code:-connection failure})" >&2
+  cat "$out" >&2
+  rm -f "$out"
+  return 22
+}
+'''
+
 def postStatus(String key, String state, String description) {
   // Nothing to post against until prepare has resolved the head sha (e.g. a
   // build aborted while still in prepare).
@@ -91,10 +146,10 @@ def postStatus(String key, String state, String description) {
   ]))
   sh(
     label: "GitHub status: ${contexts[key]} -> ${state}",
-    script: "curl -sf -o /dev/null -X POST " +
+    script: gh_curl + "gh_curl -X POST " +
             "-u \$GITHUB_STATUS_CREDS_USR:\$GITHUB_STATUS_CREDS_PSW " +
             "-H 'Accept: application/vnd.github+json' -d @status.json " +
-            "'${github_api}/repos/${github_repo}/statuses/${env.HEAD_SHA}'"
+            "'${github_api}/repos/${github_repo}/statuses/${env.HEAD_SHA}' > /dev/null"
   )
 }
 
@@ -209,7 +264,8 @@ def doPrepare() {
   def pr_data = null
   for (int attempt = 0; attempt < 3; attempt++) {
     pr_data = readJSON(text: sh(
-      script: "curl -sf -u \$GITHUB_RO_CREDS_USR:\$GITHUB_RO_CREDS_PSW " +
+      label: "fetch PR ${params.ghprbPullId}",
+      script: gh_curl + "gh_curl -u \$GITHUB_RO_CREDS_USR:\$GITHUB_RO_CREDS_PSW " +
               "-H 'Accept: application/vnd.github+json' " +
               "'${github_api}/repos/${github_repo}/pulls/${params.ghprbPullId}'",
       returnStdout: true,

--- a/ceph-pr-pipeline/build/pr_checks.sh
+++ b/ceph-pr-pipeline/build/pr_checks.sh
@@ -22,9 +22,50 @@ set -o pipefail
 GH_REPO=${GH_REPO:-"ceph/ceph"}
 GH_API="https://api.github.com/repos/${GH_REPO}"
 
+# A bare `curl -sf` fails the whole check on a single 403 (GitHub's secondary
+# rate limit) or 5xx, with exit 22 and no clue which status it was.  Retry the
+# responses that can clear on their own, and say what we got otherwise.  Same
+# helper as gh_curl in the pipeline's Jenkinsfile.
 gh_api() {
-    curl -sf -u "${GITHUB_USER}:${GITHUB_PASS}" \
-        -H "Accept: application/vnd.github+json" "$@"
+    local out code attempt retry
+    local url="${@: -1}"
+    out=$(mktemp)
+    for attempt in 1 2 3 4 5; do
+        code=$(curl -s -o "$out" -w '%{http_code}' --max-time 60 \
+            -u "${GITHUB_USER}:${GITHUB_PASS}" \
+            -H "Accept: application/vnd.github+json" "$@") || code=""
+        case "$code" in
+            2??)
+                cat "$out"
+                rm -f "$out"
+                return 0
+                ;;
+            403)
+                # also what a revoked token gets; only the rate limit clears on its own
+                if grep -qi 'rate limit' "$out"; then retry=yes; else retry=no; fi
+                ;;
+            429|5??|"")
+                retry=yes
+                ;;
+            *)
+                retry=no
+                ;;
+        esac
+        if [ "$retry" = no ]; then
+            echo "gh_api: HTTP $code from $url, not retrying" >&2
+            cat "$out" >&2
+            rm -f "$out"
+            return 22
+        fi
+        echo "gh_api: HTTP ${code:-connection failure} from $url, attempt ${attempt}/5" >&2
+        if [ "$attempt" -lt 5 ]; then
+            sleep $((attempt * 5))
+        fi
+    done
+    echo "gh_api: giving up on $url after 5 attempts (last HTTP ${code:-connection failure})" >&2
+    cat "$out" >&2
+    rm -f "$out"
+    return 22
 }
 
 # Paginate a list endpoint ($1, e.g. "pulls/123/files") and emit one combined


### PR DESCRIPTION
Two commits; together they replace #2710.

### 1. Retry the GitHub API calls instead of dying on one bad response

2026-09-10 13:42 UTC, builds [1126](https://jenkins.ceph.com/job/ceph-pr-pipeline/1126/) and [1127](https://jenkins.ceph.com/job/ceph-pr-pipeline/1127/) (both ceph/ceph#71659) died 25 seconds in, in the same second, on the first line of `doPrepare`:

```
+ curl -sf -u **** -H Accept: application/vnd.github+json https://api.github.com/repos/ceph/ceph/pulls/71659
ERROR: script returned exit code 22
```

Builds started just before (1125) and just after (1128) went through fine — a momentary GitHub hiccup, and `curl -sf` threw away the status code.

Both Jenkinsfile call sites and `pr_checks.sh`'s `gh_api` now go through a helper that retries 429 / 5xx / connection failures / the **rate-limit flavour of 403** with a 5s, 10s, 15s, 20s backoff. 403 is also what a revoked token gets and that never clears on its own, so it's only retried when GitHub's body says "rate limit". Anything else fails immediately, with the URL, status code and response body in the log.

`curl --retry` alone wouldn't cover this: it ignores 403, and `--retry-all-errors` (what #2710 used) is too new for the curl on some builders.

### 2. A status POST never fails a leg, and the sweep always runs

Three holes in the status lifecycle, all seen this week:

- **`postStatus()` threw on a failed POST**, so a status update could change a leg's outcome. In the 2026-09-09 brownout that turned dozens of green legs red — [985](https://jenkins.ceph.com/job/ceph-pr-pipeline/985/)'s 78-minute arm64 make check passed, then died posting `-> success`. Now best-effort: warn and carry on; `leg_finalized` only flips once a terminal POST actually lands, so the `post{}` sweep can repair what slipped. *(from #2710)*
- **No `success{}` branch in `post{}`**, so a green build whose `-> success` was lost left it pending forever. *(from #2710)*
- **`finalizePendingStatuses()` bailed when `HEAD_SHA` was unset** — but the trigger has already set every `CHECKS` context to "queued" on the sha it passes in, so a build dying before prepare resolves the PR (1126/1127, and the "superseded" path) leaves them all stuck pending: no failure to look at, PR silently blocked. That's what 71659 looked like. Now falls back to `params.HEAD_SHA` and sweeps the `CHECKS` tokens. A manual run without `HEAD_SHA` has nothing trigger-posted to clean up, so it still returns.

### Testing

- Declarative linter: **Jenkinsfile successfully validated** (both commits); `bash -n` clean on `pr_checks.sh`.
- Helper exercised standalone: live 200 (body on stdout, rc=0); live 404 (fails fast, prints GitHub's message, rc=22); local server 503×2→200 (two retries, 15s, rc=0); dead port (retries as "connection failure" — curl writes `000` for `%{http_code}` on a refused connection, so the non-zero exit is what's checked); local 403 with "secondary rate limit" body ×2→200 (retried, rc=0); local 403 "Bad credentials" (fails fast in 0s, rc=22).

Found while running `make check` on Ubuntu 26.04 via `DISTRO_BASE=resolute`; unrelated to that work otherwise.