### PR TITLE
bwc: give sccache a cache that outlives the container

### DIFF
--- a/scripts/bwc.sh
+++ b/scripts/bwc.sh
@@ -14,8 +14,10 @@
 #   GIT_BRANCH - Pass the current branch name to BWC in order
 #                to generate a container tag. Defaults to "main"
 #   NPMCACHE - Path to shared npm cache directory.
+#   SCCACHE_DIR - Host directory for the compiler cache.  Defaults to
+#                 ~/.cache/ceph-sccache; set it empty to disable caching.
+#   SCCACHE_CACHE_SIZE - Cap for that directory.  Defaults to 40G.
 bwc() {
-    # TODO: enable (read-only?) sccache support
     # specify timeout in hours for $1
     local timeout=$(($1*60*60))
     shift
@@ -24,6 +26,19 @@ bwc() {
     local args=()
     if [ "${NPMCACHE}" ]; then
         args+=(--npm-cache-path="${NPMCACHE}")
+    fi
+    # The bwc images ship sccache and ceph's do_cmake.sh prefers it over
+    # ccache ("if type sccache ... elif type ccache"), but nothing pointed
+    # it at a directory outliving the container, so every build compiled
+    # from scratch into a cache that was thrown away with the container --
+    # ceph-pr-pipeline run 1202 logged "Building with sccache ... SCCACHE_CONF="
+    # and then 33m45s of full compile.  Give it a per-builder directory.
+    local sccache_dir="${SCCACHE_DIR-${HOME}/.cache/ceph-sccache}"
+    if [ "${sccache_dir}" ]; then
+        mkdir -p "${sccache_dir}"
+        args+=("--extra=--volume=${sccache_dir}:/sccache:z")
+        args+=("--extra=-eSCCACHE_DIR=/sccache")
+        args+=("--extra=-eSCCACHE_CACHE_SIZE=${SCCACHE_CACHE_SIZE:-40G}")
     fi
     args+=("${@}")
     timeout "${timeout}" ./src/script/build-with-container.py \

--- a/scripts/ceph-windows/setup_ceph_vstart_container
+++ b/scripts/ceph-windows/setup_ceph_vstart_container
@@ -4,7 +4,7 @@
 # container on the builder host, replacing the libvirt Ubuntu VM that
 # setup_libvirt_ubuntu_vm + setup_ceph_vstart provisioned (and fully rebuilt
 # ceph in) on every run.  Same Release build and vstart configuration as the
-# VM flow, but the image has the build deps baked in and a persistent ccache
+# VM flow, but the image has the build deps baked in and bwc's persistent sccache
 # makes repeat builds fast.
 #
 # The cluster container runs with --net=host and vstart binds the libvirt
@@ -20,7 +20,6 @@ if [[ -z $WORKSPACE ]]; then echo "ERROR: The WORKSPACE env variable is not set"
 
 export VSTART_DIR="$WORKSPACE/ceph_vstart"
 export VSTART_CONTAINER="ceph_build"
-VSTART_CCACHE_DIR="${VSTART_CCACHE_DIR:-$HOME/.cache/ceph-win32-build/vstart-ccache}"
 
 USE_MEMSTORE="${USE_MEMSTORE:-no}"
 VSTART_MEMSTORE_BYTES="5368709120"  # 5GB
@@ -38,7 +37,7 @@ else
     OBJECTSTORE_ARGS="--bluestore -o bluestore_block_size=$VSTART_BLUESTORE_BYTES"
 fi
 
-mkdir -p "$VSTART_DIR" "$VSTART_CCACHE_DIR"
+mkdir -p "$VSTART_DIR"
 cd "$WORKSPACE/ceph"
 cat > .env << EOF
 NPROC=$(nproc)
@@ -57,26 +56,20 @@ cat > vstart-build.sh << 'EOF'
 set -o errexit
 set -o pipefail
 
-cmake_flags=(
-    -DCMAKE_BUILD_TYPE=Release
-    -DWITH_RADOSGW=OFF
-    -DWITH_MGR_DASHBOARD_FRONTEND=OFF
+# The compiler cache is bwc's (sccache, mounted from the builder): asking
+# do_cmake.sh for ccache here achieved nothing, because it prefers sccache
+# whenever the image ships it -- which the bwc images do.
+./do_cmake.sh \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DWITH_RADOSGW=OFF \
+    -DWITH_MGR_DASHBOARD_FRONTEND=OFF \
     -DWITH_TESTS=OFF
-)
-if command -v ccache > /dev/null; then
-    cmake_flags+=(-DWITH_CCACHE=ON)
-    ccache -s
-fi
-./do_cmake.sh "${cmake_flags[@]}"
 cd ./build
 ninja vstart
-command -v ccache > /dev/null && ccache -s || true
+command -v sccache > /dev/null && sccache --show-stats || true
 EOF
 chmod +x vstart-build.sh
-time bwc 2 \
-    "--extra=--volume=$VSTART_CCACHE_DIR:/vstartccache:z" \
-    "--extra=-eCCACHE_DIR=/vstartccache" \
-    -e custom -- ./vstart-build.sh
+time bwc 2 -e custom -- ./vstart-build.sh
 
 #
 # Run the cluster; the container stays up (sleep) until cleanup removes it.


### PR DESCRIPTION
Every bwc build has been compiling ceph from scratch, in every job.

The bwc images ship sccache, and ceph's `do_cmake.sh` prefers it over ccache (`if type sccache … elif type ccache`), so `-DWITH_SCCACHE=ON` gets added and sccache becomes the compiler launcher. But nothing ever pointed sccache at storage, so each build filled a cache *inside the container* and threw it away on exit — the `# TODO: enable (read-only?) sccache support` that has been on `bwc()` since it was written. ceph-pr-pipeline [run 1202](https://jenkins.ceph.com/job/ceph-pr-pipeline/1202/) shows it plainly: `Building with sccache … SCCACHE_CONF=` followed by 33m45s of full compile, on a builder that had built ceph minutes earlier for another leg.

This mounts a per-builder directory (`~/.cache/ceph-sccache`, 40G cap, both overridable) into every bwc container and points `SCCACHE_DIR` at it. It lives in `bwc()` rather than any single caller so everything benefits: the pipeline's shared build, make check, arm64, the windows leg's vstart cluster, and the other jobs that build through bwc.

**Measured** on sockeni08 (192 cores), two identical full builds of ceph main with the pipeline's own env (`WITH_CRIMSON=true`), the second with the build directory wiped so every object had to be recompiled:

| | elapsed | cache after |
|---|---|---|
| cold (empty cache) | **52.9 min** | 1937 MB written |
| warm (cache kept) | **34.3 min** | 1937 MB, unchanged |

18.6 min saved, 35% faster, and the cache not growing on the warm run confirms every compile was a hit. That is the best case — identical source. Real PR-to-PR reuse will land lower (the windows cross-build's ccache, which does persist, runs 41–70% hit rates), so expect a meaningful fraction of that per build rather than the full 19 minutes.

Verified end to end before measuring: `podman inspect` on a live pipeline container showed `/home/jenkins-build/.cache/ceph-sccache -> /sccache` with `SCCACHE_DIR` and `SCCACHE_CACHE_SIZE` set, and the host directory filled up as the compile progressed (~2 files per object).

Also drops dead wiring from the windows vstart build, which asked `do_cmake.sh` for ccache and mounted a ccache directory: sccache won, and those stats read 0/0 across a 33-minute build. It now reports sccache's stats instead.