### PR TITLE
ceph-pr-pipeline: archive all legs' artifacts in one call

### DIFF
--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -685,6 +685,34 @@ def doWindowsTests() {
   }
 }
 
+// The controller's compress-artifacts plugin rewrites the build's whole
+// archive on every archiveArtifacts call instead of adding to it
+// (ZipStorage.archive writes a fresh zip and renames it into place;
+// "TODO support updating entries" upstream), so when two parallel legs
+// both archive, whichever finishes last silently wipes the other's
+// artifacts.  Legs stash instead, and this lone archiveArtifacts call
+// ships everything at once.
+def archiveLegArtifacts() {
+  if (!run_windows && !run_api) {
+    return
+  }
+  node("small") {
+    dir("leg-artifacts") {
+      deleteDir()
+      for (name in ["windows-artifacts", "api-logs"]) {
+        try {
+          unstash(name)
+        } catch (hudson.AbortException e) {
+          // that leg never ran, or died before stashing
+        }
+      }
+      archiveArtifacts(artifacts: "artifacts/**, ceph/build/out/*.log",
+                       allowEmptyArchive: true)
+      deleteDir()
+    }
+  }
+}
+
 pipeline {
   agent none
   options {
@@ -771,7 +799,9 @@ pipeline {
                 mkdir -p artifacts
                 cp ceph/build/*.log vstart-container.log artifacts/ 2>/dev/null || true
               """
-              archiveArtifacts(artifacts: "artifacts/**", allowEmptyArchive: true)
+              // Archived by archiveLegArtifacts in the pipeline post{}.
+              stash(name: "windows-artifacts", includes: "artifacts/**",
+                    allowEmpty: true)
               sh """#!/bin/bash
                 source ./ceph-build/scripts/build_utils.sh
                 source ./ceph-build/scripts/ceph-windows/cleanup
@@ -846,8 +876,11 @@ pipeline {
                         try {
                           doApiTests()
                         } finally {
-                          archiveArtifacts(artifacts: "ceph/build/out/*.log",
-                                           allowEmptyArchive: true)
+                          // Archived by archiveLegArtifacts in the
+                          // pipeline post{}.
+                          stash(name: "api-logs",
+                                includes: "ceph/build/out/*.log",
+                                allowEmpty: true)
                           sh """#!/bin/bash
                             podman rm -f ceph_build 2>/dev/null || true
                             podman unshare chown -R 0:0 "\$WORKSPACE"/ceph 2>/dev/null || true
@@ -879,6 +912,11 @@ pipeline {
     // error.
     success {
       script { finalizePendingStatuses("success", "succeeded") }
+    }
+    // cleanup runs after the conditions above, so the status sweeps
+    // aren't stuck behind the wait for the archive node.
+    cleanup {
+      script { archiveLegArtifacts() }
     }
   }
 }


### PR DESCRIPTION
### Problem

In [run 1113](https://jenkins.ceph.com/job/ceph-pr-pipeline/1113/), the windows leg's `collect_artifacts` completed and `archiveArtifacts(artifacts: "artifacts/**")` ran successfully at 15:13:36, yet the finished build holds only the API leg's 20 `ceph/build/out/*.log` files.

### Root cause

The controller has the **compress-artifacts** plugin as the artifact manager. Its `ZipStorage.archive()` writes a brand-new zip containing only the current call's files and renames it over the build's `archive.zip` — it never merges (the upstream source carries a literal `// TODO support updating entries`). So with parallel legs each calling `archiveArtifacts`, the last call wins and everything archived earlier in the build silently vanishes.

Run 1113 fits exactly: windows archived at 15:13:36, the API leg archived at 16:11:05, and only the API logs survived. Every retained run of the job shows the same last-writer-wins signature — each has *either* `artifacts/**` (windows) *or* `ceph/build/out/*.log` (API), never both. It is not a toko-node/executor/workspace issue; the old per-leg jobs never hit this because each build archived exactly once.

### Fix

Only one `archiveArtifacts` call per build: the windows and API legs now `stash` their files (`allowEmpty: true`), and a new `archiveLegArtifacts()` in the pipeline-level `post{}` unstashes both (tolerating a leg that never ran) and archives everything in one call from a `small` node. It runs under the `cleanup` condition so the GitHub status sweeps aren't delayed by the wait for that node's executor.

Sizes are modest (windows artifacts ~9 MB, API logs ~23–39 MB compressed), so the stash round-trip through the controller is cheap. The change also stays correct if compress-artifacts is ever disabled in favor of the default artifact manager.

Jenkinsfile passes the declarative linter (`pipeline-model-converter/validate`).