### PR TITLE
Changes from Git: per-repo commit links, and a real ceph.git changelog for dashboard e2e

### DIFF
--- a/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
+++ b/ceph-dashboard-cephadm-e2e-nightly/config/definitions/ceph-dashboard-cephadm-e2e-nightly.yml
@@ -41,9 +41,10 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph/
           branches:
             - '{ceph_branch}'
-          browser: auto
           timeout: 20
           skip-tag: true
           shallow-clone: true
@@ -51,6 +52,8 @@
 
       - git:
           url: https://github.com/ceph/ceph-build.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph-build/
           branches:
             - main
           basedir: ceph-build

--- a/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
+++ b/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
@@ -58,10 +58,11 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph/
           branches:
             - origin/pr/${{ghprbPullId}}/merge
           refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
-          browser: auto
           timeout: 20
           skip-tag: true
           shallow-clone: true
@@ -69,6 +70,8 @@
 
       - git:
           url: https://github.com/ceph/ceph-build.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph-build/
           branches:
             - main
           basedir: ceph-build

--- a/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
+++ b/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml
@@ -63,9 +63,13 @@
           branches:
             - origin/pr/${{ghprbPullId}}/merge
           refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+          changelog-against:
+            remote: origin
+            branch: main
           timeout: 20
           skip-tag: true
           shallow-clone: true
+          depth: 50
           wipe-workspace: true
 
       - git:

--- a/ceph-iscsi-stable/config/definitions/ceph-iscsi-stable.yml
+++ b/ceph-iscsi-stable/config/definitions/ceph-iscsi-stable.yml
@@ -3,6 +3,8 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph-iscsi.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph-iscsi/
           branches:
             - $CEPH_ISCSI_BRANCH
           skip-tag: true
@@ -14,6 +16,8 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph-iscsi-tools.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph-iscsi-tools/
           branches:
             - $CEPH_ISCSI_TOOLS_BRANCH
           skip-tag: true

--- a/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
+++ b/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml
@@ -5,6 +5,8 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph/
           branches:
             - origin/main
           skip-tag: true
@@ -18,6 +20,8 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph/
           branches:
             - origin/pr/${{ghprbPullId}}/merge
           refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
@@ -31,6 +35,8 @@
     scm:
       - git:
           url: https://github.com/ceph/cbt.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/cbt/
           refspec: +refs/heads/main:refs/remotes/origin/main
           do-not-fetch-tags: true
           honor-refspec: true

--- a/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
+++ b/ceph-pr-commits/config/definitions/ceph-pr-commits.yml
@@ -3,10 +3,11 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph/
           branches:
             - ${{sha1}}
           refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
-          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: true
@@ -17,9 +18,10 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph-build.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph-build/
           branches:
             - origin/main
-          browser-url: https://github.com/ceph/ceph-build
           timeout: 20
           skip-tag: true
           wipe-workspace: false

--- a/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml
+++ b/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml
@@ -57,6 +57,8 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph/
           branches:
             - origin/pr/${{ghprbPullId}}/merge
           refspec: +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
@@ -68,6 +70,8 @@
 
       - git:
           url: https://github.com/ceph/ceph-build.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph-build/
           branches:
             - main
           basedir: ceph-build

--- a/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
+++ b/nfs-ganesha-stable/config/definitions/nfs-ganesha-stable.yml
@@ -3,6 +3,8 @@
     scm:
       - git:
           url: https://github.com/nfs-ganesha/nfs-ganesha.git
+          browser: githubweb
+          browser-url: https://github.com/nfs-ganesha/nfs-ganesha/
           branches:
             - $NFS_GANESHA_BRANCH
           skip-tag: true
@@ -14,6 +16,8 @@
     scm:
       - git:
           url: https://github.com/nfs-ganesha/nfs-ganesha-debian.git
+          browser: githubweb
+          browser-url: https://github.com/nfs-ganesha/nfs-ganesha-debian/
           branches:
             - $NFS_GANESHA_DEBIAN_BRANCH
           skip-tag: true
@@ -25,6 +29,8 @@
     scm:
       - git:
           url: https://github.com/nfs-ganesha/ntirpc.git
+          browser: githubweb
+          browser-url: https://github.com/nfs-ganesha/ntirpc/
           branches:
             - $NTIRPC_BRANCH
           skip-tag: true

--- a/nfs-ganesha/config/definitions/nfs-ganesha.yml
+++ b/nfs-ganesha/config/definitions/nfs-ganesha.yml
@@ -3,6 +3,8 @@
     scm:
       - git:
           url: https://github.com/nfs-ganesha/nfs-ganesha.git
+          browser: githubweb
+          browser-url: https://github.com/nfs-ganesha/nfs-ganesha/
           branches:
             - $NFS_GANESHA_BRANCH
           skip-tag: true
@@ -14,6 +16,8 @@
     scm:
       - git:
           url: https://github.com/nfs-ganesha/nfs-ganesha-debian.git
