### PR TITLE
ceph-tag: strip a leading "v" from VERSION

### DIFF
--- a/ceph-tag/build/build
+++ b/ceph-tag/build/build
@@ -11,6 +11,10 @@ install_python_packages $TEMPVENV "pkgs[@]"
 # remove "-release" from $BRANCH variable in case it was accidentally passed in the Jenkins UI
 BRANCH=${BRANCH//-release/}
 
+# remove a leading "v" from $VERSION in case it was accidentally passed (e.g. v21.1.1);
+# the playbook prepends the "v" itself where needed
+VERSION=${VERSION#v}
+
 # run ansible to do all the tagging and release specifying
 # a local connection and 'localhost' as the host where to execute
 cd "$WORKSPACE/ceph-build/ansible/"


### PR DESCRIPTION
ceph-release-pipeline #57 was triggered with `VERSION=v21.1.1`, which ceph-tag passed straight to the release playbook. The playbook expects the bare version (it prepends `v` itself for tags), so `dch` failed with `v21.1.1-1 is not a valid version` ([ceph-tag #674](https://jenkins.ceph.com/job/ceph-tag/674/console)).

Strip a leading `v` defensively in the ceph-tag build script, the same way we already strip `-release` from `BRANCH`. ceph-dev-pipeline is unaffected because it re-reads `VERSION` from `dist/version`.