### PR TITLE
ceph-windows: day-1 production fixes for the container leg

### DIFF
--- a/scripts/ceph-windows/setup_libvirt
+++ b/scripts/ceph-windows/setup_libvirt
@@ -87,6 +87,13 @@ if [[ ! -S /var/run/libvirt/libvirt-sock ]]; then
     sudo systemctl status libvirtd
 fi
 
+# Start from a clean host: an aborted run can skip its cleanup, and a
+# leftover (shut-off) Windows VM still holds the qcow2 path, so this run's
+# virt-install would refuse with "Disk ... is already in use by other
+# guests".  With one executor per builder, any domain that exists here is
+# such a leftover.
+delete_libvirt_vms
+
 if ! sudo virsh net-info default &>/dev/null; then
     cat << EOF > $LIBVIRT_DIR/default-net.xml
 <network>

--- a/scripts/ceph-windows/win32_build_container
+++ b/scripts/ceph-windows/win32_build_container
@@ -97,6 +97,6 @@ podman run --rm --name "$CONTAINER_NAME" \
     -e OS=ubuntu \
     -w /workspace/ceph \
     "$IMAGE" \
-    bash -c "ccache -s; timeout $WIN32_BUILD_TIMEOUT ./win32_build.sh; ccache -s"
+    bash -c "ccache -s; timeout $WIN32_BUILD_TIMEOUT ./win32_build.sh; rc=\$?; ccache -s; exit \$rc"
 
 ls -lh "$WORKSPACE/ceph.zip"

--- a/scripts/ceph-windows/win32_build_container
+++ b/scripts/ceph-windows/win32_build_container
@@ -77,7 +77,12 @@ fi
 
 # MINGW_LLVM_DIR must be set explicitly: mingw_conf.sh defaults it relative
 # to the ceph tree ($CEPH_DIR/build.deps), not to DEPS_DIR.
+# --pids-limit=-1 for the same reason build-with-container.py passes it:
+# podman's default pids cgroup cap can be exceeded by a 32-worker ninja's
+# process bursts, and ninja dies with "posix_spawn: Operation not
+# permitted" (pipeline run 1115 on adami10).
 podman run --rm --name "$CONTAINER_NAME" \
+    --pids-limit=-1 \
     -v "$WORKSPACE:/workspace" \
     -v "$deps_cache_dir:/depscache" \
     -v "$ccache_dir:/ccache" \


### PR DESCRIPTION
Three fixes from watching the first day of the containerized windows leg in production (merged this morning in #2694), each one commit:

1. **Lift the pids limit on the cross-compile container.** [Run 1115](https://jenkins.ceph.com/job/ceph-pr-pipeline/1115/) (adami10) died mid-build with `ninja: fatal: posix_spawn: Operation not permitted`, and [run 1146](https://jenkins.ceph.com/job/ceph-pr-pipeline/1146/) (braggi12) at link phase with `ld.lld: std::system_error: Resource temporarily unavailable` — both faces of podman's default pids cgroup cap, which threads count against, so 32 parallel links × lld's thread pool blow through it even on a full ccache hit (links always run). `build-with-container.py` already passes `--pids-limit=-1` everywhere for this exact reason, so the vstart cluster container was immune; the hand-rolled cross-compile `podman run` was missing it.

2. **Don't let the trailing `ccache -s` mask a failed build.** The container command ran `ccache -s; win32_build.sh; ccache -s`, so a failed cross-compile exited the container with the stats command's status — only the missing-`ceph.zip` backstop failed the leg, burying the real error above the cache stats (which is why run 1146's lld crash took digging to find). The build's exit code is now preserved around the stats.

3. **Start `setup_libvirt` from a clean host.** [Run 1125](https://jenkins.ceph.com/job/ceph-pr-pipeline/1125/) died in virt-install with `Disk ... is already in use by other guests`: aborted run 1108 had skipped its cleanup (hard aborts can skip `post{}`), leaving a shut-off Windows VM holding the qcow2 path — and 1125's own end-of-run cleanup healed the node only after the run had failed. `setup_libvirt` now calls build_utils' `delete_libvirt_vms` up front; with one executor per builder, any domain defined at that point is a leftover. Living in the shared script, this also covers the old freestyle windows jobs until they're retired.

All three are scripts-only (no job config changes), so they take effect for every run on merge with no JJB step. Casualties were repaired with re-runs; PR 69804's windows re-run is deliberately waiting for this to merge, since any leg landing on an adami/braggi-class node at link phase can hit the pids wall again.