### PR TITLE
bwc: stop the default seccomp profile from breaking libaio in the container

### DIFF
--- a/scripts/bwc.sh
+++ b/scripts/bwc.sh
@@ -40,6 +40,11 @@ bwc() {
         args+=("--extra=-eSCCACHE_DIR=/sccache")
         args+=("--extra=-eSCCACHE_CACHE_SIZE=${SCCACHE_CACHE_SIZE:-40G}")
     fi
+    local seccomp
+    seccomp=$(bwc_seccomp_profile)
+    if [ "${seccomp}" ]; then
+        args+=(--extra="${seccomp}")
+    fi
     args+=("${@}")
     timeout "${timeout}" ./src/script/build-with-container.py \
         -d "${DISTRO_BASE:-jammy}" \
@@ -47,6 +52,35 @@ bwc() {
         --current-branch="${current_branch}" \
         -t"+$(bwc_arch)" \
         "${args[@]}"
+}
+
+# bwc_seccomp_profile - Print a --security-opt argument holding the host's
+#   seccomp profile minus io_pgetevents. libaio 0.3.113 (ubuntu 24.04+) only
+#   falls back to io_getevents when io_pgetevents returns ENOSYS, and the
+#   default profile denies it with EPERM, which aborts every bluestore test.
+# Arguments: (none)
+# Variables:
+#   WORKSPACE - Path to write the generated profile to.
+# Output: --security-opt argument, or nothing
+bwc_seccomp_profile() {
+    local src dest
+    # this only applies to podman
+    command -v podman > /dev/null || return 0
+    # get the host's seccomp profile
+    src=$(podman info --format '{{.Host.Security.SECCOMPProfilePath}}' 2>/dev/null)
+    # if there isn't one, skip this
+    [ -r "${src}" ] || return 0
+    # a denied syscall has to come back as ENOSYS (38) for libaio to fall back
+    [ "$(jq -r '.defaultErrnoRet' "${src}")" = "38" ] || return 0
+    # make a temporary replacement seccomp profile
+    dest="${WORKSPACE:-$(mktemp -d)}/seccomp-ceph.json"
+    # drop io_pgetevents from the deny lists, and any list it empties
+    jq '.syscalls |= [.[]
+          | if .action != "SCMP_ACT_ALLOW"
+            then .names |= map(select(startswith("io_pgetevents") | not))
+            else . end
+          | select(.names | length > 0)]' "${src}" > "${dest}" || return 0
+    echo "--security-opt=seccomp=${dest}"
 }
 
 # bwc_populate_npm_cache - Configure the ceph sources and try to install


### PR DESCRIPTION
### The bug

libaio 0.3.113 — **ubuntu 24.04 and newer** — implements `io_getevents()` as *"call `io_pgetevents`, and if that returns `-ENOSYS`, fall back to plain `io_getevents`"* ([Debian patch `0021-Add-time64-syscall-support`](https://sources.debian.org/src/libaio/)):

```c
ret = aio_pgetevents(ctx, min_nr, nr, events, timeout, NULL);
if (ret != -ENOSYS)
        return ret;
/* ... otherwise plain io_getevents ... */
```

The container runtimes' default seccomp profile denies `io_pgetevents` with **EPERM**, not ENOSYS, so the fallback never fires. For ceph that's fatal — `KernelDevice::_aio_thread` treats any negative return as unrecoverable:

```
bdev(0x5f49dfb82a00 td/smoke/0/block) _aio_thread got (1) Operation not permitted
/ceph/src/blk/kernel/KernelDevice.cc: 701: ceph_abort_msg("got unexpected error from io_getevents")
```

In [ceph-pr-pipeline build 1162](https://jenkins.ceph.com/job/ceph-pr-pipeline/1162/) (`make check`, `DISTRO_BASE=resolute`) that was **11 of the 17 ctest failures**: `unittest_bluefs`, `unittest_bluefs_ex`, `unittest_bdev`, all six `run_rbd_unit_tests` shards, and both standalone tests — the last two being OSDs aborting at startup.

### The fix

Hand podman the host's own profile with `io_pgetevents` removed from the deny lists. **This grants nothing new.** The syscall falls through to the profile's `defaultErrnoRet`, which is ENOSYS — exactly what libaio is waiting for — and it retries with plain `io_getevents`, which the default profile has always allowed.

Upstream `containers/common` made this same change for `io_uring_*` and `membarrier` ([399bd59e0](https://github.com/containers/common/commit/399bd59e0), [0f242ca74](https://github.com/containers/common/commit/0f242ca74)) and just missed `io_pgetevents` — 399bd59e0's diff context literally shows the line sitting there. That's worth fixing upstream too, but it doesn't help the podman 4.9.3 on our builders today.

The helper no-ops (and `bwc` behaves exactly as before) when there's no podman, when the profile isn't readable, or when it doesn't use the ENOSYS default.

### Testing

Verified on **sockeni08** — noble, podman 4.9.3, crun 1.14.1, same `/usr/share/containers/seccomp.json` as the builders — with a small libaio probe (`io_setup` + `io_getevents` under strace) run in each container under the default profile and under the profile this function generates:

| container | libaio | default profile | generated profile |
|---|---|---|---|
| ubuntu:22.04 | 0.3.112-13 | ok | ok |
| ubuntu:24.04 | 0.3.113-6 | **EPERM** | ok |
| ubuntu:26.04 | 0.3.113-8 | **EPERM** | ok |

strace under the generated profile shows the intended sequence — `io_pgetevents(...) = -1 ENOSYS` followed by `io_getevents(...) = 0`. `bwc_seccomp_profile` itself was then sourced and run as-is on that host, and the profile it emitted was used for the last column.

**Note the noble row.** This isn't resolute enablement — it's a latent bug that would abort bluestore in a **noble** container today, unnoticed only because the pipeline defaults to jammy and the noble package builds never run the aio tests. jammy is unaffected either way: its libaio never calls `io_pgetevents`, so this only changes the errno of a syscall it doesn't use.