### PR TITLE
ceph-pr-pipeline: windows host cleanup is best-effort

### DIFF
--- a/ceph-pr-pipeline/build/Jenkinsfile
+++ b/ceph-pr-pipeline/build/Jenkinsfile
@@ -838,10 +838,23 @@ pipeline {
               // Archived by archiveLegArtifacts in the pipeline post{}.
               stash(name: "windows-artifacts", includes: "artifacts/**",
                     allowEmpty: true)
-              sh """#!/bin/bash
-                source ./ceph-build/scripts/build_utils.sh
-                source ./ceph-build/scripts/ceph-windows/cleanup
-              """
+              // Best-effort cleanup.  The if -> WARNING at the end is to avoid
+              // sending "failed" back to the GitHub Check in case the actual
+              // tests passed but cleanup fails.
+              script {
+                def rc = sh(
+                  label: "clean up the windows host",
+                  returnStatus: true,
+                  script: """#!/bin/bash
+                    source ./ceph-build/scripts/build_utils.sh
+                    source ./ceph-build/scripts/ceph-windows/cleanup
+                  """
+                )
+                if (rc != 0) {
+                  echo "WARNING: windows host cleanup exited ${rc}; " +
+                       "the next run on this builder cleans up what is left"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
[Build 1184](https://jenkins.ceph.com/job/ceph-pr-pipeline/1184/)'s windows leg **passed its tests** — `Windows tests succeeded` at 08:09, GitHub context posted green — and the leg still came out red.

The cause is in `post{always}`: `scripts/ceph-windows/cleanup` runs with `errexit`, and its `rm -rf` of the workspace raced the just-killed vstart container's daemons still flushing logs, dying with `rm: cannot remove '.../ceph/build/vstart/out': Directory not empty` → `Error when executing always post condition` → FAILURE.

Host teardown must never decide a leg's outcome — the same rule `postStatus()` already follows after the 2026-09-09 brownout turned green legs red. This captures the status, warns, and moves on. Nothing leaks as a result: the next run's checkout wipes the workspace with `sudo rm -rf` (#2714) and `setup_libvirt` deletes leftover VMs (#2715).