+          browser: githubweb
+          browser-url: https://github.com/nfs-ganesha/nfs-ganesha-debian/
           branches:
             - $NFS_GANESHA_DEBIAN_BRANCH
           skip-tag: true

--- a/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
+++ b/radosgw-agent-pull-requests/config/definitions/radosgw-agent-pull-requests.yml
@@ -6,10 +6,11 @@
     scm:
       - git:
           url: https://github.com/ceph/radosgw-agent.git
+          browser: githubweb
+          browser-url: https://github.com/ceph/radosgw-agent/
           branches:
             - ${{sha1}}
           refspec: +refs/pull/*:refs/remotes/origin/pr/*
-          browser: auto
           timeout: 20
           skip-tag: true
           wipe-workspace: false
@@ -20,7 +21,8 @@
     scm:
       - git:
           url: https://github.com/ceph/ceph-build.git
-          browser-url: https://github.com/ceph/ceph-build
+          browser: githubweb
+          browser-url: https://github.com/ceph/ceph-build/
           timeout: 20
           skip-tag: true
           wipe-workspace: false


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/75309 — the "Changes from Git" commit links on `ceph-dashboard-cephadm-e2e` point at `ceph/ceph` for commits that came from `ceph/ceph-build`, and 404.

Two commits:

### 1. `multi-scm jobs: give every git SCM an explicit GithubWeb browser`

The bad links are produced by the GitHub plugin's [`GithubLinkAnnotator`](https://github.com/jenkinsci/github-plugin/blob/master/src/main/java/com/coravy/hudson/plugins/github/GithubLinkAnnotator.java), which appends `(commit: <7-sha>)` to *every* changelog entry using the job-level `github` property URL — it has no per-SCM awareness. It only gets the chance because `browser: auto` makes JJB emit no `<browser>` element, so [`MultiSCMChangeLogParser`](https://github.com/jenkinsci/multiple-scms-plugin/blob/master/src/main/java/org/jenkinsci/plugins/multiplescms/MultiSCMChangeLogParser.java) hands the git plugin a null browser and `GitChangeSetList/index.jelly` falls through to the annotated-comment branch.

Setting `browser`/`browser-url` per SCM (31 SCMs, all 9 multi-SCM definition files) makes the page render real per-repo browser links instead. Also activates the `browser-url` entries in `ceph-pr-commits` and `radosgw-agent-pull-requests` that had no `browser:` key and were silently ignored by JJB.

### 2. `ceph-dashboard-cephadm-e2e: actually produce a ceph.git changelog`

This job has **never** shown a ceph.git commit: the ceph SCM builds `origin/pr/${ghprbPullId}/merge`, a different branch name every build, so the git plugin logs `First time build. Skipping changelog.` on every run. Only ceph-build (stable `origin/main`) ever contributed entries — which is why everything the reporter saw was a ceph-build commit wearing a ceph/ceph link.

`changelog-against: origin/main` computes the changelog against main instead of the previous build, so the page shows what the PR actually changes. That needs history to walk, hence `depth: 50` (clone stays shallow).

### Verification

Live, on build #25493 (ceph/ceph PR #71437, run with this config applied):
- console: `Using 'Changelog to branch' strategy`
- `/changes` renders **Changes from Git (git https://github.com/ceph/ceph.git)** with the PR's own commit, linked via GithubWeb to https://github.com/ceph/ceph/commit/2908709f… (HTTP 200), and **zero** annotator links on the page

Static, against main @ `c66efa9d` on JJB 6.5.0 (6.4.2 output is byte-identical): all 14 generated jobs build, and the XML delta is purely additive — 31 `GithubWeb` blocks with correct per-repo URLs, one `ChangelogToBranch`, `depth` 1→50. Nothing else changes.

Cost of `depth: 50` (one job only): synthetic single-branch fetch of ceph.git went 14s/48MB → 37s/183MB. Note the job's fetches include all tags (JJB's `skip-tag` maps to the old per-build-tag option, not `noTags`), which amplifies deepening — but the real depth-50 build above still completed both checkouts in under two minutes on a builder. `do-not-fetch-tags: true` is an easy follow-up if that ever matters.

### Known remainders

- The build **summary** page digest (`MultiSCMChangeLogSet/digest.jelly`) renders `msgAnnotated` unconditionally, so the annotator's `(commit: …)` link — wrong repo for ceph-build commits — survives there. Browser config cannot fix that page; dropping the ceph-build SCM (inlining `build/cleanup` via `!include-raw-verbatim`, as the job already does for its other scripts) would. Left out of this PR.
- The ceph-build case itself (a ceph-build commit rendering with a ceph-build link on `/changes`) hasn't been observed live yet — no build has carried both the config and a ceph-build changelog entry. The mechanism is identical to the verified ceph.git case.
- A PR with more than ~50 commits would have its changelog truncated by the fetch depth.

Note: a manual `jenkins-jobs update` of this config gets reverted by the `jenkins-job-builder` job on the next push to main — merging is what makes it stick.
