### PR TITLE
ceph-pr-pipeline: merge PRs locally and key the cache by head+base

### DIFF
--- a/ceph-pr-pipeline/README.md
+++ b/ceph-pr-pipeline/README.md
@@ -33,14 +33,21 @@ webhook (pull_request / issue_comment)
 ```
 
 - **Cache:** build trees are zstd-tarred to the Sepia LRC's RGW (the doli
-  cluster) as `pr-builds/<PR>/<head sha>.<arch>.tar.zst`.  Re-runs for an
-  unchanged head sha skip compilation (`FORCE_BUILD=true` overrides).
+  cluster) as `pr-builds/<PR>/<head sha>-<base sha>.<arch>.tar.zst` — the
+  tree is a product of the PR merged onto its target branch, so the key is
+  exactly those two inputs and the cache invalidates itself when either
+  side moves.  Re-runs with both unchanged skip compilation
+  (`FORCE_BUILD=true` overrides).
 - **Statuses:** each leg posts its own context via the GitHub API.  Pending
   is posted from `prepare` before legs wait for executors; canceled/failed
   runs finalize any still-pending contexts.  Docs/container/gha-only PRs
   (plus qa-only for windows/arm64) report success without building.
-- **Checkout time:** set `CEPH_REFERENCE_REPO` to a local ceph.git mirror on
-  the builders to cut the remaining clones to seconds.
+- **Checkout:** each leg checks out the PR head and **merges it locally**
+  onto the target-branch head pinned once in prepare -- GitHub's
+  `refs/pull/N/merge` is refreshed lazily and can silently point at a stale
+  base, so nothing relies on it.  A per-builder ceph.git mirror (heads only,
+  auto-created on first use, refreshed each run; location overridable via
+  `CEPH_REFERENCE_REPO`) keeps the full-history clones down to seconds.
 
 ## The windows leg
 
@@ -55,7 +62,8 @@ persistent caches.  Measured: 79 min on a node with cold caches, ~60 warm.
 
 Steps, in order (all scripts in [scripts/ceph-windows](../scripts/ceph-windows/)):
 
-1. **Checkout**: ceph-build plus the PR merge ref, then submodules.
+1. **Checkout**: ceph-build, plus the PR merged locally onto the pinned
+   target-branch head, then submodules.
 2. **Cross-compile** (`win32_build_container`): runs the PR's own
    `win32_build.sh` in a podman container built from
    `win32-build.containerfile` (just the mingw toolchain packages; podman's
@@ -176,8 +184,8 @@ validation or one-off manual windows builds.
    LRC's RGW (any `doli0N.front.sepia.ceph.com:8080` endpoint; the legs
    pick the first one that answers).  The bucket-wide 21-day expiry
    lifecycle rule and a 20T quota on the `ceph-pr-builds` RGW user live
-   server-side.  Optionally seed reference mirrors for
-   `CEPH_REFERENCE_REPO`.
+   server-side.  The per-builder ceph.git mirrors
+   create themselves on first use.
 
 ## Known gaps
 

--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -266,24 +266,46 @@ def checkoutCephBuild() {
   """
 }
 
-// One shallow checkout of the PR merge ref into ./ceph.  Point
-// CEPH_REFERENCE_REPO at a local mirror to cut the 4-5 minute clone down to
-// seconds (the git plugin silently skips a reference path that doesn't exist).
+// One checkout of the PR merged onto its target branch, with the merge done
+// HERE rather than by GitHub: refs/pull/N/merge (and its merge_commit_sha)
+// is only refreshed when something pokes the PR's mergeability, so checking
+// it out can silently test a stale base.  prepare pinned HEAD_SHA and
+// BASE_SHA once, every leg merges those same two shas, and the S3 cache is
+// keyed by exactly those inputs -- nothing depends on GitHub's test merge.
+//
+// The full history needed for the merge base comes cheaply from a
+// per-builder mirror (heads only: all of refs/pull/* would be immense),
+// auto-created on first use and refreshed per run.  The mirror is purely an
+// optimization -- the clone below fetches whatever it lacks straight from
+// GitHub, so a missing or stale mirror costs minutes, never correctness.
+// CEPH_REFERENCE_REPO overrides its location.
 def checkoutCephPr() {
-  sh "rm -rf ceph"
-  checkout scmGit(
-    branches: [[name: "origin/pr/${params.ghprbPullId}/merge"]],
-    browser: [$class: 'GithubWeb', repoUrl: 'https://github.com/ceph/ceph'],
-    userRemoteConfigs: [[
-      url: ceph_repo,
-      refspec: "+refs/pull/${params.ghprbPullId}/*:refs/remotes/origin/pr/${params.ghprbPullId}/*",
-    ]],
-    extensions: [
-      [$class: 'RelativeTargetDirectory', relativeTargetDir: 'ceph'],
-      [$class: 'CloneOption', shallow: true, noTags: true, honorRefspec: true,
-       timeout: 20, reference: params.CEPH_REFERENCE_REPO ?: ''],
-    ],
-  )
+  sh """#!/bin/bash -ex
+    MIRROR="\${CEPH_REFERENCE_REPO:-\$HOME/ceph-mirror.git}"
+    if [ ! -d "\$MIRROR" ]; then
+      git init --bare "\$MIRROR"
+      git -C "\$MIRROR" remote add origin ${ceph_repo}
+      git -C "\$MIRROR" config remote.origin.fetch '+refs/heads/*:refs/heads/*'
+      # reference clones borrow objects from here; never let gc drop any
+      git -C "\$MIRROR" config gc.auto 0
+    fi
+    flock -w 900 "\$MIRROR" git -C "\$MIRROR" fetch --prune --no-tags origin || true
+
+    # sudo: an aborted windows run can skip its cleanup and leave uid-1000
+    # (subuid-owned) files from its vstart container in the tree, which
+    # plain rm cannot delete (run 1128: leftover build/boost on braggi21).
+    sudo rm -rf ceph
+    git clone --no-checkout --no-tags --reference "\$MIRROR" ${ceph_repo} ceph
+    cd ceph
+    git fetch --no-tags origin "+refs/pull/${params.ghprbPullId}/head:refs/remotes/origin/pr-head"
+    if [ "\$(git rev-parse refs/remotes/origin/pr-head)" != "${env.HEAD_SHA}" ]; then
+      echo "PR ${params.ghprbPullId} head is now \$(git rev-parse refs/remotes/origin/pr-head), this build is for ${env.HEAD_SHA}; superseded"
+      exit 1
+    fi
+    git checkout -q "${env.BASE_SHA}"
+    git -c user.name='Ceph PR pipeline' -c user.email='jenkins@ceph.com' \\
+        merge --no-edit --no-stat "${env.HEAD_SHA}"
+  """
 }
 
 def doPrepare() {
@@ -314,11 +336,25 @@ def doPrepare() {
   env.HEAD_SHA = pr_data.head.sha
   env.ghprbTargetBranch = pr_data.base.ref
   env.ghprbActualCommit = env.HEAD_SHA
+  // Pin the target branch head once; checkoutCephPr() merges the PR head
+  // onto exactly this sha on every leg, so all legs build one identical
+  // tree and the S3 cache is keyed by precisely its two inputs.  Keying by
+  // the head sha alone let a PR that sat still while its base moved keep
+  // restoring a tree built against an old base, which could no longer even
+  // re-run cmake in today's build container (runs 1137/1152: FindBoost
+  // "0.0.0" because /opt/ceph boost changed under a stale cached tree).
+  def base_ref = readJSON(text: sh(
+    label: "resolve ${env.ghprbTargetBranch} head",
+    script: gh_curl + "gh_curl -u \$GITHUB_RO_CREDS_USR:\$GITHUB_RO_CREDS_PSW " +
+            "-H 'Accept: application/vnd.github+json' " +
+            "'${github_api}/repos/${github_repo}/git/ref/heads/${env.ghprbTargetBranch}'",
+    returnStdout: true,
+  ))
+  env.BASE_SHA = base_ref.object.sha
 
-  // A conflicted PR has no refs/pull/N/merge on GitHub, so every leg's
-  // checkout would die with "Couldn't find any revision to build" and five
-  // cryptic red statuses.  Say it plainly on the applicable contexts and
-  // stop here instead.
+  // A conflicted PR can't be merged, so every leg's checkout would die in
+  // its local merge with conflict noise and five cryptic red statuses.
+  // Say it plainly on the applicable contexts and stop here instead.
   if (pr_data.mergeable == false) {
     params.CHECKS.tokenize(" ").each { key ->
       def branch_ok = true
@@ -338,12 +374,12 @@ def doPrepare() {
       (${pr_data.base.ref}) @ ${env.HEAD_SHA[0..7]}<br />
       not built: merge conflicts
     """.stripIndent()
-    error("PR ${params.ghprbPullId} has merge conflicts (mergeable=false); refs/pull/N/merge does not exist")
+    error("PR ${params.ghprbPullId} has merge conflicts (mergeable=false); nothing to build")
   }
 
   currentBuild.description = """\
     <a href="https://github.com/${github_repo}/pull/${params.ghprbPullId}">PR ${params.ghprbPullId}</a>
-    (${pr_data.base.ref}) @ ${env.HEAD_SHA[0..7]}<br />
+    (${pr_data.base.ref}) @ ${env.HEAD_SHA[0..7]} onto ${env.BASE_SHA[0..7]}<br />
     CHECKS=${params.CHECKS}
   """.stripIndent()
 
@@ -442,7 +478,7 @@ def bwcPreamble(String arch) {
     source ./ceph-build/ceph-pr-pipeline/build/s3_cache.sh
     export CACHE_ENDPOINTS="${cache_endpoints}"
     export CACHE_BUCKET="${cache_bucket}"
-    export CACHE_KEY="pr-builds/${params.ghprbPullId}/${env.HEAD_SHA}.${arch}.tar.zst"
+    export CACHE_KEY="pr-builds/${params.ghprbPullId}/${env.HEAD_SHA}-${env.BASE_SHA}.${arch}.tar.zst"
     export AWS_ACCESS_KEY_ID="\$CACHE_BUCKET_CREDS_USR"
     export AWS_SECRET_ACCESS_KEY="\$CACHE_BUCKET_CREDS_PSW"
     export DOCKER_HUB_USERNAME="\$DOCKER_HUB_CREDS_USR"

--- a/ceph-pr-pipeline/config/definitions/ceph-pr-pipeline.yml
+++ b/ceph-pr-pipeline/config/definitions/ceph-pr-pipeline.yml
@@ -66,7 +66,7 @@
       - string:
           name: CEPH_REFERENCE_REPO
           default: ""
-          description: "Path to a local ceph.git reference/mirror repo on the builders to speed up cloning (ignored where it doesn't exist)"
+          description: "Location of the per-builder ceph.git mirror that speeds up cloning (auto-created and refreshed each run; default $HOME/ceph-mirror.git)"
 
       - string:
           name: CEPH_BUILD_BRANCH


### PR DESCRIPTION
Reworked per @batrick's review: no more reliance on GitHub's test merge, in either the checkout or the cache key.

**Before:** legs checked out `refs/pull/N/merge` (refreshed lazily by GitHub — it can silently point at the PR merged onto a stale base), and the S3 build cache was keyed by the PR head sha alone (so a PR that sat still while its base moved kept restoring a tree built against old main — [run 1137](https://jenkins.ceph.com/job/ceph-pr-pipeline/1137/) and [run 1152](https://jenkins.ceph.com/job/ceph-pr-pipeline/1152/) died with `FindBoost "0.0.0"` when such trees could no longer re-run cmake in today's build container).

**Now:**
- `prepare` pins two shas once: the PR head (as before) and the **current target-branch head**.
- Every leg checks out the PR head and **merges it locally** onto exactly that pinned base sha. Merge conflicts fail cleanly (and the existing `mergeable == false` fast-path in prepare still reports them plainly before any leg runs). All legs of a run build one identical tree even if the base moves mid-run — which is actually stronger than the old behavior, where GitHub could move the merge ref between legs.
- The cache key is exactly the merge's two inputs: `pr-builds/<PR>/<head sha>-<base sha>.<arch>.tar.zst`. It invalidates itself when either side moves; old head-keyed objects age out via the bucket's 21-day expiry.

The local merge needs real ancestry, so the shallow clone is replaced by a full-history clone backed by a **per-builder heads-only mirror** (auto-created on first use, `git fetch`-refreshed each run under flock, `gc.auto=0` so reference clones never lose borrowed objects). The mirror is purely an optimization — the clone fetches anything it lacks straight from GitHub, so a missing/stale mirror costs minutes, never correctness. This also retires the hand-seeded `CEPH_REFERENCE_REPO` TODO: the param now just overrides the mirror location.